### PR TITLE
Let Client.attach wait until stream initialization is finished

### DIFF
--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -71,6 +71,7 @@ public struct ClientOptions {
     private enum DefaultClientOptions {
         static let syncLoopDuration = 50
         static let reconnectStreamDelay = 1000 // 1000 millisecond
+        static let maximumAttachmentTimeout = 5000 // millisecond
     }
 
     /**
@@ -112,12 +113,19 @@ public struct ClientOptions {
      */
     var reconnectStreamDelay: Int
 
-    public init(key: String? = nil, apiKey: String? = nil, token: String? = nil, syncLoopDuration: Int? = nil, reconnectStreamDelay: Int? = nil) {
+    /**
+     * `maximumAttachmentTimeout` is the latest time to wait for a initialization of attached document.
+     * The default value is `5000`(ms).
+     */
+    var maximumAttachmentTimeout: Int
+
+    public init(key: String? = nil, apiKey: String? = nil, token: String? = nil, syncLoopDuration: Int? = nil, reconnectStreamDelay: Int? = nil, attachTimeout: Int? = nil) {
         self.key = key
         self.apiKey = apiKey
         self.token = token
         self.syncLoopDuration = syncLoopDuration ?? DefaultClientOptions.syncLoopDuration
         self.reconnectStreamDelay = reconnectStreamDelay ?? DefaultClientOptions.reconnectStreamDelay
+        self.maximumAttachmentTimeout = attachTimeout ?? DefaultClientOptions.maximumAttachmentTimeout
     }
 }
 
@@ -147,12 +155,15 @@ public actor Client {
     private var attachmentMap: [String: Attachment]
     private let syncLoopDuration: Int
     private let reconnectStreamDelay: Int
+    private let maximumAttachmentTimeout: Int
 
     private let rpcClient: YorkieServiceAsyncClient
     private var watchLoopReconnectTimer: Timer?
     private var watchLoopTask: Task<Void, Never>?
 
     private let group: EventLoopGroup
+
+    private var semaphoresForInitialzation = [String: DispatchSemaphore]()
 
     // Public variables.
     public private(set) var id: ActorID?
@@ -174,6 +185,7 @@ public actor Client {
         self.attachmentMap = [String: Attachment]()
         self.syncLoopDuration = options.syncLoopDuration
         self.reconnectStreamDelay = options.reconnectStreamDelay
+        self.maximumAttachmentTimeout = options.maximumAttachmentTimeout
 
         self.group = PlatformSupport.makeEventLoopGroup(loopCount: 1) // EventLoopGroup helpers
 
@@ -294,6 +306,10 @@ public actor Client {
             self.runWatchLoop()
 
             Logger.info("[AD] c:\"\(self.key))\" attaches d:\"\(doc.getKey())\"")
+
+            if isManualSync == false {
+                try await self.waitForInitialization(doc)
+            }
 
             return doc
         } catch {
@@ -543,6 +559,29 @@ public actor Client {
         self.doWatchLoop()
     }
 
+    private func waitForInitialization(_ doc: Document) async throws {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        self.semaphoresForInitialzation[doc.getKey()] = semaphore
+
+        defer {
+            semaphoresForInitialzation.removeValue(forKey: doc.getKey())
+        }
+
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            DispatchQueue.global().async {
+                if semaphore.wait(timeout: DispatchTime.now() + DispatchTimeInterval.milliseconds(self.maximumAttachmentTimeout)) == .timedOut {
+                    let message = "[AD] Time out for Initialization. d:\"\(doc.getKey())\""
+                    Logger.warning(message)
+                    continuation.resume(throwing: YorkieError.timeout(message: message))
+                } else {
+                    Logger.info("[AD] got Initialization. d:\"\(doc.getKey())\"")
+                    continuation.resume(returning: doc.getKey())
+                }
+            }
+        }
+    }
+
     private func handleWatchDocumentsResponse(keys: [String], response: WatchDocumentsResponse) {
         Logger.debug("[WL] c:\"\(self.key)\" got response \(response)")
 
@@ -556,6 +595,8 @@ public actor Client {
                 for pbClient in pbPeers.clients {
                     self.attachmentMap[docID]?.peerPresenceMap[pbClient.id.toHexString] = Converter.fromPresence(pbPresence: pbClient.presence)
                 }
+
+                semaphoresForInitialzation[docID]?.signal()
             }
 
             let event = PeerChangedEvent(value: keys.reduce([String: [String: Presence]](), self.getPeersWithDocKey(peersMap:key:)))

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -22,4 +22,5 @@ enum YorkieError: Error {
     case clientNotActive(message: String)
     case type(message: String)
     case noSuchElement(message: String)
+    case timeout(message: String)
 }

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -119,17 +119,13 @@ final class ClientIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, false)
         try await self.c2.attach(self.d2, false)
 
-        // Since attach's response doesn't wait for the watch ready,
-        // We need to wait here until the threshold.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         await self.d1.update { root in
             root.k1 = "v1"
             root.k2 = "v2"
             root.k3 = "v3"
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         var result = await d2.getRoot().get(key: "k1") as? String
         XCTAssert(result == "v1")
@@ -144,7 +140,7 @@ final class ClientIntegrationTests: XCTestCase {
             root.double = Double.pi
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let resultInteger = await self.d2.getRoot().get(key: "integer") as? Int32
         XCTAssert(resultInteger == Int32.max)
@@ -161,7 +157,7 @@ final class ClientIntegrationTests: XCTestCase {
             root.date = curr
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let resultTrue = await self.d2.getRoot().get(key: "true") as? Bool
         XCTAssert(resultTrue == true)
@@ -231,14 +227,10 @@ final class ClientIntegrationTests: XCTestCase {
             }
         }.store(in: &self.cancellables)
 
-        // Since attach's response doesn't wait for the watch ready,
-        // We need to wait here until the threshold.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         c1Name = "c1+"
         try await c1.updatePresence("name", c1Name)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let presence1: PresenceType = self.decodePresence(await c2.getPeers(key: d2.getKey())[c1.id!]!)!
 
@@ -247,7 +239,7 @@ final class ClientIntegrationTests: XCTestCase {
         c2Name = "c2+"
         try await c2.updatePresence("name", c2Name)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let presence2: PresenceType = self.decodePresence(await c1.getPeers(key: d1.getKey())[c2.id!]!)!
 

--- a/Tests/Integration/ClientTests.swift
+++ b/Tests/Integration/ClientTests.swift
@@ -138,7 +138,7 @@ class ClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+//        try await Task.sleep(nanoseconds: 1_000_000_000)
 
         do {
             try await target.detach(doc)

--- a/Tests/Integration/CounterIntegrationTests.swift
+++ b/Tests/Integration/CounterIntegrationTests.swift
@@ -36,7 +36,7 @@ final class CounterIntegrationTests: XCTestCase {
             (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let age = await doc.getRoot().age as? JSONCounter<Int32>
 
@@ -50,7 +50,7 @@ final class CounterIntegrationTests: XCTestCase {
             (root.length as! JSONCounter<Int64>).increase(value: Int64(3)).increase(value: Int64(1))
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         result = await doc.toSortedJSON()
         XCTAssert(result == "{\"age\":8,\"length\":17}")
@@ -78,8 +78,6 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, false)
         try await self.c2.attach(self.d2, false)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         await self.d1.update { root in
             root.age = JSONCounter(value: Int32(1))
         }
@@ -88,7 +86,7 @@ final class CounterIntegrationTests: XCTestCase {
             root.length = JSONCounter(value: Int64(10))
         }
 
-        try await Task.sleep(nanoseconds: 2_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         var result1 = await self.d1.toSortedJSON()
         var result2 = await self.d2.toSortedJSON()
@@ -130,8 +128,6 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, false)
         try await self.c2.attach(self.d2, false)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         await self.d1.update { root in
             root.counts = [JSONCounter(value: Int32(1))]
         }
@@ -140,7 +136,7 @@ final class CounterIntegrationTests: XCTestCase {
             (root.counts as! JSONArray).append(JSONCounter(value: Int32(10)))
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         var result1 = await self.d1.toSortedJSON()
         var result2 = await self.d2.toSortedJSON()
@@ -153,7 +149,7 @@ final class CounterIntegrationTests: XCTestCase {
             ((root.counts as! JSONArray)[1] as! JSONCounter<Int32>).increase(value: Int32(3))
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         result1 = await self.d1.toSortedJSON()
         result2 = await self.d2.toSortedJSON()

--- a/Tests/Integration/TextIntegrationTests.swift
+++ b/Tests/Integration/TextIntegrationTests.swift
@@ -41,15 +41,13 @@ final class TextIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, false)
         try await self.c2.attach(self.d2, false)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
         await self.d1.update { root in
             root.text = JSONText()
             (root.text as? JSONText)?.edit(0, 0, "Hello")
             (root.text as? JSONText)?.edit(1, 3, "12")
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let result = (await d2.getRoot().text as? JSONText)?.plainText
 
@@ -72,7 +70,7 @@ final class TextIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, false)
         try await self.c2.attach(self.d2, false)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         await self.d1.update { root in
             root.text = JSONText()
@@ -81,13 +79,13 @@ final class TextIntegrationTests: XCTestCase {
             (root.text as? JSONText)?.setStyle(fromIdx: 1, toIdx: 3, attributes: ["italic": true])
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         await self.d2.update { root in
             (root.text as? JSONText)?.setStyle(fromIdx: 1, toIdx: 3, attributes: ["italic": true])
         }
 
-        try await Task.sleep(nanoseconds: 1_000_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         let resultD1 = (await d1.getRoot().text as? JSONText)?.values?.compactMap {
             $0.toJSON

--- a/Tests/Unit/Document/JSONObjectTests.swift
+++ b/Tests/Unit/Document/JSONObjectTests.swift
@@ -90,16 +90,12 @@ class JSONObjectTests: XCTestCase {
     func test_can_set_with_dictionary() async {
         let target = Document(key: "doc1")
         await target.update { root in
-            root.set([
-                "boolean": true,
-                "integer": Int32(111),
-                "long": Int64(9_999_999),
-                "double": Double(1.2222222),
-                "string": "abc",
-                "compB": ["id": "b",
-                          "compC": ["id": "c",
-                                    "compD": ["id": "d-1"]]]
-            ])
+            root.set(["boolean": true,
+                      "integer": Int32(111),
+                      "long": Int64(9_999_999),
+                      "double": Double(1.2222222),
+                      "string": "abc",
+                      "compB": ["id": "b", "compC": ["id": "c", "compD": ["id": "d-1"]]]])
 
             XCTAssertEqual(root.debugDescription,
                            """
@@ -124,16 +120,13 @@ class JSONObjectTests: XCTestCase {
     func test_can_set_with_key_and_dictionary() async {
         let target = Document(key: "doc1")
         await target.update { root in
-            root.set(key: "top", value: [
-                "boolean": true,
-                "integer": Int32(111),
-                "long": Int64(9_999_999),
-                "double": Double(1.2222222),
-                "string": "abc",
-                "compB": ["id": "b",
-                          "compC": ["id": "c",
-                                    "compD": ["id": "d-1"]]]
-            ])
+            root.set(key: "top",
+                     value: ["boolean": true,
+                             "integer": Int32(111),
+                             "long": Int64(9_999_999),
+                             "double": Double(1.2222222),
+                             "string": "abc",
+                             "compB": ["id": "b", "compC": ["id": "c", "compD": ["id": "d-1"]]]])
 
             XCTAssertEqual(root.debugDescription,
                            """


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is the same as the issue https://github.com/yorkie-team/yorkie-js-sdk/pull/440 in JS.

- Client.attach() wait until the attached document has been initialized or timed out.
- The default timeout is 5 sec.
-  Due to the sync duration being 1 sec, Change the delay time for document sync in Test Codes from 1 sec to 1.5 sec.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
