### PR TITLE
Support Network byte order for Primitive values

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -28,21 +28,21 @@ enum Converter {
         case .boolean:
             return .boolean(data[0] == 1)
         case .integer:
-            let result = data.withUnsafeBytes { $0.load(as: Int32.self) }
+            let result = Int32(bigEndian: data.withUnsafeBytes { $0.load(as: Int32.self) })
             return .integer(result)
         case .double:
-            let result = data.withUnsafeBytes { $0.load(as: Double.self) }
+            let result = Double(bitPattern: UInt64(bigEndian: data.withUnsafeBytes { $0.load(as: UInt64.self) }))
             return .double(result)
         case .string:
             return .string(String(decoding: data, as: UTF8.self))
         case .long:
-            let result = data.withUnsafeBytes { $0.load(as: Int64.self) }
+            let result = Int64(bigEndian: data.withUnsafeBytes { $0.load(as: Int64.self) })
             return .long(result)
         case .bytes:
             return .bytes(data)
         case .date:
-            let milliseconds = data.withUnsafeBytes { $0.load(as: Double.self) }
-            return .date(Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000))
+            let milliseconds = Int(bigEndian: data.withUnsafeBytes { $0.load(as: Int.self) })
+            return .date(Date(timeIntervalSince1970: TimeInterval(Double(milliseconds) / 1000)))
         default:
             throw YorkieError.unimplemented(message: String(describing: valueType))
         }

--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -118,8 +118,8 @@ class Primitive: CRDTElement {
         case .bytes(let value):
             return value
         case .date(let value):
-            let milliseconds = value.millisecondTimeIntervalSince1970.bigEndian
-            return withUnsafeBytes(of: milliseconds) { Data($0) }
+            let milliseconds = value.millisecondTimeIntervalSince1970
+            return withUnsafeBytes(of: milliseconds.bigEndian) { Data($0) }
         }
     }
 }

--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-enum PrimitiveValue {
+enum PrimitiveValue: Equatable {
     case null
     case boolean(Bool)
     case integer(Int32)
@@ -40,7 +40,14 @@ class Primitive: CRDTElement {
 
     init(value: PrimitiveValue, createdAt: TimeTicket) {
         self.createdAt = createdAt
-        self.value = value
+
+        switch value {
+        case .date(let dateValue):
+            // Trim the less than a millisecond
+            self.value = .date(Date(timeIntervalSince1970: Double(dateValue.millisecondTimeIntervalSince1970) / 1000))
+        default:
+            self.value = value
+        }
     }
 
     /**
@@ -101,17 +108,17 @@ class Primitive: CRDTElement {
             var valueInInt = Int(exactly: NSNumber(value: value))
             return Data(bytes: &valueInInt, count: MemoryLayout.size(ofValue: valueInInt))
         case .integer(let value):
-            return withUnsafeBytes(of: value) { Data($0) }
+            return withUnsafeBytes(of: value.bigEndian) { Data($0) }
         case .double(let value):
-            return withUnsafeBytes(of: value) { Data($0) }
+            return withUnsafeBytes(of: value.bitPattern.bigEndian) { Data($0) }
         case .string(let value):
             return value.data(using: .utf8) ?? Data()
         case .long(let value):
-            return withUnsafeBytes(of: value) { Data($0) }
+            return withUnsafeBytes(of: value.bigEndian) { Data($0) }
         case .bytes(let value):
             return value
         case .date(let value):
-            let milliseconds = value.timeIntervalSince1970 * 1000
+            let milliseconds = value.millisecondTimeIntervalSince1970.bigEndian
             return withUnsafeBytes(of: milliseconds) { Data($0) }
         }
     }
@@ -141,7 +148,7 @@ extension Primitive {
         case .bytes(let value):
             return "\(value)"
         case .date(let value):
-            return "\(value.timeIntervalSince1970 * 1000)"
+            return "\(value.millisecondTimeIntervalSince1970)"
         }
     }
 
@@ -159,5 +166,15 @@ extension Primitive {
         let primitive = Primitive(value: self.value, createdAt: self.getCreatedAt())
         primitive.setMovedAt(self.getMovedAt())
         return primitive
+    }
+}
+
+private extension Date {
+    /**
+     * `millisecondTimeIntervalSince1970` returns the number representing the milliseconds elapsed between 1 January 1970 00:00:00 UTC and the given date.
+     *  It's simmilar getTime() in javascript
+     */
+    var millisecondTimeIntervalSince1970: Int {
+        Int(floor(self.timeIntervalSince1970 * 1000))
     }
 }

--- a/Tests/Document/CRDT/PrimitiveTests.swift
+++ b/Tests/Document/CRDT/PrimitiveTests.swift
@@ -98,12 +98,12 @@ class PrimitiveTests: XCTestCase {
 
     func test_value_is_date() throws {
         let testDate = Date()
-        print(testDate.timeIntervalSince1970)
         let primitiveValue = Primitive(value: .date(testDate), createdAt: TimeTicket.initialTimeTicket)
         let valueFromData = try Converter.valueFrom(valueType: .date, data: primitiveValue.toBytes())
+
         switch valueFromData {
-        case .date(let value):
-            XCTAssertEqual(value.timeIntervalSince1970, testDate.timeIntervalSince1970)
+        case .date:
+            XCTAssertEqual(primitiveValue.value, valueFromData)
         default:
             XCTFail("Type error.")
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

### For the interchange between different platforms.
- When converting primitive values to a byte stream,  apply network byte order(Big endian)
- Trim the less than a millisecond in Date primitive value

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
