### PR TITLE
Improve Document sync Test.

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -41,7 +41,7 @@ enum Converter {
         case .bytes:
             return .bytes(data)
         case .date:
-            let milliseconds = Int(littleEndian: data.withUnsafeBytes { $0.load(as: Int.self) })
+            let milliseconds = Int64(littleEndian: data.withUnsafeBytes { $0.load(as: Int64.self) })
             return .date(Date(timeIntervalSince1970: TimeInterval(Double(milliseconds) / 1000)))
         default:
             throw YorkieError.unimplemented(message: String(describing: valueType))

--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -44,7 +44,7 @@ class Primitive: CRDTElement {
         switch value {
         case .date(let dateValue):
             // Trim the less than a millisecond
-            self.value = .date(Date(timeIntervalSince1970: Double(dateValue.millisecondTimeIntervalSince1970) / 1000))
+            self.value = .date(dateValue.trimedLessThanMilliseconds)
         default:
             self.value = value
         }
@@ -118,7 +118,7 @@ class Primitive: CRDTElement {
         case .bytes(let value):
             return value
         case .date(let value):
-            let milliseconds = value.millisecondTimeIntervalSince1970
+            let milliseconds = value.millisecondsTimeIntervalSince1970
             return withUnsafeBytes(of: milliseconds.littleEndian) { Data($0) }
         }
     }
@@ -148,7 +148,7 @@ extension Primitive {
         case .bytes(let value):
             return "\(value)"
         case .date(let value):
-            return "\(value.millisecondTimeIntervalSince1970)"
+            return "\(value.millisecondsTimeIntervalSince1970)"
         }
     }
 
@@ -169,12 +169,16 @@ extension Primitive {
     }
 }
 
-private extension Date {
+extension Date {
     /**
-     * `millisecondTimeIntervalSince1970` returns the number representing the milliseconds elapsed between 1 January 1970 00:00:00 UTC and the given date.
+     * `millisecondsTimeIntervalSince1970` returns the number representing the milliseconds elapsed between 1 January 1970 00:00:00 UTC and the given date.
      *  It's simmilar getTime() in javascript
      */
-    var millisecondTimeIntervalSince1970: Int {
-        Int(floor(self.timeIntervalSince1970 * 1000))
+    var millisecondsTimeIntervalSince1970: Int64 {
+        Int64(floor(self.timeIntervalSince1970 * 1000))
+    }
+
+    var trimedLessThanMilliseconds: Date {
+        Date(timeIntervalSince1970: TimeInterval(Double(self.millisecondsTimeIntervalSince1970) / 1000))
     }
 }

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -135,30 +135,50 @@ final class ClientIntegrationTests: XCTestCase {
 
         await self.d1.update { root in
             root.k1 = "v1"
+            root.k2 = "v2"
+            root.k3 = "v3"
         }
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
         var result = await d2.getRoot().get(key: "k1") as? String
         XCTAssert(result == "v1")
-
-        await self.d1.update { root in
-            root.k2 = "v2"
-        }
-
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         result = await self.d2.getRoot().get(key: "k2") as? String
         XCTAssert(result == "v2")
+        result = await self.d2.getRoot().get(key: "k3") as? String
+        XCTAssert(result == "v3")
 
         await self.d1.update { root in
-            root.k3 = "v3"
+            root.integer = Int32.max
+            root.long = Int64.max
+            root.double = Double.pi
         }
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        result = await self.d2.getRoot().get(key: "k3") as? String
-        XCTAssert(result == "v3")
+        let resultInteger = await self.d2.getRoot().get(key: "integer") as? Int32
+        XCTAssert(resultInteger == Int32.max)
+        let resultLong = await self.d2.getRoot().get(key: "long") as? Int64
+        XCTAssert(resultLong == Int64.max)
+        let resultDouble = await self.d2.getRoot().get(key: "double") as? Double
+        XCTAssert(resultDouble == Double.pi)
+
+        let curr = Date()
+
+        await self.d1.update { root in
+            root.true = true
+            root.false = false
+            root.date = curr
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let resultTrue = await self.d2.getRoot().get(key: "true") as? Bool
+        XCTAssert(resultTrue == true)
+        let resultFalse = await self.d2.getRoot().get(key: "false") as? Bool
+        XCTAssert(resultFalse == false)
+        let resultDate = await self.d2.getRoot().get(key: "date") as? Date
+        XCTAssert(resultDate?.trimedLessThanMilliseconds == curr.trimedLessThanMilliseconds)
 
         try await self.c1.detach(self.d1)
         try await self.c2.detach(self.d2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Improve the client auto sync test to check all primitive types.
-  Specify Date rawValue type to Int64
- Add utility function "trimedLessThanMilliseconds"
  - In Yorkie system, the Date primitive value is represented as milliseconds Int64.
  - In iOS, the Date value is represented as seconds Double.
  - So, the date value in iOS has to trim less than milliseconds to transmit and compare values.  
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
- Date.trimedLessThanMilliseconds is required, to compare the iOS Date structure with the Yorkie Date primitive value.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
