### PR TITLE
Add get(keyPath:) to JSONObject

### DIFF
--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -155,7 +155,7 @@ public class JSONArray {
     @discardableResult
     /// - Returns: The number of elements.
     func push(_ value: Any) -> Int {
-        if let value = value as? YorkieJSONObjectable {
+        if let value = value as? JSONObjectable {
             let length = self.push(JSONObject())
             let appendedIndex = length - 1
             let jsonObject = self[appendedIndex] as? JSONObject

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -73,7 +73,7 @@ public class JSONObject {
             self.set(key: key, value: JSONObject())
             let jsonObject = self.get(key: key) as? JSONObject
             jsonObject?.set(value)
-        } else if let value = value as? YorkieJSONObjectable {
+        } else if let value = value as? JSONObjectable {
             self.set(key: key, value: JSONObject())
             let jsonObject = self.get(key: key) as? JSONObject
             jsonObject?.set(value.toJsonObject)

--- a/Sources/Document/Util/JSONObjectable.swift
+++ b/Sources/Document/Util/JSONObjectable.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-/// ``YorkieJSONObjectable`` provide a way to make a dictionary including members of a type confirming ``YorkieJSONObjectable``.
-public protocol YorkieJSONObjectable: Codable {
-    /// The members of ``excludedLabels`` is not included in a dictionary made by ``toYorkieObject``.
+/// ``JSONObjectable`` provide a way to make a dictionary including members of a type confirming ``JSONObjectable``.
+public protocol JSONObjectable: Codable {
+    /// The members of ``JSONObjectable/excludedMembers`` is not included in a dictionary made by ``JSONObjectable/toJsonObject``.
     var excludedMembers: [String] { get }
 }
 
-public extension YorkieJSONObjectable {
-    /// ``toJsonObject`` make a dictionary including members of a type confirming ``YorkieObjectable``.
+public extension JSONObjectable {
+    /// ``toJsonObject`` make a dictionary including members of a type confirming ``JSONObjectable``.
     internal var toJsonObject: [String: Any] {
         guard let data = try? JSONEncoder().encode(self),
               let dictionary = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
@@ -34,7 +34,7 @@ public extension YorkieJSONObjectable {
         var result = [String: Any]()
         for (key, value) in dictionary {
             guard self.excludedMembers.contains(key) == false else { continue }
-            if let value = value as? YorkieJSONObjectable {
+            if let value = value as? JSONObjectable {
                 result[key] = value.toJsonObject
             } else if let value = value as? [Any] {
                 result[key] = value.toJsonArray
@@ -51,11 +51,11 @@ public extension YorkieJSONObjectable {
     }
 }
 
-/// ``toJsonArray`` provide a way to make a array including types confiming``YorkieJSONObjectable``, arrys, and values.
+/// ``toJsonArray`` provide a way to make an array including types confiming``JSONObjectable``, arrys, and values.
 internal extension Array {
     var toJsonArray: [Any] {
         self.map {
-            if let value = $0 as? YorkieJSONObjectable {
+            if let value = $0 as? JSONObjectable {
                 return value.toJsonObject
             } else if let value = $0 as? Array {
                 return value.toJsonArray

--- a/Tests/Document/JSONObjectTests.swift
+++ b/Tests/Document/JSONObjectTests.swift
@@ -156,7 +156,7 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    private struct JsonObejctTestType: YorkieJSONObjectable {
+    private struct JsonObejctTestType: JSONObjectable {
         var id: Int64 = 100
         var type: String = "struct"
         var serial: Int32 = 1234
@@ -167,7 +167,7 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    private struct JsonArrayTestType: YorkieJSONObjectable {
+    private struct JsonArrayTestType: JSONObjectable {
         var id: Int64 = 200
     }
 
@@ -203,19 +203,19 @@ class JSONObjectTests: XCTestCase {
         }
     }
 
-    private struct JSONObject0: YorkieJSONObjectable {
+    private struct JSONObject0: JSONObjectable {
         let first: JSONObject1
     }
 
-    private struct JSONObject1: YorkieJSONObjectable {
+    private struct JSONObject1: JSONObjectable {
         let second: JSONObject2
     }
 
-    private struct JSONObject2: YorkieJSONObjectable {
+    private struct JSONObject2: JSONObjectable {
         let third: JSONObject3
     }
 
-    private struct JSONObject3: YorkieJSONObjectable {
+    private struct JSONObject3: JSONObjectable {
         let value: String
     }
 

--- a/Tests/Document/Util/YorkieJSONObjectableTests.swift
+++ b/Tests/Document/Util/YorkieJSONObjectableTests.swift
@@ -18,12 +18,12 @@ import Combine
 import XCTest
 @testable import Yorkie
 
-struct KanbanColumn: YorkieJSONObjectable {
+struct KanbanColumn: JSONObjectable {
     let title: String
     var cards: [KanbanCard] = []
 }
 
-struct KanbanCard: YorkieJSONObjectable {
+struct KanbanCard: JSONObjectable {
     let title: String
 }
 

--- a/Yorkie.xcodeproj/project.pbxproj
+++ b/Yorkie.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		CEC631DE28F4F36100915A85 /* StringEscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC631DC28F4F15900915A85 /* StringEscapingTests.swift */; };
 		CECCCB8428C96CD600544204 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECCCB8228C96C9200544204 /* XCTestCase+Extension.swift */; };
 		CEDB32E028EBE6A4004BBA80 /* CRDTObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDB32DF28EBE6A4004BBA80 /* CRDTObjectTests.swift */; };
-		CEDDE26E2914EAD00032B16A /* YorkieJSONObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDDE26D2914EAD00032B16A /* YorkieJSONObjectable.swift */; };
+		CEDDE26E2914EAD00032B16A /* JSONObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDDE26D2914EAD00032B16A /* JSONObjectable.swift */; };
 		CEDDE2722914EB5C0032B16A /* YorkieJSONObjectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDDE2702914EB260032B16A /* YorkieJSONObjectableTests.swift */; };
 		CEEB17E328C84D26004988DD /* yorkie.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEB17E028C84D26004988DD /* yorkie.pb.swift */; };
 		CEEB17E428C84D26004988DD /* resources.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEB17E128C84D26004988DD /* resources.pb.swift */; };
@@ -180,7 +180,7 @@
 		CEC631DC28F4F15900915A85 /* StringEscapingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringEscapingTests.swift; sourceTree = "<group>"; };
 		CECCCB8228C96C9200544204 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
 		CEDB32DF28EBE6A4004BBA80 /* CRDTObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRDTObjectTests.swift; sourceTree = "<group>"; };
-		CEDDE26D2914EAD00032B16A /* YorkieJSONObjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YorkieJSONObjectable.swift; sourceTree = "<group>"; };
+		CEDDE26D2914EAD00032B16A /* JSONObjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectable.swift; sourceTree = "<group>"; };
 		CEDDE2702914EB260032B16A /* YorkieJSONObjectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YorkieJSONObjectableTests.swift; sourceTree = "<group>"; };
 		CEEB17DC28C84CC3004988DD /* resources.proto */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.protobuf; path = resources.proto; sourceTree = "<group>"; };
 		CEEB17DD28C84CC3004988DD /* yorkie.proto */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.protobuf; path = yorkie.proto; sourceTree = "<group>"; };
@@ -514,7 +514,7 @@
 		CEDDE26C2914EABA0032B16A /* Util */ = {
 			isa = PBXGroup;
 			children = (
-				CEDDE26D2914EAD00032B16A /* YorkieJSONObjectable.swift */,
+				CEDDE26D2914EAD00032B16A /* JSONObjectable.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -750,7 +750,7 @@
 				CEEB17E528C84D26004988DD /* yorkie.grpc.swift in Sources */,
 				CEBC840A2909252000781AE9 /* ElementConverter.swift in Sources */,
 				CE8ED31C28F56506009A5419 /* RemoveOperation.swift in Sources */,
-				CEDDE26E2914EAD00032B16A /* YorkieJSONObjectable.swift in Sources */,
+				CEDDE26E2914EAD00032B16A /* JSONObjectable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
[Add get(keyPath:) to JSONObject](https://github.com/yorkie-team/yorkie-ios-sdk/commit/70bc1af1b92bb1eadf2c50a1f76cd0f1e9ddc5da)
- I arbitrarily used `/.^/` for key separator. It should be changed to something suitable.

[Rename YorkieJSONObjectable to JSONObjectable](https://github.com/yorkie-team/yorkie-ios-sdk/commit/838f6db7a6bd82b72a9bed5c71dd762e93d6f490)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
