### PR TITLE
Change Document from class to actor for concurrent access to it

### DIFF
--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -118,7 +118,7 @@ final class RGATreeListNode: SplayNode<CRDTElement> {
 class RGATreeList {
     private let dummyHead: RGATreeListNode
     private var last: RGATreeListNode
-    private var nodeMapByIndex: SplayTree<CRDTElement>
+    private let nodeMapByIndex: SplayTree<CRDTElement>
     private var nodeMapByCreatedAt: [TimeTicket: RGATreeListNode]
 
     init() {

--- a/Sources/Document/Change/Change.swift
+++ b/Sources/Document/Change/Change.swift
@@ -23,7 +23,7 @@ class Change {
     private var id: ChangeID
 
     // `operations` represent a series of user edits.
-    private var operations: [Operation]
+    private let operations: [Operation]
 
     // `message` is used to save a description of the change.
     private let message: String?

--- a/Sources/Document/Change/ChangePack.swift
+++ b/Sources/Document/Change/ChangePack.swift
@@ -23,19 +23,19 @@ class ChangePack {
     /**
      * `documentKey` is the key of the document.
      */
-    private var documentKey: String
+    private let documentKey: String
 
     /**
      * `Checkpoint` is used to determine the client received changes.
      */
-    private var checkpoint: Checkpoint
+    private let checkpoint: Checkpoint
 
-    private var changes: [Change]
+    private let changes: [Change]
 
     /**
      * `snapshot` is a byte array that encode the document.
      */
-    private var snapshot: Data?
+    private let snapshot: Data?
 
     /**
      * `minSyncedTicket` is the minimum logical time taken by clients who attach

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -17,7 +17,7 @@
 import Combine
 import Foundation
 
-class Document {
+public actor Document {
     private var key: String
     private var root: CRDTRoot
     private var clone: CRDTRoot?
@@ -27,7 +27,7 @@ class Document {
 
     let eventStream: PassthroughSubject<DocEvent, YorkieError>
 
-    init(key: String) {
+    public init(key: String) {
         self.key = key
         self.root = CRDTRoot()
         self.changeID = ChangeID.initial
@@ -39,7 +39,7 @@ class Document {
     /**
      * `update` executes the given updater to update this document.
      */
-    func update(updater: (_ root: JSONObject) -> Void, message: String? = nil) {
+    public func update(updater: (_ root: JSONObject) -> Void, message: String? = nil) {
         let clone = self.cloned()
         let context = ChangeContext(id: self.changeID.next(), root: clone, message: message)
 
@@ -214,7 +214,7 @@ class Document {
     /**
      * `toSortedJSON` returns the sorted JSON encoding of this array.
      */
-    private func toSortedJSON() -> String {
+    func toSortedJSON() -> String {
         return self.root.debugDescription
     }
 
@@ -240,11 +240,12 @@ class Document {
      * `applyChanges` applies the given changes into this document.
      */
     func applyChanges(changes: [Change]) throws {
-        Logger.debug("""
-        trying to apply \(changes.count) remote changes.
-        elements:\(self.root.getElementMapSize()),
-        removeds:\(self.root.getRemovedElementSetSize())
-        """)
+        Logger.debug(
+            """
+            trying to apply \(changes.count) remote changes.
+            elements:\(self.root.getElementMapSize()),
+            removeds:\(self.root.getRemovedElementSetSize())
+            """)
 
         Logger.trivial(changes.map { "\($0.getID().getStructureAsString())\t\($0.getStructureAsString())" }.joined(separator: "\n"))
 
@@ -259,9 +260,11 @@ class Document {
         }
 
         Logger.debug(
-            "after appling \(changes.count) remote changes.\n" +
-                "elements:\(self.root.getElementMapSize()), \n" +
-                "removeds:\(self.root.getRemovedElementSetSize())"
+            """
+            after appling \(changes.count) remote changes.
+            elements:\(self.root.getElementMapSize()),
+            removeds:\(self.root.getRemovedElementSetSize())
+            """
         )
     }
 
@@ -275,11 +278,5 @@ class Document {
             }
         }
         return pathTrie.findPrefixes().map { $0.joined(separator: ".") }
-    }
-}
-
-extension Document: CustomDebugStringConvertible {
-    var debugDescription: String {
-        self.toSortedJSON()
     }
 }

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -24,8 +24,8 @@ public class JSONArray {
     static let notAppend = -1
     static let notFound = -1
 
-    var target: CRDTArray!
-    var context: ChangeContext!
+    private var target: CRDTArray!
+    private var context: ChangeContext!
 
     public init() {}
 

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -20,14 +20,14 @@ import Foundation
  * `JSONArray` represents JSON array, but unlike regular JSON, it has time
  * tickets created by a logical clock to resolve conflicts.
  */
-class JSONArray {
+public class JSONArray {
     static let notAppend = -1
     static let notFound = -1
 
     var target: CRDTArray!
     var context: ChangeContext!
 
-    init() {}
+    public init() {}
 
     init(target: CRDTArray, changeContext: ChangeContext) {
         self.target = target
@@ -139,7 +139,7 @@ class JSONArray {
         self.push(value)
     }
 
-    func append(values: [Any]) {
+    public func append(values: [Any]) {
         self.push(values: values)
     }
 
@@ -511,6 +511,10 @@ class JSONArray {
         }
         return Self.notFound
     }
+
+    var debugDescription: String {
+        self.target.debugDescription
+    }
 }
 
 extension JSONArray: JSONDatable {
@@ -523,15 +527,23 @@ extension JSONArray: JSONDatable {
     }
 }
 
-extension JSONArray: Sequence {
-    typealias Element = Any
+extension JSONArray {
+    var toArray: [Any] {
+        self.target.compactMap {
+            toJSONElement(from: $0)
+        }
+    }
+}
 
-    func makeIterator() -> JSONArrayIterator {
+extension JSONArray: Sequence {
+    public typealias Element = Any
+
+    public func makeIterator() -> JSONArrayIterator {
         return JSONArrayIterator(self.target, self.context)
     }
 }
 
-class JSONArrayIterator: IteratorProtocol {
+public class JSONArrayIterator: IteratorProtocol {
     private var values: [CRDTElement]
     private var iteratorNext: Int = 0
     private let context: ChangeContext
@@ -544,7 +556,7 @@ class JSONArrayIterator: IteratorProtocol {
         }
     }
 
-    func next() -> Any? {
+    public func next() -> Any? {
         defer {
             self.iteratorNext += 1
         }
@@ -555,19 +567,5 @@ class JSONArrayIterator: IteratorProtocol {
 
         let value = self.values[self.iteratorNext]
         return ElementConverter.toWrappedElement(from: value, context: self.context)
-    }
-}
-
-extension JSONArray: CustomDebugStringConvertible {
-    var debugDescription: String {
-        self.target.debugDescription
-    }
-}
-
-extension JSONArray {
-    var toArray: [Any] {
-        self.target.compactMap {
-            toJSONElement(from: $0)
-        }
     }
 }

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -21,7 +21,7 @@ import Foundation
  * tickets created by a logical clock to resolve conflicts.
  */
 @dynamicMemberLookup
-class JSONObject {
+public class JSONObject {
     var target: CRDTObject!
     var context: ChangeContext!
 
@@ -156,7 +156,7 @@ class JSONObject {
         self.context.push(operation: operation)
     }
 
-    func get(key: String) -> Any? {
+    public func get(key: String) -> Any? {
         guard let value = try? self.target.get(key: key) else {
             Logger.error("The value does not exist. - key: \(key)")
             return nil
@@ -165,7 +165,7 @@ class JSONObject {
         return toJSONElement(from: value)
     }
 
-    func remove(key: String) {
+    public func remove(key: String) {
         Logger.trivial("obj[\(key)]")
 
         let removed = try? self.target.remove(key: key, executedAt: self.context.issueTimeTicket())
@@ -180,7 +180,7 @@ class JSONObject {
         self.context.registerRemovedElement(removed)
     }
 
-    subscript(key: String) -> Any? {
+    public subscript(key: String) -> Any? {
         get {
             self.get(key: key)
         }
@@ -206,16 +206,22 @@ class JSONObject {
     private func toSortedJSON() -> String {
         self.target.toSortedJSON()
     }
+
+    var iterator: [(key: String, value: CRDTElement)] {
+        return self.target.map { (key: String, value: CRDTElement) in
+            (key, value)
+        }
+    }
 }
 
 extension JSONObject: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         self.toJson()
     }
 }
 
 extension JSONObject: CustomDebugStringConvertible {
-    var debugDescription: String {
+    public var debugDescription: String {
         self.toSortedJSON()
     }
 }
@@ -230,39 +236,7 @@ extension JSONObject: JSONDatable {
     }
 }
 
-extension JSONObject: Sequence {
-    typealias Element = (key: String, value: CRDTElement)
-
-    func makeIterator() -> JSONObjectIterator {
-        return JSONObjectIterator(self.target)
-    }
-}
-
-class JSONObjectIterator: IteratorProtocol {
-    private var values: [(key: String, value: CRDTElement)]
-    private var iteratorNext: Int = 0
-
-    init(_ crdtObject: CRDTObject) {
-        self.values = []
-        crdtObject.forEach { (key: String, value: CRDTElement) in
-            values.append((key, value))
-        }
-    }
-
-    func next() -> (key: String, value: CRDTElement)? {
-        defer {
-            self.iteratorNext += 1
-        }
-
-        guard self.iteratorNext < self.values.count else {
-            return nil
-        }
-
-        return self.values[self.iteratorNext]
-    }
-}
-
-extension JSONObject {
+public extension JSONObject {
     subscript(dynamicMember member: String) -> Any? {
         get {
             self.get(key: member)

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -22,8 +22,8 @@ import Foundation
  */
 @dynamicMemberLookup
 public class JSONObject {
-    var target: CRDTObject!
-    var context: ChangeContext!
+    private var target: CRDTObject!
+    private var context: ChangeContext!
 
     init() {}
 

--- a/Sources/Document/Operation/RemoveOperation.swift
+++ b/Sources/Document/Operation/RemoveOperation.swift
@@ -35,7 +35,7 @@ class RemoveOperation: Operation {
      */
     func execute(root: CRDTRoot) throws {
         let parent = root.find(createdAt: getParentCreatedAt())
-        guard let obj = parent as? CRDTContainer else {
+        guard let object = parent as? CRDTContainer else {
             let log: String
             if let parent {
                 log = "only object and array can execute remove: \(parent)"
@@ -47,7 +47,7 @@ class RemoveOperation: Operation {
             throw YorkieError.unexpected(message: log)
         }
 
-        let element = try obj.remove(createdAt: self.createdAt, executedAt: getExecutedAt())
+        let element = try object.remove(createdAt: self.createdAt, executedAt: getExecutedAt())
         root.registerRemovedElement(element)
     }
 

--- a/Sources/Document/Time/TimeTicket.swift
+++ b/Sources/Document/Time/TimeTicket.swift
@@ -30,8 +30,8 @@ struct TimeTicket: Comparable {
     static let initial = TimeTicket(lamport: 0, delimiter: Values.initialDelimiter, actorID: ActorIDs.initial)
     static let max = TimeTicket(lamport: Values.maxLamport, delimiter: Values.maxDelemiter, actorID: ActorIDs.max)
 
-    private var lamport: Int64
-    private var delimiter: UInt32
+    private let lamport: Int64
+    private let delimiter: UInt32
     private var actorID: ActorID?
 
     init(lamport: Int64, delimiter: UInt32, actorID: ActorID?) {

--- a/Tests/Document/DocumentConcurrentAccessTests.swift
+++ b/Tests/Document/DocumentConcurrentAccessTests.swift
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import XCTest
+@testable import Yorkie
+
+class DocumentConcurrentAccessTests: XCTestCase {
+    func test_there_is_no_race_condition() async throws {
+        let testLoopCount = 500
+        let expect = expectation(description: "")
+        expect.expectedFulfillmentCount = 5 * testLoopCount
+
+        let target = Document(key: "doc-1")
+
+        for index in 0 ..< testLoopCount {
+            Task.detached(priority: .utility) {
+                await target.update { root in
+                    root.k1 = "\(index)"
+                }
+                expect.fulfill()
+            }
+
+            Task.detached(priority: .userInitiated) {
+                await target.update { root in
+                    root.k1 = "\(index)"
+                }
+                expect.fulfill()
+            }
+
+            Task.detached(priority: .low) {
+                await target.update { root in
+                    root.k1 = "\(index)"
+                }
+                expect.fulfill()
+            }
+
+            Task.detached(priority: .high) {
+                await target.update { root in
+                    root.k1 = "\(index)"
+                }
+                expect.fulfill()
+            }
+
+            Task.detached(priority: .background) {
+                await target.update { root in
+                    root.k1 = "\(index)"
+                }
+                expect.fulfill()
+            }
+        }
+
+        wait(for: [expect], timeout: 100)
+    }
+}

--- a/Tests/Document/JSONArrayTests.swift
+++ b/Tests/Document/JSONArrayTests.swift
@@ -18,9 +18,9 @@ import XCTest
 @testable import Yorkie
 
 class JSONArrayTests: XCTestCase {
-    func test_can_append() {
+    func test_can_append() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = JSONArray()
             let array = root["array"] as? JSONArray
 
@@ -46,9 +46,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_append_with_array() {
+    func test_can_append_with_array() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             array?.append(Int32(4))
@@ -60,9 +60,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_get_element_by_id_and_index() {
+    func test_can_get_element_by_id_and_index() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             let element = array?.getElement(byIndex: 0) as? Primitive
@@ -73,9 +73,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_get_last() {
+    func test_can_get_last() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let primitive = array?.getLast() as? Primitive else {
@@ -91,9 +91,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_insert_into_after() {
+    func test_can_insert_into_after() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let firstElement = array?.getElement(byIndex: 0) as? Primitive else {
@@ -108,9 +108,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_insert_into_before() {
+    func test_can_insert_into_before() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let thirdElement = array?.getElement(byIndex: 2) as? Primitive else {
@@ -125,9 +125,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_move_to_before() {
+    func test_can_move_to_before() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let firstElement = array?.getElement(byIndex: 0) as? Primitive else {
@@ -146,9 +146,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_move_to_after() {
+    func test_can_move_to_after() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let firstElement = array?.getElement(byIndex: 0) as? Primitive else {
@@ -167,9 +167,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_move_to_front() {
+    func test_can_move_to_front() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
 
@@ -184,9 +184,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_move_to_last() {
+    func test_can_move_to_last() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let firstElement = array?.getElement(byIndex: 0) as? Primitive else {
@@ -200,9 +200,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_remove() {
+    func test_can_remove() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
             guard let firstElement = array?.getElement(byIndex: 0) as? Primitive else {
@@ -223,9 +223,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_get_length() {
+    func test_can_get_length() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3)]
             let array = root["array"] as? JSONArray
 
@@ -233,9 +233,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_remove_partial_elements() {
+    func test_can_remove_partial_elements() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
             let array = root["array"] as? JSONArray
 
@@ -247,9 +247,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_replace_partial_elements() {
+    func test_can_replace_partial_elements() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
             let array = root["array"] as? JSONArray
 
@@ -260,9 +260,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_check_to_include() {
+    func test_can_check_to_include() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
             let array = root["array"] as? JSONArray
 
@@ -273,9 +273,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_get_index() {
+    func test_can_get_index() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
             let array = root["array"] as? JSONArray
 
@@ -286,9 +286,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_get_last_index() {
+    func test_can_get_last_index() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
             let array = root["array"] as? JSONArray
 
@@ -299,9 +299,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_insert_jsonObject() {
+    func test_can_insert_jsonObject() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["top"] = JSONObject()
             let object = root["top"] as? JSONObject
 
@@ -311,9 +311,9 @@ class JSONArrayTests: XCTestCase {
         }
     }
 
-    func test_can_insert_jsonArray() {
+    func test_can_insert_jsonArray() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root["array"] = JSONArray()
             let array = root["array"] as? JSONArray
 

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -18,9 +18,9 @@ import XCTest
 @testable import Yorkie
 
 class JSONObjectTests: XCTestCase {
-    func test_can_set() throws {
+    func test_can_set() async throws {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root.set(key: "boolean", value: true)
             root.set(key: "integer", value: Int32(111))
             root.set(key: "long", value: Int64(9_999_999))
@@ -52,9 +52,9 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    func test_can_remove() {
+    func test_can_remove() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root.boolean = true
             root.integer = Int32(111)
             root.long = Int64(9_999_999)
@@ -87,9 +87,9 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    func test_can_set_with_dictionary() {
+    func test_can_set_with_dictionary() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root.set([
                 "boolean": true,
                 "integer": Int32(111),
@@ -121,9 +121,9 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    func test_can_set_with_key_and_dictionary() {
+    func test_can_set_with_key_and_dictionary() async {
         let target = Document(key: "doc1")
-        target.update { root in
+        await target.update { root in
             root.set(key: "top", value: [
                 "boolean": true,
                 "integer": Int32(111),

--- a/Yorkie.xcodeproj/project.pbxproj
+++ b/Yorkie.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		CE9557CB29066D8C00DF4DFA /* TrieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9557C929066D8700DF4DFA /* TrieTests.swift */; };
 		CE9557CD2907523A00DF4DFA /* JSONArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9557CC2907523A00DF4DFA /* JSONArray.swift */; };
 		CE9557CF2908B6BA00DF4DFA /* JSONDatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9557CE2908B6BA00DF4DFA /* JSONDatable.swift */; };
+		CE9F6FAE2910FBBA002F776D /* DocumentConcurrentAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9F6FAD2910FBBA002F776D /* DocumentConcurrentAccessTests.swift */; };
 		CEA2DA4328F672AD00431B61 /* MoveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA2DA4128F672AD00431B61 /* MoveOperationTests.swift */; };
 		CEA2DA4428F672AD00431B61 /* AddOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA2DA4228F672AD00431B61 /* AddOperationTests.swift */; };
 		CEA2DA4628F68D0A00431B61 /* ChangeID.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA2DA4528F68D0A00431B61 /* ChangeID.swift */; };
@@ -82,8 +83,8 @@
 		CEEB17E828C84D6A004988DD /* GRPC in Frameworks */ = {isa = PBXBuildFile; productRef = CEEB17E728C84D6A004988DD /* GRPC */; };
 		CEEB17EB28C84D7B004988DD /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = CEEB17EA28C84D7B004988DD /* SwiftProtobuf */; };
 		CEF64375290A349F00C32B99 /* DocEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF64374290A349F00C32B99 /* DocEvent.swift */; };
-		CEF6437A290A4F0B00C32B99 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF64379290A4F0B00C32B99 /* Optional+Extensions.swift */; };
 		CEF64378290A380000C32B99 /* DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF64376290A37BB00C32B99 /* DocumentTests.swift */; };
+		CEF6437A290A4F0B00C32B99 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF64379290A4F0B00C32B99 /* Optional+Extensions.swift */; };
 		CEFF0015290120000020561A /* JSONObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFF0014290120000020561A /* JSONObject.swift */; };
 /* End PBXBuildFile section */
 
@@ -156,6 +157,7 @@
 		CE9557C929066D8700DF4DFA /* TrieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrieTests.swift; sourceTree = "<group>"; };
 		CE9557CC2907523A00DF4DFA /* JSONArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONArray.swift; sourceTree = "<group>"; };
 		CE9557CE2908B6BA00DF4DFA /* JSONDatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDatable.swift; sourceTree = "<group>"; };
+		CE9F6FAD2910FBBA002F776D /* DocumentConcurrentAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentConcurrentAccessTests.swift; sourceTree = "<group>"; };
 		CEA2DA4128F672AD00431B61 /* MoveOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoveOperationTests.swift; sourceTree = "<group>"; };
 		CEA2DA4228F672AD00431B61 /* AddOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddOperationTests.swift; sourceTree = "<group>"; };
 		CEA2DA4528F68D0A00431B61 /* ChangeID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeID.swift; sourceTree = "<group>"; };
@@ -176,8 +178,8 @@
 		CEEB17E128C84D26004988DD /* resources.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = resources.pb.swift; sourceTree = "<group>"; };
 		CEEB17E228C84D26004988DD /* yorkie.grpc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = yorkie.grpc.swift; sourceTree = "<group>"; };
 		CEF64374290A349F00C32B99 /* DocEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocEvent.swift; sourceTree = "<group>"; };
-		CEF64379290A4F0B00C32B99 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		CEF64376290A37BB00C32B99 /* DocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTests.swift; sourceTree = "<group>"; };
+		CEF64379290A4F0B00C32B99 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		CEFF0014290120000020561A /* JSONObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObject.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -302,6 +304,7 @@
 				CE9557BE2902024700DF4DFA /* JSONObjectTests.swift */,
 				CEBC84062909130900781AE9 /* JSONArrayTests.swift */,
 				CEF64376290A37BB00C32B99 /* DocumentTests.swift */,
+				CE9F6FAD2910FBBA002F776D /* DocumentConcurrentAccessTests.swift */,
 			);
 			path = Document;
 			sourceTree = "<group>";
@@ -726,6 +729,7 @@
 				CEDB32E028EBE6A4004BBA80 /* CRDTObjectTests.swift in Sources */,
 				CE370E5C28EEBFA6008FCABD /* RHTTests.swift in Sources */,
 				CE8BB73828FE28410020F62A /* ChangeTests.swift in Sources */,
+				CE9F6FAE2910FBBA002F776D /* DocumentConcurrentAccessTests.swift in Sources */,
 				CEA2DA4D28F6944000431B61 /* StringExtensionsTests.swift in Sources */,
 				CE3EC95F28D2AAA1009471BC /* SplayTreeTests.swift in Sources */,
 				CE8C230B28D15FF200432DE5 /* ClientTests.swift in Sources */,


### PR DESCRIPTION
Remove redundant codes

Change Document from class to actor for concurrent access to it.
Remove some redundant codes.
Change TimeTicket/lamport and delimiter from var to let


<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
