### PR TITLE
Clarify the ClientEvent that is sent to client

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
-    - uses: docker-practice/actions-setup-docker@master
+    - uses: docker-practice/actions-setup-docker@1.0.11
     - run: docker-compose -f docker/docker-compose-ci.yml up --build -d
     - name: Run tests
       run: swift test --enable-code-coverage -v --filter YorkieIntegrationTests

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -69,7 +69,7 @@ class TextViewModel {
             }.store(in: &self.cancellables)
 
             // define event handler that apply remote changes to local
-            textEventStream.sink { [weak self] events in
+            self.textEventStream.sink { [weak self] events in
                 var textChanges = [TextOperation]()
 
                 events.filter { $0.actor != clientID }.forEach {
@@ -100,7 +100,7 @@ class TextViewModel {
 
             }.store(in: &self.cancellables)
 
-            await(self.document.getRoot().content as? JSONText)?.setEventStream(eventStream: textEventStream)
+            await(self.document.getRoot().content as? JSONText)?.setEventStream(eventStream: self.textEventStream)
 
             await self.syncText()
         }

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/View/PeerSelectionDisplayLayoutManager.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/View/PeerSelectionDisplayLayoutManager.swift
@@ -30,7 +30,7 @@ class PeerSelectionDisplayLayoutManager: NSLayoutManager {
             let colors = Array(attrs.filter { $0.key.rawValue.starts(with: Self.AttributeKeyPrefix) }.compactMapValues { $0 as? UIColor }.values)
 
             let tokenGlypeRange = glyphRange(forCharacterRange: subrange, actualCharacterRange: nil)
-            drawBackground(forGlyphRange: tokenGlypeRange, at: origin, colors: colors)
+            self.drawBackground(forGlyphRange: tokenGlypeRange, at: origin, colors: colors)
         }
 
         super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
@@ -47,10 +47,10 @@ class TextEditorViewController: UIViewController {
         didSet {
             if oldValue != self.isCompositioning {
                 Task {
-                    if isCompositioning {
-                        await model?.pause()
+                    if self.isCompositioning {
+                        await self.model?.pause()
                     } else {
-                        await model?.resume()
+                        await self.model?.resume()
                     }
                 }
             }
@@ -163,7 +163,7 @@ class TextEditorViewController: UIViewController {
                 }
 
                 // Correct peer selection position.
-                peerSelection.forEach { selection in
+                self.peerSelection.forEach { selection in
                     var prevSelectRange = selection.value.0
                     let newDocEnd = storage.length
 
@@ -179,10 +179,10 @@ class TextEditorViewController: UIViewController {
                         }
                     }
 
-                    peerSelection[selection.key] = (prevSelectRange, selection.value.1)
+                    self.peerSelection[selection.key] = (prevSelectRange, selection.value.1)
                 }
 
-                peerSelection = peerSelection.filter { $0.value.0.length > 0 }
+                self.peerSelection = self.peerSelection.filter { $0.value.0.length > 0 }
 
             case .select(let range, let actorID):
 
@@ -191,9 +191,9 @@ class TextEditorViewController: UIViewController {
                 let newColor = UIColor(red: CGFloat.random(in: 0 ... 1), green: CGFloat.random(in: 0 ... 1), blue: CGFloat.random(in: 0 ... 1), alpha: 0.2)
 
                 if let color = peerSelection[actorID]?.1 {
-                    peerSelection[actorID] = (range, color)
+                    self.peerSelection[actorID] = (range, color)
                 } else {
-                    peerSelection[actorID] = (range, newColor)
+                    self.peerSelection[actorID] = (range, newColor)
                 }
             }
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "6bf35472cb8621481e59e6d1450b19627db81cea",
-        "version" : "1.13.1"
+        "revision" : "f09cfb4d36315e2b48dbba1359179abf3cb2e6ac",
+        "version" : "1.14.2"
       }
     },
     {
@@ -32,7 +32,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
-        "version" : "1.4.4"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
-        "version" : "2.45.0"
+        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
+        "version" : "2.48.0"
       }
     },
     {
@@ -59,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "91dd2d61fb772e1311bb5f13b59266b579d77e42",
-        "version" : "1.15.0"
+        "revision" : "d75ed708d00353acf173ca23018b6bd46f949464",
+        "version" : "1.17.0"
       }
     },
     {
@@ -68,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "d6656967f33ed8b368b38e4b198631fc7c484a40",
-        "version" : "1.23.1"
+        "revision" : "38feec96bcd929028939107684073554bf01abeb",
+        "version" : "1.25.2"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
-        "version" : "1.20.3"
+        "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
+        "version" : "1.21.0"
       }
     }
   ],

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -161,7 +161,7 @@ public actor Client {
 
     private let rpcClient: YorkieServiceAsyncClient
     private var watchLoopReconnectTimer: Timer?
-    private var watchLoopTask: Task<Void, Never>?
+    private var remoteWatchStream: GRPCAsyncServerStreamingCall<WatchDocumentsRequest, WatchDocumentsResponse>?
 
     private let group: EventLoopGroup
 
@@ -260,8 +260,9 @@ public actor Client {
             return
         }
 
-        self.watchLoopTask?.cancel()
-        self.watchLoopTask = nil
+        if self.remoteWatchStream != nil {
+            self.disconnectWatchStream()
+        }
 
         var deactivateRequest = DeactivateClientRequest()
 
@@ -505,7 +506,7 @@ public actor Client {
     }
 
     private func setSyncTimer(_ reconnect: Bool) {
-        let syncLoopDuration = (reconnect || self.watchLoopTask == nil) ? self.reconnectStreamDelay : self.syncLoopDuration
+        let syncLoopDuration = (reconnect || self.remoteWatchStream == nil) ? self.reconnectStreamDelay : self.syncLoopDuration
 
         let timer = Timer(timeInterval: Double(syncLoopDuration) / 1000, repeats: false) { _ in
             Task {
@@ -555,8 +556,7 @@ public actor Client {
     }
 
     private func doWatchLoop() {
-        self.watchLoopTask?.cancel()
-        self.watchLoopTask = nil
+        self.disconnectWatchStream()
 
         self.watchLoopReconnectTimer?.invalidate()
         self.watchLoopReconnectTimer = nil
@@ -579,24 +579,26 @@ public actor Client {
         request.client = Converter.toClient(id: id, presence: self.presenceInfo)
         request.documentKeys = realtimeSyncDocKeys
 
-        let stream = self.rpcClient.watchDocuments(request)
+        self.remoteWatchStream = self.rpcClient.makeWatchDocumentsCall(request)
 
         let event = StreamConnectionStatusChangedEvent(value: .connected)
         self.eventStream.send(event)
 
-        self.watchLoopTask = Task {
-            do {
-                for try await response in stream {
-                    self.handleWatchDocumentsResponse(docKeys: realtimeSyncDocKeys, response: response)
-                }
-            } catch {
-                switch error {
-                case is CancellationError:
-                    break
-                default:
-                    Logger.warning("[WL] c:\"\(self.key)\" has Error \(error)")
+        Task {
+            if let stream = remoteWatchStream?.responseStream {
+                do {
+                    for try await response in stream {
+                        self.handleWatchDocumentsResponse(docKeys: realtimeSyncDocKeys, response: response)
+                    }
+                } catch {
+                    if let status = error as? GRPCStatus, status.code == .cancelled {
+                        // End.
+                        print("Done.")
+                    } else {
+                        Logger.warning("[WL] c:\"\(self.key)\" has Error \(error)")
 
-                    self.onStreamDisconnect()
+                        self.onStreamDisconnect()
+                    }
                 }
             }
         }
@@ -646,37 +648,32 @@ public actor Client {
             let publisher = pbWatchEvent.publisher.id.toHexString
             let presence = Converter.fromPresence(pbPresence: pbWatchEvent.publisher.presence)
 
-            for key in responseKeys {
+            for docKey in responseKeys {
                 switch pbWatchEvent.type {
                 case .documentsWatched:
-                    self.attachmentMap[key]?.peerPresenceMap[publisher] = presence
+                    self.attachmentMap[docKey]?.peerPresenceMap[publisher] = presence
+
+                    self.sendPeerChangeEvent(.watched, responseKeys, publisher)
                 case .documentsUnwatched:
-                    self.attachmentMap[key]?.peerPresenceMap.removeValue(forKey: publisher)
+                    self.sendPeerChangeEvent(.unwatched, responseKeys, publisher)
+
+                    self.attachmentMap[docKey]?.peerPresenceMap.removeValue(forKey: publisher)
                 case .documentsChanged:
-                    self.attachmentMap[key]?.remoteChangeEventReceived = true
+                    self.attachmentMap[docKey]?.remoteChangeEventReceived = true
+
+                    let event = DocumentsChangedEvent(value: responseKeys)
+                    self.eventStream.send(event)
                 case .presenceChanged:
-                    if let peerPresence = self.attachmentMap[key]?.peerPresenceMap[publisher], peerPresence.clock > presence.clock {
+                    if let peerPresence = self.attachmentMap[docKey]?.peerPresenceMap[publisher], peerPresence.clock > presence.clock {
                         break
                     }
 
-                    self.attachmentMap[key]?.peerPresenceMap[publisher] = presence
+                    self.attachmentMap[docKey]?.peerPresenceMap[publisher] = presence
+
+                    self.sendPeerChangeEvent(.presenceChanged, responseKeys, publisher)
                 case .UNRECOGNIZED:
                     break
                 }
-            }
-
-            switch pbWatchEvent.type {
-            case .documentsChanged:
-                let event = DocumentsChangedEvent(value: responseKeys)
-                self.eventStream.send(event)
-            case .documentsWatched:
-                self.sendPeerChangeEvent(.watched, responseKeys, publisher)
-            case .documentsUnwatched:
-                self.sendPeerChangeEvent(.unwatched, responseKeys, publisher)
-            case .presenceChanged:
-                self.sendPeerChangeEvent(.presenceChanged, responseKeys, publisher)
-            case .UNRECOGNIZED:
-                break
             }
         }
     }
@@ -690,9 +687,18 @@ public actor Client {
         self.eventStream.send(event)
     }
 
+    private func disconnectWatchStream() {
+        self.remoteWatchStream?.cancel()
+        self.remoteWatchStream = nil
+
+        Logger.debug("[WD] c:\"\(self.key)\" unwatches")
+
+        let event = StreamConnectionStatusChangedEvent(value: .disconnected)
+        self.eventStream.send(event)
+    }
+
     private func onStreamDisconnect() {
-        self.watchLoopTask?.cancel()
-        self.watchLoopTask = nil
+        self.disconnectWatchStream()
 
         self.watchLoopReconnectTimer = Timer(timeInterval: Double(self.reconnectStreamDelay) / 1000, repeats: false) { _ in
             Task {
@@ -703,9 +709,6 @@ public actor Client {
         if let watchLoopReconnectTimer = self.watchLoopReconnectTimer {
             RunLoop.main.add(watchLoopReconnectTimer, forMode: .common)
         }
-
-        let event = StreamConnectionStatusChangedEvent(value: .disconnected)
-        self.eventStream.send(event)
     }
 
     @discardableResult

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -638,7 +638,7 @@ public actor Client {
                     self.attachmentMap[docID]?.peerPresenceMap[pbClient.id.toHexString] = Converter.fromPresence(pbPresence: pbClient.presence)
                 }
 
-                semaphoresForInitialzation[docID]?.signal()
+                self.semaphoresForInitialzation[docID]?.signal()
             }
 
             self.sendPeerChangeEvent(.initialized, docKeys)
@@ -687,6 +687,10 @@ public actor Client {
     }
 
     private func disconnectWatchStream() {
+        guard self.remoteWatchStream != nil else {
+            return
+        }
+
         self.remoteWatchStream?.cancel()
         self.remoteWatchStream = nil
 

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -592,8 +592,7 @@ public actor Client {
                     }
                 } catch {
                     if let status = error as? GRPCStatus, status.code == .cancelled {
-                        // End.
-                        print("Done.")
+                        // Canceled by Client by detach. so there is No need to reconnect.
                     } else {
                         Logger.warning("[WL] c:\"\(self.key)\" has Error \(error)")
 

--- a/Sources/Core/ClientEvent.swift
+++ b/Sources/Core/ClientEvent.swift
@@ -76,6 +76,29 @@ struct DocumentsChangedEvent: BaseClientEvent {
 }
 
 /**
+ * `PeersChangedValue` represents the value of the PeersChanged event.
+ */
+struct PeersChangedValue: Equatable {
+    enum `Type`: String {
+        case initialized
+        case watched
+        case unwatched
+        case presenceChanged = "presence-changed"
+    }
+
+    let type: `Type`
+    let peers: [DocumentKey: PresenceMap]
+
+    static func == (lhs: Yorkie.PeersChangedValue, rhs: Yorkie.PeersChangedValue) -> Bool {
+        if lhs.type == rhs.type {
+            return NSDictionary(dictionary: lhs.peers).isEqual(to: rhs.peers)
+        }
+
+        return false
+    }
+}
+
+/**
  * `PeersChangedEvent` is an event that occurs when the states of another peers
  * of the attached documents changes.
  */
@@ -88,7 +111,7 @@ struct PeerChangedEvent: BaseClientEvent {
     /**
      * `PeersChangedEvent` value
      */
-    var value: [String: [String: Presence]]
+    var value: PeersChangedValue
 }
 
 /**

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -313,7 +313,7 @@ final class CRDTText: CRDTTextElement {
             return (fromPos, fromPos)
         }
 
-        return (fromPos, try self.rgaTreeSplit.findNodePos(toIdx))
+        return try (fromPos, self.rgaTreeSplit.findNodePos(toIdx))
     }
 
     /**

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -426,7 +426,7 @@ class RGATreeSplit<T: RGATreeSplitValue> {
      */
     public func findIndexesFromRange(_ range: RGATreeSplitNodeRange) throws -> (Int, Int) {
         let (fromPos, toPos) = range
-        return (try self.findIdxFromNodePos(fromPos, false), try self.findIdxFromNodePos(toPos, true))
+        return try (self.findIdxFromNodePos(fromPos, false), self.findIdxFromNodePos(toPos, true))
     }
 
     /**

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -23,13 +23,15 @@ import Foundation
  */
 public typealias Presence = [String: Any]
 
+public typealias DocumentKey = String
+
 /**
  * A CRDT-based data type. We can representing the model
  * of the application. And we can edit it even while offline.
  *
  */
 public actor Document {
-    private let key: String
+    private let key: DocumentKey
     private var root: CRDTRoot
     private var clone: CRDTRoot?
     private var changeID: ChangeID

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -148,7 +148,7 @@ public class JSONArray {
 
     func push(values: [Any]) {
         values.forEach { value in
-            push(value)
+            self.push(value)
         }
     }
 
@@ -622,7 +622,7 @@ public class JSONArrayIterator: IteratorProtocol {
         self.context = context
         self.values = []
         crdtArray.forEach { element in
-            values.append(element)
+            self.values.append(element)
         }
     }
 

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -40,7 +40,7 @@ public class JSONObject {
 
     func set(_ values: [String: Any]) {
         values.forEach { (key: String, value: Any) in
-            set(key: key, value: value)
+            self.set(key: key, value: value)
         }
     }
 

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -221,12 +221,14 @@ final class ClientIntegrationTests: XCTestCase {
             PeersChangedValue(type: .initialized, peers: [docKey: [c1ActorID: PresenceType(name: "c1", cursor: Cursor(x: 0, y: 0)).createdDictionary,
                                                                    c2ActorID: PresenceType(name: "c2", cursor: Cursor(x: 1, y: 1)).createdDictionary]]),
             PeersChangedValue(type: .presenceChanged, peers: [docKey: [c1ActorID: PresenceType(name: "c1+", cursor: Cursor(x: 0, y: 0)).createdDictionary]]),
-            PeersChangedValue(type: .presenceChanged, peers: [docKey: [c2ActorID: PresenceType(name: "c2+", cursor: Cursor(x: 1, y: 1)).createdDictionary]])
+            PeersChangedValue(type: .presenceChanged, peers: [docKey: [c2ActorID: PresenceType(name: "c2+", cursor: Cursor(x: 1, y: 1)).createdDictionary]]),
+            PeersChangedValue(type: .unwatched, peers: [docKey: [c1ActorID: PresenceType(name: "c1+", cursor: Cursor(x: 0, y: 0)).createdDictionary]])
         ]
 
         c1.eventStream.sink { event in
             switch event {
             case let event as PeerChangedEvent:
+                print("#### c1 \(event)")
                 XCTAssertEqual(event.value, c1ExpectedValues[c1NumberOfEvents])
                 c1NumberOfEvents += 1
             default:
@@ -237,6 +239,7 @@ final class ClientIntegrationTests: XCTestCase {
         c2.eventStream.sink { event in
             switch event {
             case let event as PeerChangedEvent:
+                print("#### c2 \(event)")
                 XCTAssertEqual(event.value, c2ExpectedValues[c2NumberOfEvents])
                 c2NumberOfEvents += 1
 
@@ -274,6 +277,10 @@ final class ClientIntegrationTests: XCTestCase {
         XCTAssert(c1Peer.isEqual(to: c2Peer))
 
         try await c1.detach(d1)
+
+        // Keep the watchLoop of c2 for catch the detach event of c1.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
         try await c2.detach(d2)
 
         try await c1.deactivate()

--- a/Tests/Unit/Document/CRDT/CRDTTextTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTextTests.swift
@@ -21,20 +21,20 @@ final class CRDTTextTests: XCTestCase {
     func test_should_handle_edit_operations_with_case1() throws {
         let text = CRDTText(rgaTreeSplit: RGATreeSplit(), createdAt: TimeTicket.initial)
 
-        try text.edit(try text.createRange(0, 0), "ABCD", TimeTicket.initial)
+        try text.edit(text.createRange(0, 0), "ABCD", TimeTicket.initial)
         XCTAssertEqual("[{\"val\":\"ABCD\"}]", text.toJSON())
 
-        try text.edit(try text.createRange(1, 3), "12", TimeTicket.initial)
+        try text.edit(text.createRange(1, 3), "12", TimeTicket.initial)
         XCTAssertEqual("[{\"val\":\"A\"},{\"val\":\"12\"},{\"val\":\"D\"}]", text.toJSON())
     }
 
     func test_should_handle_edit_operations_with_case2() throws {
         let text = CRDTText(rgaTreeSplit: RGATreeSplit(), createdAt: TimeTicket.initial)
 
-        try text.edit(try text.createRange(0, 0), "ABCD", TimeTicket.initial)
+        try text.edit(text.createRange(0, 0), "ABCD", TimeTicket.initial)
         XCTAssertEqual("[{\"val\":\"ABCD\"}]", text.toJSON())
 
-        try text.edit(try text.createRange(3, 3), "\n", TimeTicket.initial)
+        try text.edit(text.createRange(3, 3), "\n", TimeTicket.initial)
         XCTAssertEqual("[{\"val\":\"ABC\"},{\"val\":\"\\n\"},{\"val\":\"D\"}]", text.toJSON())
     }
 }

--- a/Tests/Unit/Document/CRDT/RGATreeListTests.swift
+++ b/Tests/Unit/Document/CRDT/RGATreeListTests.swift
@@ -244,10 +244,12 @@ class RGATreeListTests: XCTestCase {
         let e3 = Primitive(value: .string("C123"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
         try target.insert(e3)
 
-        XCTAssertEqual("\(try target.getPreviousCreatedAt(ofCreatedAt: e1.createdAt))",
+        var result = try target.getPreviousCreatedAt(ofCreatedAt: e1.createdAt)
+        XCTAssertEqual("\(result)",
                        "0:000000000000000000000000:0")
 
-        XCTAssertEqual("\(try target.getPreviousCreatedAt(ofCreatedAt: e2.createdAt))",
+        result = try target.getPreviousCreatedAt(ofCreatedAt: e2.createdAt)
+        XCTAssertEqual("\(result)",
                        "1:999:0")
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Elaborate on the value of the PeersChanged event
- Add sending of connected and disconnected events
- To close the server-side stream of the watch loop, The remote watch stream was explicitly closed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
ref: https://github.com/yorkie-team/yorkie-js-sdk/pull/464

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
