### PR TITLE
Change eventStream of Client from Error to Never

### DIFF
--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -153,7 +153,7 @@ public actor Client {
     public var isActive: Bool { self.status == .activated }
     public private(set) var status: ClientStatus
     public var presence: Presence { self.presenceInfo.data }
-    public nonisolated let eventStream: PassthroughSubject<BaseClientEvent, Error>
+    public nonisolated let eventStream: PassthroughSubject<BaseClientEvent, Never>
 
     /**
      * @param rpcAddr - the address of the RPC server.

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -223,8 +223,7 @@ final class ClientIntegrationTests: XCTestCase {
         var c1Name = "c1"
         var c2Name = "c2"
 
-        c1.eventStream.sink { _ in
-        } receiveValue: { event in
+        c1.eventStream.sink { event in
             switch event {
             case let event as PeerChangedEvent:
                 print("#### c1 \(event)")
@@ -233,8 +232,7 @@ final class ClientIntegrationTests: XCTestCase {
             }
         }.store(in: &self.cancellables)
 
-        c2.eventStream.sink { _ in
-        } receiveValue: { event in
+        c2.eventStream.sink { event in
             switch event {
             case let event as PeerChangedEvent:
                 print("#### c2 \(event)")

--- a/Tests/Unit/Core/ClientTests.swift
+++ b/Tests/Unit/Core/ClientTests.swift
@@ -36,8 +36,7 @@ class ClientTests: XCTestCase {
             return
         }
 
-        target.eventStream.sink { _ in
-        } receiveValue: { event in
+        target.eventStream.sink { event in
             switch event {
             case let event as StatusChangedEvent:
                 status = event.value
@@ -84,8 +83,7 @@ class ClientTests: XCTestCase {
             return
         }
 
-        target.eventStream.sink { _ in
-        } receiveValue: { event in
+        target.eventStream.sink { event in
             switch event {
             case let event as StatusChangedEvent:
                 status = event.value
@@ -125,8 +123,7 @@ class ClientTests: XCTestCase {
             return
         }
 
-        target.eventStream.sink { _ in
-        } receiveValue: { event in
+        target.eventStream.sink { event in
             print("#### \(event)")
             switch event {
             case let event as StatusChangedEvent:

--- a/Tests/Unit/Document/DocumentTests.swift
+++ b/Tests/Unit/Document/DocumentTests.swift
@@ -727,9 +727,7 @@ class DocumentTests: XCTestCase {
     func test_change_paths_test_for_object() async {
         let target = Document(key: "test-doc")
 
-        await target.eventStream.sink { _ in
-
-        } receiveValue: { event in
+        await target.eventStream.sink { event in
             XCTAssertEqual(event.type, .localChange)
             XCTAssertEqual((event as? LocalChangeEvent)?.value[0].paths, ["$."])
         }.store(in: &self.cancellables)
@@ -791,9 +789,7 @@ class DocumentTests: XCTestCase {
     func test_change_paths_test_for_array() async {
         let target = Document(key: "test-doc")
 
-        await target.eventStream.sink { _ in
-
-        } receiveValue: { event in
+        await target.eventStream.sink { event in
             XCTAssertEqual(event.type, .localChange)
 
             XCTAssertEqual((event as? LocalChangeEvent)?.value[0].paths.sorted(), ["$.arr", "$.\\$\\$\\.\\.\\.hello"].sorted())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change eventStream of Client from Error to Never
 - It simplifies the interface of `Client.eventStream.sink`
 
Change labels of Document.update

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
