### PR TITLE
Verify sequence when processing pushpull

### DIFF
--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
@@ -76,7 +76,7 @@ class TextEditorViewController: UIViewController {
         self.textView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor).isActive = true
         self.textView.leftAnchor.constraint(equalTo: view.layoutMarginsGuide.leftAnchor).isActive = true
         self.textView.rightAnchor.constraint(equalTo: view.layoutMarginsGuide.rightAnchor).isActive = true
-        self.textView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor).isActive = true
+        self.textView.keyboardLayoutGuide.topAnchor.constraint(equalToSystemSpacingBelow: self.textView.bottomAnchor, multiplier: 1).isActive = true
 
         self.textView.textStorage.delegate = self
         self.textView.delegate = self
@@ -195,6 +195,12 @@ class TextEditorViewController: UIViewController {
                 } else {
                     self.peerSelection[actorID] = (range, newColor)
                 }
+            case .documentCorrupted:
+                let alert = UIAlertController(title: "Error", message: "A serious error has occurred in the document. Close Document.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "Close", style: .default, handler: { _ in
+                    self.navigationController?.popViewController(animated: true)
+                }))
+                self.present(alert, animated: true, completion: nil)
             }
         }
 

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -179,7 +179,8 @@ extension Converter {
     static func fromChangeID(_ pbChangeID: PbChangeID) -> ChangeID {
         ChangeID(clientSeq: pbChangeID.clientSeq,
                  lamport: pbChangeID.lamport,
-                 actor: pbChangeID.actorID.toHexString)
+                 actor: pbChangeID.actorID.toHexString,
+                 serverSeq: pbChangeID.serverSeq)
     }
 }
 

--- a/Sources/Document/Change/ChangeID.swift
+++ b/Sources/Document/Change/ChangeID.swift
@@ -33,17 +33,18 @@ struct ChangeID {
     private var lamport: Int64
     private var actor: ActorID?
 
-    init(clientSeq: UInt32, lamport: Int64, actor: ActorID? = nil) {
+    init(clientSeq: UInt32, lamport: Int64, actor: ActorID? = nil, serverSeq: Int64? = nil) {
         self.clientSeq = clientSeq
         self.lamport = lamport
         self.actor = actor
+        self.serverSeq = serverSeq
     }
 
     /**
      * `next` creates a next ID of this ID.
      */
     func next() -> ChangeID {
-        return ChangeID(clientSeq: self.clientSeq + 1, lamport: self.lamport + 1, actor: self.actor)
+        return ChangeID(clientSeq: self.clientSeq + 1, lamport: self.lamport + 1, actor: self.actor, serverSeq: self.serverSeq)
     }
 
     /**
@@ -68,6 +69,13 @@ struct ChangeID {
      */
     mutating func setActor(_ actorID: ActorID) {
         self.actor = actorID
+    }
+
+    /**
+     * `getServerSeq` returns the server sequence of this ID.
+     */
+    func getServerSeq() -> Int64? {
+        return self.serverSeq
     }
 
     /**

--- a/Sources/Document/DocEvent.swift
+++ b/Sources/Document/DocEvent.swift
@@ -32,6 +32,10 @@ public enum DocEventType: String {
      * remote document change event type
      */
     case remoteChange = "remote-change"
+    /**
+     * document corrupted event type
+     */
+    case corrupted
 }
 
 /**
@@ -97,4 +101,11 @@ struct RemoteChangeEvent: DocEvent {
      * RemoteChangeEvent type
      */
     var value: [ChangeInfo]
+}
+
+struct CorruptedEvent: DocEvent {
+    /**
+     * ``DocEventType/corrupted``
+     */
+    let type: DocEventType = .corrupted
 }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -137,7 +137,7 @@ public actor Document {
 
             // The server does not apply changes sent by pushPull request to changes of pushPull response.
             // So add size of local changes.
-            if pack.getCheckpoint().getClientSeq() > self.checkpoint.getClientSeq() {
+            if serverSeq < pack.getCheckpoint().getClientSeq(), pack.getCheckpoint().getClientSeq() > self.checkpoint.getClientSeq() {
                 serverSeq += Int64(pack.getCheckpoint().getClientSeq() - self.checkpoint.getClientSeq())
             }
         }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -332,7 +332,7 @@ public actor Document {
             newServerSeq = serverSeq
 
             // Skip already processed opertaions by local changes.
-            if change.id.getActorID() != clientID {
+            if change.id.getActorID() != clientID || change.id.getClientSeq() > self.checkpoint.getClientSeq() {
                 try change.execute(root: clone)
                 try change.execute(root: self.root)
             }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -320,7 +320,7 @@ public actor Document {
                 throw YorkieError.unexpected(message: "No server seq in the change!!!")
             }
 
-            guard newServerSeq > serverSeq else {
+            guard newServerSeq < serverSeq else {
                 // Skip already processed change.
                 continue
             }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -115,11 +115,11 @@ public actor Document {
      */
     func applyChangePack(pack: ChangePack, clientID: ActorID) throws {
         // 0. Check Sequences.
-        
+
         let minClientSequence = self.localChanges.first?.id.getClientSeq() ?? self.checkpoint.getClientSeq()
         let maxClientSequence = self.localChanges.last?.id.getClientSeq() ?? self.checkpoint.getClientSeq()
 
-        guard (minClientSequence...maxClientSequence).contains(pack.getCheckpoint().getClientSeq()) else {
+        guard (minClientSequence ... maxClientSequence).contains(pack.getCheckpoint().getClientSeq()) else {
             let event = CorruptedEvent()
             self.eventStream.send(event)
 
@@ -134,7 +134,7 @@ public actor Document {
             serverSeq = pack.getCheckpoint().getServerSeq()
         } else if pack.hasChanges() {
             serverSeq = try self.applyChanges(changes: pack.getChanges(), clientID: clientID)
-            
+
             // The server does not apply changes sent by pushPull request to changes of pushPull response.
             // So add size of local changes.
             if pack.getCheckpoint().getClientSeq() > self.checkpoint.getClientSeq() {
@@ -319,12 +319,12 @@ public actor Document {
             guard let serverSeq = change.id.getServerSeq() else {
                 throw YorkieError.unexpected(message: "No server seq in the change!!!")
             }
-            
+
             guard newServerSeq > serverSeq else {
                 // Skip already processed change.
                 continue
             }
-            
+
             guard newServerSeq + 1 == serverSeq else {
                 throw YorkieError.sequenceCorrupted(message: "Bad Server Sequence! expected seq: \(newServerSeq + 1), actual seq : \(String(describing: change.id.getServerSeq()))")
             }
@@ -336,7 +336,7 @@ public actor Document {
                 try change.execute(root: clone)
                 try change.execute(root: self.root)
             }
-            
+
             self.changeID.syncLamport(with: change.id.getLamport())
         }
 

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -26,4 +26,5 @@ enum YorkieError: Error {
     case documentNotAttached(message: String)
     case documentNotDetached(message: String)
     case documentRemoved(message: String)
+    case sequenceCorrupted(message: String)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Add sequence validation logic.
  - When applying changePack, the clientSeq sent by the server has to 
    - '>=' the sequence of localChanges.first
    - '<=' the sequence of localChanges.last
    - If not, the client can't make a proper change pack.
  - When applying changePack, the serverSeq sent by the server has to equal to prevServerSeq + 1
- Update serverSeq with the actual data.
- Add Yorkie.sequenceCorrupted Error
  - Pause realtime sync when occurred. 
- Add DocEvent corrupted.
  - When a document has a bad sequence. DocEvent.corrupted event fired. 
  - Any suggestion for this is welcome. (@chacha912 )
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
CI test will be success after https://github.com/yorkie-team/yorkie/pull/503 is merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
