### PR TITLE
Remove features for dynamicMemberLookup from JSONObject

### DIFF
--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-class Document<T: JSONSpec> {
+class Document {
     private var key: String
     private var root: CRDTRoot
     private var clone: CRDTRoot?
@@ -35,11 +35,11 @@ class Document<T: JSONSpec> {
     /**
      * `update` executes the given updater to update this document.
      */
-    func update(updater: (_ root: JSONObject<T>) -> Void, message: String? = nil) throws {
+    func update(updater: (_ root: JSONObject) -> Void, message: String? = nil) throws {
         let clone = self.cloned()
         let context = ChangeContext(id: self.changeID.next(), root: clone, message: message)
 
-        let proxy = JSONObject<T>(target: clone.getObject(), context: context)
+        let proxy = JSONObject(target: clone.getObject(), context: context)
         updater(proxy)
 
         if context.hasOperations() {
@@ -127,11 +127,11 @@ class Document<T: JSONSpec> {
     /**
      * `getRoot` returns a new proxy of cloned root.
      */
-    func getRoot() -> JSONObject<T> {
+    func getRoot() -> JSONObject {
         let clone = self.cloned()
         let context = ChangeContext(id: self.changeID.next(), root: clone)
 
-        return JSONObject<T>(target: clone.getObject(), context: context)
+        return JSONObject(target: clone.getObject(), context: context)
     }
 
     /**

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -35,7 +35,7 @@ class Document {
     /**
      * `update` executes the given updater to update this document.
      */
-    func update(updater: (_ root: JSONObject) -> Void, message: String? = nil) throws {
+    func update(updater: (_ root: JSONObject) -> Void, message: String? = nil) {
         let clone = self.cloned()
         let context = ChangeContext(id: self.changeID.next(), root: clone, message: message)
 
@@ -46,7 +46,7 @@ class Document {
             Logger.trivial("trying to update a local change: \(self.toJSON())")
 
             let change = context.getChange()
-            try change.execute(root: self.root)
+            try? change.execute(root: self.root)
             self.localChanges.append(change)
             self.changeID = change.getID()
 

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -16,13 +16,7 @@
 
 import Foundation
 
-// It will be implemented soon.
-protocol JSONArrayable: AnyObject {
-    var target: CRDTArray { get set }
-    var context: ChangeContext { get set }
-}
-
-class JSONArray<T>: JSONArrayable {
+class JSONArray {
     var target: CRDTArray
     var context: ChangeContext
 

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -209,7 +209,7 @@ class JSONObject {
         self.get(keyPath: keyPath)
     }
 
-    subscript(key key: String) -> Any? {
+    subscript(key: String) -> Any? {
         get {
             self.get(key: key)
         }

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -29,132 +29,212 @@ protocol JSONObjectable: AnyObject {
  * `JSONObject` represents a JSON object, but unlike regular JSON, it has time
  * tickets created by a logical clock to resolve conflicts.
  */
-@dynamicMemberLookup
-class JSONObject<T: JSONSpec>: JSONObjectable {
-    var dataHandler: ObjectDataHandler?
-    private var jsonSpec: T
-    private let keyMap: [AnyKeyPath: String]
+class JSONObject {
+    var target: CRDTObject!
+    var context: ChangeContext!
 
-    init() {
-        self.jsonSpec = T()
-        self.keyMap = T.keyMap
-    }
+    init() {}
 
     init(target: CRDTObject, context: ChangeContext) {
-        self.dataHandler = ObjectDataHandler(target: target, context: context)
-        self.jsonSpec = T()
-        self.keyMap = T.keyMap
+        self.target = target
+        self.context = context
     }
 
-    subscript<V>(dynamicMember member: WritableKeyPath<T, V>) -> V {
-        get {
-            guard let key = self.keyMap[member] else {
-                assertionFailure("Must define a label for keyPath\(String(describing: member))")
-                return self.jsonSpec[keyPath: member]
-            }
-
-            Logger.trivial("obj[\(key)]")
-
-            let defaultValue = self.jsonSpec[keyPath: member]
-
-            guard let dataHandler = self.dataHandler else {
-                Logger.error("This instance is not binded.")
-                return defaultValue
-            }
-
-            let value = try? dataHandler.get(key: key)
-            if let jsonObject = defaultValue as? JSONObjectable,
-               let crdtObject = value as? CRDTObject
-            {
-                jsonObject.dataHandler = ObjectDataHandler(target: crdtObject, context: dataHandler.context)
-                return jsonObject as? V ?? defaultValue
-            } else if let crdtArray = value as? CRDTArray, let jsonArray = defaultValue as? JSONArrayable {
-                jsonArray.target = crdtArray
-                jsonArray.context = dataHandler.context
-                return jsonArray as? V ?? defaultValue
+    func set(_ values: [String: Any]) {
+        values.forEach { (key: String, value: Any) in
+            if let value = value as? [String: Any] {
+                set(key: key, value: JSONObject())
+                let jsonObject = get(key: key) as? JSONObject
+                jsonObject?.set(value)
+//            } else if let value = value as? [Any] {
+                // It will be implemented soon.
             } else {
-                return value as? V ?? defaultValue
+                set(key: key, value: value)
+            }
+        }
+    }
+
+    func set<T>(key: String, value: T) {
+        if let value = value as? Bool {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? Int32 {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? Int64 {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? Double {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? String {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? Data {
+            self.setValue(key: key, value: value)
+        } else if let value = value as? Date {
+            self.setValue(key: key, value: value)
+        } else if value is JSONObject {
+            let object = CRDTObject(createdAt: self.context.issueTimeTicket())
+            self.setValue(key: key, value: object)
+        } else if value is JSONArray {
+            let array = CRDTArray(createdAt: self.context.issueTimeTicket())
+            self.setValue(key: key, value: array)
+        } else {
+            Logger.error("The value is not supported. - key: \(key): value: \(value)")
+        }
+    }
+
+    private func setAndRegister(key: String, value: CRDTElement) {
+        let removed = self.target.set(key: key, value: value)
+        self.context.registerElement(value, parent: self.target)
+        if let removed {
+            self.context.registerRemovedElement(removed)
+        }
+    }
+
+    private func setPrimitive(key: String, value: PrimitiveValue) {
+        let primitive = Primitive(value: value, createdAt: context.issueTimeTicket())
+        self.setAndRegister(key: key, value: primitive)
+
+        let operation = SetOperation(key: key,
+                                     value: primitive,
+                                     parentCreatedAt: self.target.getCreatedAt(),
+                                     executedAt: self.context.issueTimeTicket())
+        self.context.push(operation: operation)
+    }
+
+    private func setValue(key: String, value: Bool) {
+        self.setPrimitive(key: key, value: .boolean(value))
+    }
+
+    private func setValue(key: String, value: Int32) {
+        self.setPrimitive(key: key, value: .integer(value))
+    }
+
+    private func setValue(key: String, value: Int64) {
+        self.setPrimitive(key: key, value: .long(value))
+    }
+
+    private func setValue(key: String, value: Double) {
+        self.setPrimitive(key: key, value: .double(value))
+    }
+
+    private func setValue(key: String, value: String) {
+        self.setPrimitive(key: key, value: .string(value))
+    }
+
+    private func setValue(key: String, value: Data) {
+        self.setPrimitive(key: key, value: .bytes(value))
+    }
+
+    private func setValue(key: String, value: Date) {
+        self.setPrimitive(key: key, value: .date(value))
+    }
+
+    private func setValue(key: String, value: CRDTObject) {
+        self.setAndRegister(key: key, value: value)
+
+        let operation = SetOperation(key: key,
+                                     value: value.deepcopy(),
+                                     parentCreatedAt: self.target.getCreatedAt(),
+                                     executedAt: self.context.issueTimeTicket())
+        self.context.push(operation: operation)
+    }
+
+    private func setValue(key: String, value: CRDTArray) {
+        self.setAndRegister(key: key, value: value)
+
+        let operation = SetOperation(key: key,
+                                     value: value,
+                                     parentCreatedAt: self.target.getCreatedAt(),
+                                     executedAt: self.context.issueTimeTicket())
+        self.context.push(operation: operation)
+    }
+
+    func get(keyPath: String) -> Any? {
+        let keys = keyPath.components(separatedBy: ".")
+        var nested: JSONObject = self
+        for key in keys {
+            let value = nested.get(key: key)
+            if let jsonObject = value as? JSONObject {
+                nested = jsonObject
+            } else {
+                return value
             }
         }
 
-        set {
-            guard let key = self.keyMap[member] else {
-                assertionFailure("Must define a label for keyPath\(String(describing: member))")
-                return
+        return nested
+    }
+
+    func get(key: String) -> Any? {
+        let value = try? self.target.get(key: key)
+        if let value = value as? Primitive {
+            switch value.value {
+            case .null:
+                return nil
+            case .boolean(let result):
+                return result
+            case .integer(let result):
+                return result
+            case .long(let result):
+                return result
+            case .double(let result):
+                return result
+            case .string(let result):
+                return result
+            case .bytes(let result):
+                return result
+            case .date(let result):
+                return result
             }
-
-            Logger.trivial("obj[\(key)]=\(String(describing: newValue))")
-
-            guard let dataHandler = self.dataHandler else {
-                Logger.error("This instance is not binded.")
-                return
-            }
-
-            if let value = newValue as? JSONObjectable {
-                let crdtObject: CRDTObject
-                if let value = try? dataHandler.get(key: key) as? CRDTObject {
-                    crdtObject = value
-                } else {
-                    crdtObject = CRDTObject(createdAt: dataHandler.context.issueTimeTicket())
-                }
-
-                let valueObject = ObjectDataHandler(target: crdtObject, context: dataHandler.context)
-                value.dataHandler = valueObject
-
-                dataHandler.set(key: key, value: valueObject.target)
-                self.jsonSpec[keyPath: member] = newValue
-            } else if let value = newValue as? JSONArrayable {
-                let crdtArray: CRDTArray
-                if let value = try? dataHandler.get(key: key) as? CRDTArray {
-                    crdtArray = value
-                } else {
-                    crdtArray = CRDTArray(createdAt: dataHandler.context.issueTimeTicket())
-                }
-
-                value.target = crdtArray
-                value.context = dataHandler.context
-
-                dataHandler.set(key: key, value: value.target)
-                self.jsonSpec[keyPath: member] = newValue
-            } else {
-                dataHandler.set(key: key, value: newValue)
-            }
+        } else if let object = value as? CRDTObject {
+            return JSONObject(target: object, context: self.context)
+        } else if let array = value as? CRDTArray {
+            return JSONArray(target: array, changeContext: self.context)
+        } else {
+            Logger.error("The value does not exist. - key: \(key)")
+            return nil
         }
+    }
+
+    func remove(key: String) {
+        Logger.trivial("obj[\(key)]")
+
+        let removed = try? self.target.remove(key: key, executedAt: self.context.issueTimeTicket())
+        guard let removed else {
+            return
+        }
+
+        let removeOperation = RemoveOperation(parentCreatedAt: self.target.getCreatedAt(),
+                                              createdAt: removed.getCreatedAt(),
+                                              executedAt: self.context.issueTimeTicket())
+        self.context.push(operation: removeOperation)
+        self.context.registerRemovedElement(removed)
     }
 
     /**
      * `getID` returns the ID(time ticket) of this Object.
      */
-    func getID() -> TimeTicket? {
-        self.dataHandler?.target.getCreatedAt()
+    func getID() -> TimeTicket {
+        self.target.getCreatedAt()
     }
 
     /**
      * `toJSON` returns the JSON encoding of this object.
      */
     func toJson() -> String {
-        self.dataHandler?.target.toJSON() ?? "{}"
+        self.target.toJSON()
     }
 
-    func toSortedJSON() -> String {
-        self.dataHandler?.target.toSortedJSON() ?? "{}"
+    private func toSortedJSON() -> String {
+        self.target.toSortedJSON()
     }
-
-    func remove(member: AnyKeyPath) throws {
-        guard let key = self.keyMap[member] else {
-            return
-        }
-
-        Logger.trivial("obj[\(key)]")
-
-        try self.dataHandler?.remove(key: key)
-    }
-
-    func setWithDictionary(values: [AnyKeyPath: Any]) {}
 }
 
 extension JSONObject: CustomStringConvertible {
     var description: String {
         self.toJson()
+    }
+}
+
+extension JSONObject: CustomDebugStringConvertible {
+    var debugDescription: String {
+        self.toSortedJSON()
     }
 }

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -205,6 +205,19 @@ class JSONObject {
         self.context.registerRemovedElement(removed)
     }
 
+    subscript(keyPath keyPath: String) -> Any? {
+        self.get(keyPath: keyPath)
+    }
+
+    subscript(key key: String) -> Any? {
+        get {
+            self.get(key: key)
+        }
+        set {
+            self.set(key: key, value: newValue)
+        }
+    }
+
     /**
      * `getID` returns the ID(time ticket) of this Object.
      */

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -45,6 +45,12 @@ class JSONObject {
         }
     }
 
+    func set(key: String, values: [String: Any]) {
+        self.set(key: key, value: JSONObject())
+        let jsonObject = self.get(key: key) as? JSONObject
+        jsonObject?.set(values)
+    }
+
     func set<T>(key: String, value: T) {
         if let value = value as? Bool {
             self.setValue(key: key, value: value)

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -16,15 +16,6 @@
 
 import Foundation
 
-protocol JSONSpec {
-    init()
-    static var keyMap: [AnyKeyPath: String] { get }
-}
-
-protocol JSONObjectable: AnyObject {
-    var dataHandler: ObjectDataHandler? { get set }
-}
-
 /**
  * `JSONObject` represents a JSON object, but unlike regular JSON, it has time
  * tickets created by a logical clock to resolve conflicts.

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -36,7 +36,7 @@ class JSONObject {
     private func isValidKey(_ key: String) -> Bool {
         return key.contains(self.reservedCharacterForKey) == false
     }
-    
+
     func set(_ values: [String: Any]) {
         values.forEach { (key: String, value: Any) in
             if let value = value as? [String: Any] {
@@ -152,7 +152,7 @@ class JSONObject {
                                      executedAt: self.context.issueTimeTicket())
         self.context.push(operation: operation)
     }
-    
+
     /// Search the value by separating the key with dot and return it.
     func get(keyPath: String) -> Any? {
         let keys = keyPath.components(separatedBy: JSONObject.keySeparator)

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -117,6 +117,37 @@ class JSONProxyTests: XCTestCase {
             XCTAssertEqual(idOfCompD, "d-2")
         }
     }
+
+    func test_can_set_with_key_and_dictionary() {
+        let target = TestDocument()
+        target.update { root in
+            root.set(key: "top", values: [
+                "boolean": true,
+                "integer": Int32(111),
+                "long": Int64(9_999_999),
+                "double": Double(1.2222222),
+                "string": "abc",
+                "compB": ["id": "b",
+                          "compC": ["id": "c",
+                                    "compD": ["id": "d-1"]]]
+            ])
+
+            XCTAssertEqual(root.debugDescription,
+                           """
+                           {"top":{"boolean":"true","compB":{"compC":{"compD":{"id":"d-1"},"id":"c"},"id":"b"},"double":1.2222222,"integer":111,"long":9999999,"string":"abc"}}
+                           """)
+            let compD = root.get(keyPath: "top.compB.compC.compD") as? JSONObject
+            compD?.set(key: "id", value: "d-2")
+
+            XCTAssertEqual(root.debugDescription,
+                           """
+                           {"top":{"boolean":"true","compB":{"compC":{"compD":{"id":"d-2"},"id":"c"},"id":"b"},"double":1.2222222,"integer":111,"long":9999999,"string":"abc"}}
+                           """)
+
+            let idOfCompD = root.get(keyPath: "top.compB.compC.compD.id") as? String
+            XCTAssertEqual(idOfCompD, "d-2")
+        }
+    }
 }
 
 class TestDocument {

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -55,21 +55,21 @@ class JSONProxyTests: XCTestCase {
     func test_can_remove() throws {
         let target = TestDocument()
         target.update { root in
-            root.set(key: "boolean", value: true)
-            root.set(key: "integer", value: Int32(111))
-            root.set(key: "long", value: Int64(9_999_999))
-            root.set(key: "double", value: Double(1.2222222))
-            root.set(key: "string", value: "abc")
+            root[key: "boolean"] = true
+            root[key: "integer"] = Int32(111)
+            root[key: "long"] = Int64(9_999_999)
+            root[key: "double"] = Double(1.2222222)
+            root[key: "string"] = "abc"
 
-            root.set(key: "compB", value: JSONObject())
-            let compB = root.get(key: "compB") as? JSONObject
-            compB?.set(key: "id", value: "b")
-            compB?.set(key: "compC", value: JSONObject())
-            let compC = compB?.get(key: "compC") as? JSONObject
-            compC?.set(key: "id", value: "c")
-            compC?.set(key: "compD", value: JSONObject())
-            let compD = compC?.get(key: "compD") as? JSONObject
-            compD?.set(key: "id", value: "d-1")
+            root[key: "compB"] = JSONObject()
+            let compB = root[key: "compB"] as? JSONObject
+            compB?[key: "id"] = "b"
+            compB?[key: "compC"] = JSONObject()
+            let compC = compB?[key: "compC"] as? JSONObject
+            compC?[key: "id"] = "c"
+            compC?[key: "compD"] = JSONObject()
+            let compD = compC?[key: "compD"] as? JSONObject
+            compD?[key: "id"] = "d-1"
 
             XCTAssertEqual(root.debugDescription,
                            """

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -17,9 +17,9 @@
 import XCTest
 @testable import Yorkie
 
-class JSONProxyTests: XCTestCase {
-    func test_can_set() {
-        let target = TestDocument()
+class JSONObjectTests: XCTestCase {
+    func test_can_set() throws {
+        let target = Document(key: "doc1")
         target.update { root in
             root.set(key: "boolean", value: true)
             root.set(key: "integer", value: Int32(111))
@@ -52,8 +52,8 @@ class JSONProxyTests: XCTestCase {
         }
     }
 
-    func test_can_remove() throws {
-        let target = TestDocument()
+    func test_can_remove() {
+        let target = Document(key: "doc1")
         target.update { root in
             root["boolean"] = true
             root["integer"] = Int32(111)
@@ -88,7 +88,7 @@ class JSONProxyTests: XCTestCase {
     }
 
     func test_can_set_with_dictionary() {
-        let target = TestDocument()
+        let target = Document(key: "doc1")
         target.update { root in
             root.set([
                 "boolean": true,
@@ -119,7 +119,7 @@ class JSONProxyTests: XCTestCase {
     }
 
     func test_can_set_with_key_and_dictionary() {
-        let target = TestDocument()
+        let target = Document(key: "doc1")
         target.update { root in
             root.set(key: "top", values: [
                 "boolean": true,
@@ -147,12 +147,5 @@ class JSONProxyTests: XCTestCase {
             let idOfCompD = root[keyPath: "top.compB.compC.compD.id"] as? String
             XCTAssertEqual(idOfCompD, "d-2")
         }
-    }
-}
-
-class TestDocument {
-    func update(_ callback: (_ root: JSONObject) -> Void) {
-        let root = JSONObject(target: CRDTObject(createdAt: TimeTicket.initial), context: ChangeContext(id: ChangeID.initial, root: CRDTRoot()))
-        callback(root)
     }
 }

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -121,7 +121,7 @@ class JSONObjectTests: XCTestCase {
     func test_can_set_with_key_and_dictionary() {
         let target = Document(key: "doc1")
         target.update { root in
-            root.set(key: "top", values: [
+            root.set(key: "top", value: [
                 "boolean": true,
                 "integer": Int32(111),
                 "long": Int64(9_999_999),

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -55,21 +55,21 @@ class JSONProxyTests: XCTestCase {
     func test_can_remove() throws {
         let target = TestDocument()
         target.update { root in
-            root[key: "boolean"] = true
-            root[key: "integer"] = Int32(111)
-            root[key: "long"] = Int64(9_999_999)
-            root[key: "double"] = Double(1.2222222)
-            root[key: "string"] = "abc"
+            root["boolean"] = true
+            root["integer"] = Int32(111)
+            root["long"] = Int64(9_999_999)
+            root["double"] = Double(1.2222222)
+            root["string"] = "abc"
 
-            root[key: "compB"] = JSONObject()
-            let compB = root[key: "compB"] as? JSONObject
-            compB?[key: "id"] = "b"
-            compB?[key: "compC"] = JSONObject()
-            let compC = compB?[key: "compC"] as? JSONObject
-            compC?[key: "id"] = "c"
-            compC?[key: "compD"] = JSONObject()
-            let compD = compC?[key: "compD"] as? JSONObject
-            compD?[key: "id"] = "d-1"
+            root["compB"] = JSONObject()
+            let compB = root["compB"] as? JSONObject
+            compB?["id"] = "b"
+            compB?["compC"] = JSONObject()
+            let compC = compB?["compC"] as? JSONObject
+            compC?["id"] = "c"
+            compC?["compD"] = JSONObject()
+            let compD = compC?["compD"] as? JSONObject
+            compD?["id"] = "d-1"
 
             XCTAssertEqual(root.debugDescription,
                            """
@@ -144,7 +144,7 @@ class JSONProxyTests: XCTestCase {
                            {"top":{"boolean":"true","compB":{"compC":{"compD":{"id":"d-2"},"id":"c"},"id":"b"},"double":1.2222222,"integer":111,"long":9999999,"string":"abc"}}
                            """)
 
-            let idOfCompD = root.get(keyPath: "top.compB.compC.compD.id") as? String
+            let idOfCompD = root[keyPath: "top.compB.compC.compD.id"] as? String
             XCTAssertEqual(idOfCompD, "d-2")
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove features for ```dynamicMemberLookup``` from JSONObject

We faced that the references of class instances using generics should be held in JsonArray.
We decided to provide a simple interface first, even though many issues have been resolved and can resolve the above issue. Because new issues keep coming up.

So, removed features for ```dynamicMemberLookup``` from JSONObject

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
