### PR TITLE
Add x-yorkie-user-agent

### DIFF
--- a/Sources/Core/Auth.swift
+++ b/Sources/Core/Auth.swift
@@ -40,6 +40,7 @@ class AuthClientInterceptor<Request, Response>: ClientInterceptor<Request, Respo
                 header.add(name: "authorization", value: token)
             }
 
+            header.add(name: "x-yorkie-user-agent", value: "yorkie-ios-sdk/\(yorkieVersion)")
             part = .metadata(header)
         default:
             break

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -205,12 +205,7 @@ public actor Client {
 
         let channel = builder.connect(host: rpcAddress.host, port: rpcAddress.port)
 
-        let authInterceptors: AuthClientInterceptors?
-        if options.apiKey != nil || options.token != nil {
-            authInterceptors = AuthClientInterceptors(apiKey: options.apiKey, token: options.token)
-        } else {
-            authInterceptors = nil
-        }
+        let authInterceptors = AuthClientInterceptors(apiKey: options.apiKey, token: options.token)
 
         self.rpcClient = YorkieServiceAsyncClient(channel: channel, interceptors: authInterceptors)
         self.eventStream = PassthroughSubject()

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+let yorkieVersion = "0.3.3"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds x-yorkie-user-agent header to all requests for metrics.

Due to the apple version policy, get version from info.plist is not possible. So I made Version.swift.

https://stackoverflow.com/questions/68237292/xcode-manage-version-and-build-number-option 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
