### PR TITLE
Change Counter increase() to accept any numeric value

### DIFF
--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -60,17 +60,9 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
     public func increase(_ primitive: Primitive) throws -> CRDTCounter {
         switch primitive.value {
         case .integer(let int32Value):
-            guard let value = int32Value as? T else {
-                throw YorkieError.type(message: "Value Type mismatch: \(type(of: primitive)), \(T.self)")
-            }
-
-            self.value = self.value.addingReportingOverflow(value).partialValue
+            self.value &+= T(int32Value)
         case .long(let int64Value):
-            guard let value = int64Value as? T else {
-                throw YorkieError.type(message: "Value Type mismatch: \(type(of: primitive.value))")
-            }
-
-            self.value = self.value.addingReportingOverflow(value).partialValue
+            self.value &+= T(int64Value)
         default:
             throw YorkieError.type(message: "Unsupported type of value: \(type(of: primitive.value))")
         }

--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -65,6 +65,8 @@ class Primitive: CRDTElement {
             return .integer(casted)
         case let casted as Int64:
             return .long(casted)
+        case let casted as Int:
+            return .long(Int64(casted))
         case let casted as Double:
             return .double(casted)
         case let casted as String:

--- a/Sources/Document/Util/YorkieCountable.swift
+++ b/Sources/Document/Util/YorkieCountable.swift
@@ -19,6 +19,7 @@ import Foundation
 public protocol YorkieCountable: BinaryInteger {
     var littleEndian: Self { get }
     func addingReportingOverflow(_ other: Self) -> (partialValue: Self, overflow: Bool)
+    static func &+= (lhs: inout Self, rhs: Self)
 }
 
 extension Int32: YorkieCountable {}

--- a/Tests/Integration/CounterIntegrationTests.swift
+++ b/Tests/Integration/CounterIntegrationTests.swift
@@ -32,10 +32,8 @@ final class CounterIntegrationTests: XCTestCase {
         await doc.update { root in
             root.age = JSONCounter(value: Int32(1))
             root.length = JSONCounter(value: Int64(10))
-            do {
-                try (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
-                try (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
-            } catch {}
+            (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
+            (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
         }
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -48,10 +46,8 @@ final class CounterIntegrationTests: XCTestCase {
         XCTAssert(result == "{\"age\":6,\"length\":13}")
 
         await doc.update { root in
-            do {
-                try (root.age as! JSONCounter<Int32>).increase(value: Int32(1)).increase(value: Int32(1))
-                try (root.length as! JSONCounter<Int64>).increase(value: Int64(3)).increase(value: Int64(1))
-            } catch {}
+            (root.age as! JSONCounter<Int32>).increase(value: Int32(1)).increase(value: Int32(1))
+            (root.length as! JSONCounter<Int64>).increase(value: Int64(3)).increase(value: Int64(1))
         }
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -59,21 +55,11 @@ final class CounterIntegrationTests: XCTestCase {
         result = await doc.toSortedJSON()
         XCTAssert(result == "{\"age\":8,\"length\":17}")
 
-        let expectation = XCTestExpectation(description: "failed Test")
-        var failedTestResult = false
-
         await doc.update { root in
-            do {
-                try (root.age as! JSONCounter<Int32>).increase(value: Int64(1))
-            } catch {
-                failedTestResult = true
-                expectation.fulfill()
-            }
+            (root.age as! JSONCounter<Int32>).increase(value: Int64(1))
         }
-
-        wait(for: [expectation], timeout: 1)
-
-        XCTAssert(failedTestResult)
+        result = await doc.toSortedJSON()
+        XCTAssertEqual(result, "{\"age\":9,\"length\":17}")
     }
 
     func test_can_sync_counter() async throws {
@@ -110,10 +96,8 @@ final class CounterIntegrationTests: XCTestCase {
         XCTAssert(result1 == result2)
 
         await self.d1.update { root in
-            do {
-                try (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
-                try (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
-            } catch {}
+            (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
+            (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
         }
 
         try await Task.sleep(nanoseconds: 2_000_000_000)
@@ -165,10 +149,8 @@ final class CounterIntegrationTests: XCTestCase {
         XCTAssert(result1 == "{\"counts\":[1,10]}")
 
         await self.d1.update { root in
-            do {
-                try ((root.counts as! JSONArray)[0] as! JSONCounter<Int32>).increase(value: Int32(5))
-                try ((root.counts as! JSONArray)[1] as! JSONCounter<Int32>).increase(value: Int32(3))
-            } catch {}
+            ((root.counts as! JSONArray)[0] as! JSONCounter<Int32>).increase(value: Int32(5))
+            ((root.counts as! JSONArray)[1] as! JSONCounter<Int32>).increase(value: Int32(3))
         }
 
         try await Task.sleep(nanoseconds: 1_000_000_000)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Change Counter increase() to accept any numeric value
  - Now accepts any Integer values.
  - Floating-point values are cast to integer values (eg. 3.5 => 3)
  - Int type converted to long primitive type.
  - JSONCounter doesn't throw errors.
- Add Counter Test Codes.
  - overflow
  - floating-point value.
     
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
do-try-catch is no longer required when calling increase().
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
