### PR TITLE
Remove duplicated key from TextNodeAttr

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -763,7 +763,6 @@ extension Converter {
             pbTextNode.value = String(describing: textNode.value.content)
             textNode.value.getAttributes().forEach { key, value in
                 var attr = PbTextNodeAttr()
-                attr.key = key
                 attr.value = value.value
                 attr.updatedAt = toTimeTicket(value.updatedAt)
                 pbTextNode.attributes[key] = attr

--- a/Sources/API/V1/Protos/resources.proto
+++ b/Sources/API/V1/Protos/resources.proto
@@ -180,9 +180,8 @@ message RGANode {
 }
 
 message TextNodeAttr {
-  string key = 1;
-  string value = 2;
-  TimeTicket updated_at = 3;
+  string value = 1;
+  TimeTicket updated_at = 2;
 }
 
 message TextNode {
@@ -283,7 +282,6 @@ enum ValueType {
   VALUE_TYPE_TEXT = 10;
   VALUE_TYPE_INTEGER_CNT = 11;
   VALUE_TYPE_LONG_CNT = 12;
-  VALUE_TYPE_DOUBLE_CNT = 13;
 }
 
 enum DocEventType {

--- a/Sources/API/V1/resources.pb.swift
+++ b/Sources/API/V1/resources.pb.swift
@@ -50,7 +50,6 @@ enum Yorkie_V1_ValueType: SwiftProtobuf.Enum {
   case text // = 10
   case integerCnt // = 11
   case longCnt // = 12
-  case doubleCnt // = 13
   case UNRECOGNIZED(Int)
 
   init() {
@@ -72,7 +71,6 @@ enum Yorkie_V1_ValueType: SwiftProtobuf.Enum {
     case 10: self = .text
     case 11: self = .integerCnt
     case 12: self = .longCnt
-    case 13: self = .doubleCnt
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -92,7 +90,6 @@ enum Yorkie_V1_ValueType: SwiftProtobuf.Enum {
     case .text: return 10
     case .integerCnt: return 11
     case .longCnt: return 12
-    case .doubleCnt: return 13
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -117,7 +114,6 @@ extension Yorkie_V1_ValueType: CaseIterable {
     .text,
     .integerCnt,
     .longCnt,
-    .doubleCnt,
   ]
 }
 
@@ -1184,8 +1180,6 @@ struct Yorkie_V1_TextNodeAttr {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var key: String = String()
-
   var value: String = String()
 
   var updatedAt: Yorkie_V1_TimeTicket {
@@ -1631,7 +1625,6 @@ extension Yorkie_V1_ValueType: SwiftProtobuf._ProtoNameProviding {
     10: .same(proto: "VALUE_TYPE_TEXT"),
     11: .same(proto: "VALUE_TYPE_INTEGER_CNT"),
     12: .same(proto: "VALUE_TYPE_LONG_CNT"),
-    13: .same(proto: "VALUE_TYPE_DOUBLE_CNT"),
   ]
 }
 
@@ -3207,9 +3200,8 @@ extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
 extension Yorkie_V1_TextNodeAttr: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TextNodeAttr"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "key"),
-    2: .same(proto: "value"),
-    3: .standard(proto: "updated_at"),
+    1: .same(proto: "value"),
+    2: .standard(proto: "updated_at"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -3218,9 +3210,8 @@ extension Yorkie_V1_TextNodeAttr: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.value) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._updatedAt) }()
+      case 1: try { try decoder.decodeSingularStringField(value: &self.value) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._updatedAt) }()
       default: break
       }
     }
@@ -3231,20 +3222,16 @@ extension Yorkie_V1_TextNodeAttr: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.key.isEmpty {
-      try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
-    }
     if !self.value.isEmpty {
-      try visitor.visitSingularStringField(value: self.value, fieldNumber: 2)
+      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
     }
     try { if let v = self._updatedAt {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Yorkie_V1_TextNodeAttr, rhs: Yorkie_V1_TextNodeAttr) -> Bool {
-    if lhs.key != rhs.key {return false}
     if lhs.value != rhs.value {return false}
     if lhs._updatedAt != rhs._updatedAt {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove duplicated key from TextNodeAttr.

Since TextNode.attributes have keys, this commit removes key from TextNodeAttr.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
