### PR TITLE
Allow specifying a topic when subscribing to a document

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
-    - uses: docker-practice/actions-setup-docker@master
-      timeout-minutes: 12
+    - name: Setup Docker on macOS
+      uses: douglascamata/setup-docker-macos-action@v1-alpha
     - run: docker-compose -f docker/docker-compose-ci.yml up --build -d
     - name: Run tests
       run: swift test --enable-code-coverage -v --filter YorkieIntegrationTests

--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: docker-practice/actions-setup-docker@master
+      timeout-minutes: 12
     - run: docker-compose -f docker/docker-compose-ci.yml up --build -d
     - name: Run tests
       run: swift test --enable-code-coverage -v --filter YorkieIntegrationTests

--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - uses: docker-practice/actions-setup-docker@master

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - name: SwiftLint

--- a/Examples/KanbanApp/KanbanApp/Kanban/KanbanViewModel.swift
+++ b/Examples/KanbanApp/KanbanApp/Kanban/KanbanViewModel.swift
@@ -19,8 +19,6 @@ import Foundation
 import Yorkie
 
 class KanbanViewModel: ObservableObject {
-    private var cancellables = Set<AnyCancellable>()
-
     private(set) var defaultColumns: [KanbanColumn] = [
         KanbanColumn(title: "todo", cards: [
             KanbanCard(title: "walking"),
@@ -48,7 +46,7 @@ class KanbanViewModel: ObservableObject {
         Task { [weak self] in
             guard let self else { return }
 
-            await self.document.eventStream.sink { _ in
+            await self.document.subscribe { _ in
                 Task { @MainActor [weak self] in
                     guard let self, let lists = await self.document.getRoot().lists as? JSONArray else { return }
 
@@ -66,7 +64,7 @@ class KanbanViewModel: ObservableObject {
                         return KanbanColumn(id: column.getID(), title: column.title as! String, cards: cards)
                     }
                 }
-            }.store(in: &self.cancellables)
+            }
 
             Task {
                 try! await self.client.activate()

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -57,8 +57,6 @@ class TextViewModel {
             }
 
             // subscribe document event.
-            let clientID = await self.client.id
-
             await self.document.subscribe { [weak self] event in
                 if event.type == .snapshot {
                     Task { [weak self] in
@@ -74,7 +72,7 @@ class TextViewModel {
 
                 var textChanges = [TextOperation]()
 
-                event.value.filter { $0.actorID != clientID }.forEach { changeInfo in
+                event.value.forEach { changeInfo in
                     changeInfo.operations.forEach {
                         if let op = $0 as? EditOpInfo {
                             let range = NSRange(location: op.from, length: op.to - op.from)

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -27,7 +27,6 @@ enum TextOperation {
 class TextViewModel {
     private var client: Client
     private let document: Document
-    private var textEventStream = PassthroughSubject<[TextChange], Never>()
 
     private weak var operationSubject: PassthroughSubject<[TextOperation], Never>?
 

--- a/Sources/Document/CRDT/CRDTRoot.swift
+++ b/Sources/Document/CRDT/CRDTRoot.swift
@@ -62,8 +62,7 @@ class CRDTRoot {
         var pairForLoop: CRDTElementPair = pair
         while let parent = pairForLoop.parent {
             let createdAt = pairForLoop.element.createdAt
-            var subPath = try parent.subPath(createdAt: createdAt)
-            subPath = self.escapeSubpath(subPath)
+            let subPath = try parent.subPath(createdAt: createdAt)
             result.append(subPath)
             guard let parentPair = self.elementPairMapByCreatedAt[parent.createdAt] else {
                 break
@@ -74,12 +73,6 @@ class CRDTRoot {
 
         result.append(self.subPathPrefix)
         return result.reversed()
-    }
-
-    private func escapeSubpath(_ target: String) -> String {
-        return [self.subPathPrefix, self.subPathSeparator].reduce(target) { partialResult, seq in
-            partialResult.replacingOccurrences(of: seq, with: "\\\(seq)")
-        }
     }
 
     /**

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -38,11 +38,7 @@ func stringifyAttributes(_ attributes: TextAttributes) -> [String: String] {
     }
 }
 
-/**
- * `TextChange` is the value passed as an argument to `Text.onChanges()`.
- * `Text.onChanges()` is called when the `Text` is modified.
- */
-public class TextChange {
+class TextChange {
     /**
      * `TextChangeType` is the type of TextChange.
      */
@@ -152,8 +148,6 @@ final class CRDTText: CRDTTextElement {
     var movedAt: TimeTicket?
     var removedAt: TimeTicket?
 
-    weak var eventStream: PassthroughSubject<[TextChange], Never>?
-
     /**
      * `rgaTreeSplit` returns rgaTreeSplit.
      *
@@ -219,12 +213,6 @@ final class CRDTText: CRDTTextElement {
             changes.append(selectionChange)
         }
 
-        if let eventStream {
-            self.remoteChangeLock = true
-            eventStream.send(changes)
-            self.remoteChangeLock = false
-        }
-
         return (latestCreatedAtMap, changes)
     }
 
@@ -274,12 +262,6 @@ final class CRDTText: CRDTTextElement {
             }
         }
 
-        if let eventStream {
-            self.remoteChangeLock = true
-            eventStream.send(changes)
-            self.remoteChangeLock = false
-        }
-
         return changes
     }
 
@@ -292,17 +274,7 @@ final class CRDTText: CRDTTextElement {
             return nil
         }
 
-        if let change = try self.selectPriv(range, updatedAt) {
-            if let eventStream {
-                self.remoteChangeLock = true
-                eventStream.send([change])
-                self.remoteChangeLock = false
-            }
-
-            return change
-        }
-
-        return nil
+        return try self.selectPriv(range, updatedAt)
     }
 
     /**

--- a/Sources/Document/Change/Change.swift
+++ b/Sources/Document/Change/Change.swift
@@ -52,8 +52,9 @@ struct Change {
     /**
      * `execute` executes the operations of this change to the given root.
      */
-    func execute(root: CRDTRoot) throws {
-        try self.operations.forEach {
+    @discardableResult
+    func execute(root: CRDTRoot) throws -> [any OperationInfo] {
+        try self.operations.flatMap {
             try $0.execute(root: root)
         }
     }

--- a/Sources/Document/DocEvent.swift
+++ b/Sources/Document/DocEvent.swift
@@ -58,7 +58,7 @@ public struct SnapshotEvent: DocEvent {
     public var value: Data
 }
 
-protocol ChangeEventable: DocEvent {
+protocol ChangeEvent: DocEvent {
     var type: DocEventType { get }
     var value: [ChangeInfo] { get }
 }
@@ -78,7 +78,7 @@ public struct ChangeInfo {
  * by local changes.
  *
  */
-public struct LocalChangeEvent: ChangeEventable {
+public struct LocalChangeEvent: ChangeEvent {
     /**
      * ``DocEventType/localChange``
      */
@@ -94,7 +94,7 @@ public struct LocalChangeEvent: ChangeEventable {
  * by remote changes.
  *
  */
-public struct RemoteChangeEvent: ChangeEventable {
+public struct RemoteChangeEvent: ChangeEvent {
     /**
      * ``DocEventType/remoteChange``
      */

--- a/Sources/Document/DocEvent.swift
+++ b/Sources/Document/DocEvent.swift
@@ -47,24 +47,30 @@ public protocol DocEvent {
  * the server.
  *
  */
-struct SnapshotEvent: DocEvent {
+public struct SnapshotEvent: DocEvent {
     /**
      * ``DocEventType.snapshot``
      */
-    let type: DocEventType = .snapshot
+    public let type: DocEventType = .snapshot
     /**
      * SnapshotEvent type
      */
-    var value: Data
+    public var value: Data
+}
+
+protocol ChangeEventable: DocEvent {
+    var type: DocEventType { get }
+    var value: [ChangeInfo] { get }
 }
 
 /**
- * `ChangeInfo` represents a pair of `Change` and the JsonPath of the changed
- * element.
+ * `ChangeInfo` represents the modifications made during a document update
+ * and the message passed.
  */
-struct ChangeInfo {
-    let change: Change
-    let paths: [String]
+public struct ChangeInfo {
+    public let message: String
+    public let operations: [any OperationInfo]
+    public let actorID: ActorID?
 }
 
 /**
@@ -72,15 +78,15 @@ struct ChangeInfo {
  * by local changes.
  *
  */
-struct LocalChangeEvent: DocEvent {
+public struct LocalChangeEvent: ChangeEventable {
     /**
      * ``DocEventType/localChange``
      */
-    let type: DocEventType = .localChange
+    public let type: DocEventType = .localChange
     /**
      * LocalChangeEvent type
      */
-    var value: [ChangeInfo]
+    public var value: [ChangeInfo]
 }
 
 /**
@@ -88,13 +94,13 @@ struct LocalChangeEvent: DocEvent {
  * by remote changes.
  *
  */
-struct RemoteChangeEvent: DocEvent {
+public struct RemoteChangeEvent: ChangeEventable {
     /**
      * ``DocEventType/remoteChange``
      */
-    let type: DocEventType = .remoteChange
+    public let type: DocEventType = .remoteChange
     /**
      * RemoteChangeEvent type
      */
-    var value: [ChangeInfo]
+    public var value: [ChangeInfo]
 }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -371,7 +371,7 @@ public actor Document {
 
     private func processDocEvent(_ event: DocEvent) {
         if event.type != .snapshot {
-            if let event = event as? ChangeEventable {
+            if let event = event as? ChangeEvent {
                 var changeInfos = [String: [ChangeInfo]]()
 
                 event.value.forEach { changeInfo in

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -122,6 +122,17 @@ public actor Document {
     }
 
     /**
+     * `unsubscribe` unregisters a callback to subscribe to events on the document.
+     */
+    public func unsubscribe(targetPath: String? = nil) {
+        if let targetPath {
+            self.subscribeCallbacks[targetPath] = nil
+        } else {
+            self.defaultSubscribeCallback = nil
+        }
+    }
+
+    /**
      * `applyChangePack` applies the given change pack into this document.
      * 1. Remove local changes applied to server.
      * 2. Update the checkpoint.

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -400,6 +400,8 @@ public actor Document {
                     self.subscribeCallbacks[key]?(event.type == .localChange ? LocalChangeEvent(value: value) : RemoteChangeEvent(value: value))
                 }
             }
+        } else {
+            self.subscribeCallbacks["$"]?(event)
         }
 
         self.defaultSubscribeCallback?(event)

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -55,6 +55,8 @@ public typealias DocumentID = String
  *
  */
 public actor Document {
+    typealias SubscribeCallback = (DocEvent) -> Void
+
     private let key: DocumentKey
     private(set) var status: DocumentStatus
     private var root: CRDTRoot
@@ -62,8 +64,8 @@ public actor Document {
     private var changeID: ChangeID
     private var checkpoint: Checkpoint
     private var localChanges: [Change]
-
-    public let eventStream: PassthroughSubject<DocEvent, Never>
+    private var defaultSubscribeCallback: SubscribeCallback?
+    private var subscribeCallbacks: [String: SubscribeCallback]
 
     public init(key: String) {
         self.key = key
@@ -72,7 +74,7 @@ public actor Document {
         self.changeID = ChangeID.initial
         self.checkpoint = Checkpoint.initial
         self.localChanges = []
-        self.eventStream = PassthroughSubject()
+        self.subscribeCallbacks = [:]
     }
 
     /**
@@ -93,15 +95,29 @@ public actor Document {
             Logger.trace("trying to update a local change: \(self.toJSON())")
 
             let change = context.getChange()
-            try? change.execute(root: self.root)
+            let opInfos = (try? change.execute(root: self.root)) ?? []
             self.localChanges.append(change)
             self.changeID = change.id
 
-            let changeInfo = ChangeInfo(change: change, paths: self.createPaths(change: change))
+            let changeInfo = ChangeInfo(message: change.message ?? "",
+                                        operations: opInfos,
+                                        actorID: change.id.getActorID())
             let changeEvent = LocalChangeEvent(value: [changeInfo])
-            self.eventStream.send(changeEvent)
+            self.processDocEvent(changeEvent)
 
             Logger.trace("after update a local change: \(self.toJSON())")
+        }
+    }
+
+    /**
+     * `subscribe` registers a callback to subscribe to events on the document.
+     * The callback will be called when the targetPath or any of its nested values change.
+     */
+    public func subscribe(targetPath: String? = nil, callback: @escaping (DocEvent) -> Void) {
+        if let targetPath {
+            self.subscribeCallbacks[targetPath] = callback
+        } else {
+            self.defaultSubscribeCallback = callback
         }
     }
 
@@ -272,7 +288,7 @@ public actor Document {
         self.clone = nil
 
         let snapshotEvent = SnapshotEvent(value: snapshot)
-        self.eventStream.send(snapshotEvent)
+        self.processDocEvent(snapshotEvent)
     }
 
     /**
@@ -293,17 +309,19 @@ public actor Document {
             try $0.execute(root: clone)
         }
 
+        var changeInfos = [ChangeInfo]()
         try changes.forEach {
-            try $0.execute(root: self.root)
+            let opInfos = try $0.execute(root: self.root)
+
+            changeInfos.append(ChangeInfo(message: $0.message ?? "",
+                                          operations: opInfos,
+                                          actorID: $0.id.getActorID()))
+
             self.changeID.syncLamport(with: $0.id.getLamport())
         }
 
-        let changeInfos = changes.map {
-            ChangeInfo(change: $0, paths: self.createPaths(change: $0))
-        }
-
         let changeEvent = RemoteChangeEvent(value: changeInfos)
-        self.eventStream.send(changeEvent)
+        self.processDocEvent(changeEvent)
 
         Logger.debug(
             """
@@ -332,5 +350,58 @@ public actor Document {
 
     public nonisolated var debugDescription: String {
         "[\(self.key)]"
+    }
+
+    private func isSameElementOrChildOf(_ elem: String, _ parent: String) -> Bool {
+        if parent == elem {
+            return true
+        }
+
+        let nodePath = elem.components(separatedBy: ".")
+        let targetPath = parent.components(separatedBy: ".")
+
+        var result = true
+
+        for (index, path) in targetPath.enumerated() where path != nodePath[safe: index] {
+            result = false
+        }
+
+        return result
+    }
+
+    private func processDocEvent(_ event: DocEvent) {
+        if event.type != .snapshot {
+            if let event = event as? ChangeEventable {
+                var changeInfos = [String: [ChangeInfo]]()
+
+                event.value.forEach { changeInfo in
+                    var operations = [String: [any OperationInfo]]()
+
+                    changeInfo.operations.forEach { operationInfo in
+                        self.subscribeCallbacks.keys.forEach { targetPath in
+                            if self.isSameElementOrChildOf(operationInfo.path, targetPath) {
+                                if operations[targetPath] == nil {
+                                    operations[targetPath] = [any OperationInfo]()
+                                }
+                                operations[targetPath]?.append(operationInfo)
+                            }
+                        }
+                    }
+
+                    operations.forEach { key, value in
+                        if changeInfos[key] == nil {
+                            changeInfos[key] = [ChangeInfo]()
+                        }
+                        changeInfos[key]?.append(ChangeInfo(message: changeInfo.message, operations: value, actorID: changeInfo.actorID))
+                    }
+                }
+
+                changeInfos.forEach { key, value in
+                    self.subscribeCallbacks[key]?(event.type == .localChange ? LocalChangeEvent(value: value) : RemoteChangeEvent(value: value))
+                }
+            }
+        }
+
+        self.defaultSubscribeCallback?(event)
     }
 }

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -189,17 +189,6 @@ public class JSONText {
     }
 
     /**
-     * `setEventStream` registers a event Stream of TextChange events.
-     */
-    public func setEventStream(eventStream: PassthroughSubject<[TextChange], Never>?) {
-        guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
-            return
-        }
-        text.eventStream = eventStream
-    }
-
-    /**
      * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
      */
     func createRange(_ fromIdx: Int, _ toIdx: Int) -> RGATreeSplitNodeRange? {

--- a/Sources/Document/Operation/IncreaseOperation.swift
+++ b/Sources/Document/Operation/IncreaseOperation.swift
@@ -40,7 +40,11 @@ struct IncreaseOperation: Operation {
         "\(self.parentCreatedAt.structureAsString).INCREASE"
     }
 
-    func execute(root: CRDTRoot) throws {
+    /**
+     * `execute` executes this operation on the given document(`root`).
+     */
+    @discardableResult
+    func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
             Logger.critical(log)
@@ -60,5 +64,15 @@ struct IncreaseOperation: Operation {
             Logger.critical(log)
             throw YorkieError.unexpected(message: log)
         }
+
+        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
+            throw YorkieError.unexpected(message: "fail to get path")
+        }
+
+        guard let value = Int((value as? Primitive)?.toJSON() ?? "") else {
+            throw YorkieError.unexpected(message: "fail to get counter value")
+        }
+
+        return [IncreaseOpInfo(path: path, value: value)]
     }
 }

--- a/Sources/Document/Operation/Operation.swift
+++ b/Sources/Document/Operation/Operation.swift
@@ -17,6 +17,122 @@
 import Foundation
 
 /**
+ * `OperationInfoType` is operation info types
+ */
+public enum OperationInfoType: String {
+    case add
+    case move
+    case set
+    case remove
+    case increase
+    case edit
+    case style
+    case select
+}
+
+/**
+ * `OperationInfo` represents the information of an operation.
+ * It is used to inform to the user what kind of operation was executed.
+ */
+public protocol OperationInfo: Equatable {
+    var type: OperationInfoType { get }
+    var path: String { get }
+}
+
+public struct AddOpInfo: OperationInfo {
+    public let type: OperationInfoType = .add
+    public let path: String
+    public let index: Int
+}
+
+public struct MoveOpInfo: OperationInfo {
+    public let type: OperationInfoType = .move
+    public let path: String
+    public let previousIndex: Int
+    public let index: Int
+}
+
+public struct SetOpInfo: OperationInfo {
+    public let type: OperationInfoType = .set
+    public let path: String
+    public let key: String
+}
+
+public struct RemoveOpInfo: OperationInfo {
+    public let type: OperationInfoType = .remove
+    public let path: String
+    public let key: String?
+    public let index: Int?
+}
+
+public struct IncreaseOpInfo: OperationInfo {
+    public let type: OperationInfoType = .increase
+    public let path: String
+    public let value: Int
+}
+
+public struct EditOpInfo: OperationInfo {
+    public let type: OperationInfoType = .edit
+    public let path: String
+    public let from: Int
+    public let to: Int
+    public let attributes: [String: Any]?
+    public let content: String?
+
+    public static func == (lhs: EditOpInfo, rhs: EditOpInfo) -> Bool {
+        if lhs.type != rhs.type ||
+            lhs.path != rhs.path ||
+            lhs.from != rhs.from ||
+            lhs.to != rhs.to ||
+            lhs.content != rhs.content
+        {
+            return false
+        }
+
+        if let leftAttrs = lhs.attributes, let rightAttrs = rhs.attributes {
+            return NSDictionary(dictionary: leftAttrs).isEqual(to: rightAttrs)
+        } else if lhs.attributes == nil, rhs.attributes == nil {
+            return true
+        }
+
+        return false
+    }
+}
+
+public struct StyleOpInfo: OperationInfo {
+    public let type: OperationInfoType = .style
+    public let path: String
+    public let from: Int
+    public let to: Int
+    public let attributes: [String: Any]?
+
+    public static func == (lhs: StyleOpInfo, rhs: StyleOpInfo) -> Bool {
+        if lhs.type != rhs.type ||
+            lhs.path != rhs.path ||
+            lhs.from != rhs.from ||
+            lhs.to != rhs.to
+        {
+            return false
+        }
+
+        if let leftAttrs = lhs.attributes, let rightAttrs = rhs.attributes {
+            return NSDictionary(dictionary: leftAttrs).isEqual(to: rightAttrs)
+        } else if lhs.attributes == nil, rhs.attributes == nil {
+            return true
+        }
+
+        return false
+    }
+}
+
+public struct SelectOpInfo: OperationInfo {
+    public let type: OperationInfoType = .select
+    public let path: String
+    public let from: Int
+    public let to: Int
+}
+
+/**
  * `Operation` represents an operation to be executed on a document.
  *  Types confiming ``Operation`` must be struct to avoid data racing.
  */
@@ -39,7 +155,7 @@ protocol Operation {
     /**
      * `execute` executes this operation on the given document(`root`).
      */
-    func execute(root: CRDTRoot) throws
+    func execute(root: CRDTRoot) throws -> [any OperationInfo]
 }
 
 extension Operation {

--- a/Sources/Document/Operation/SelectOperation.swift
+++ b/Sources/Document/Operation/SelectOperation.swift
@@ -39,7 +39,8 @@ struct SelectOperation: Operation {
     /**
      * `execute` executes this operation on the given document(`root`).
      */
-    func execute(root: CRDTRoot) throws {
+    @discardableResult
+    func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         let parent = root.find(createdAt: self.parentCreatedAt)
         guard let text = parent as? CRDTText else {
             let log: String
@@ -53,7 +54,17 @@ struct SelectOperation: Operation {
             throw YorkieError.unexpected(message: log)
         }
 
-        try text.select((self.fromPos, self.toPos), self.executedAt)
+        let change = try text.select((self.fromPos, self.toPos), self.executedAt)
+
+        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
+            throw YorkieError.unexpected(message: "fail to get path")
+        }
+
+        if let change {
+            return [SelectOpInfo(path: path, from: change.from, to: change.to)]
+        } else {
+            return []
+        }
     }
 
     /**

--- a/Sources/Document/Operation/SetOperation.swift
+++ b/Sources/Document/Operation/SetOperation.swift
@@ -38,7 +38,8 @@ struct SetOperation: Operation {
     /**
      * `execute` executes this operation on the given document(`root`).
      */
-    func execute(root: CRDTRoot) throws {
+    @discardableResult
+    func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         let parent = root.find(createdAt: self.parentCreatedAt)
         guard let parent = parent as? CRDTObject else {
             let log: String
@@ -56,6 +57,12 @@ struct SetOperation: Operation {
         let value = self.value.deepcopy()
         parent.set(key: self.key, value: value)
         root.registerElement(value, parent: parent)
+
+        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
+            throw YorkieError.unexpected(message: "fail to get path")
+        }
+
+        return [SetOpInfo(path: path, key: self.key)]
     }
 
     /**

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -480,6 +480,8 @@ final class ClientIntegrationTests: XCTestCase {
 
         try await c2.attach(d2)
 
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
         let presence2: PresenceType? = self.decodePresence(await c1.getPeerPresence(docKey: docKey, clientID: c2.id!)!)
 
         XCTAssertTrue(presence2 == PresenceType(name: "b", cursor: Cursor(x: 1, y: 1)))

--- a/Tests/Unit/Document/CRDT/CRDTRootTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTRootTests.swift
@@ -69,10 +69,10 @@ class CRDTRootTests: XCTestCase {
         XCTAssertEqual(resultA1, ["$", "K-a1"])
 
         let resultC1 = try target.createSubPaths(createdAt: c1.createdAt)
-        XCTAssertEqual(resultC1, ["$", "K-\\$a3", "K-\\.B2", "K-c1"])
+        XCTAssertEqual(resultC1, ["$", "K-$a3", "K-.B2", "K-c1"])
 
         let result = try target.createPath(createdAt: c1.createdAt)
-        XCTAssertEqual(result, "$.K-\\$a3.K-\\.B2.K-c1")
+        XCTAssertEqual(result, "$.K-$a3.K-.B2.K-c1")
     }
 
     func test_can_resturn_elements_count() throws {

--- a/Tests/Unit/Document/DocumentTests.swift
+++ b/Tests/Unit/Document/DocumentTests.swift
@@ -725,15 +725,13 @@ class DocumentTests: XCTestCase {
         XCTAssertEqual(length, 4)
     }
 
-    private var cancellables = Set<AnyCancellable>()
-
     func test_change_paths_test_for_object() async throws {
         let target = Document(key: "test-doc")
 
-        await target.eventStream.sink { event in
+        await target.subscribe { event in
             XCTAssertEqual(event.type, .localChange)
-            XCTAssertEqual((event as? LocalChangeEvent)?.value[0].paths, ["$."])
-        }.store(in: &self.cancellables)
+            XCTAssertEqual((event as? LocalChangeEvent)?.value[0].operations.compactMap { $0.path }, ["$", "$.", "$..obj", "$..obj", "$..obj", "$..obj", "$."])
+        }
 
         try await target.update { root in
             root[""] = [:]
@@ -789,14 +787,36 @@ class DocumentTests: XCTestCase {
         }
     }
 
+    // swiftlint: disable force_cast
     func test_change_paths_test_for_array() async throws {
         let target = Document(key: "test-doc")
 
-        await target.eventStream.sink { event in
+        await target.subscribe { event in
             XCTAssertEqual(event.type, .localChange)
 
-            XCTAssertEqual((event as? LocalChangeEvent)?.value[0].paths.sorted(), ["$.arr", "$.\\$\\$\\.\\.\\.hello"].sorted())
-        }.store(in: &self.cancellables)
+            if let ops = (event as? LocalChangeEvent)?.value[0].operations {
+                XCTAssertEqual(ops[0] as! SetOpInfo, SetOpInfo(path: "$", key: "arr"))
+                XCTAssertEqual(ops[1] as! AddOpInfo, AddOpInfo(path: "$.arr", index: 0))
+                XCTAssertEqual(ops[2] as! AddOpInfo, AddOpInfo(path: "$.arr", index: 1))
+                XCTAssertEqual(ops[3] as! RemoveOpInfo, RemoveOpInfo(path: "$.arr", key: nil, index: 1))
+                XCTAssertEqual(ops[4] as! SetOpInfo, SetOpInfo(path: "$", key: "$$...hello"))
+                XCTAssertEqual(ops[5] as! AddOpInfo, AddOpInfo(path: "$.$$...hello", index: 0))
+            } else {
+                XCTAssert(false, "No operations.")
+            }
+        }
+
+        await target.subscribe(targetPath: "$.arr") { event in
+            XCTAssertEqual(event.type, .localChange)
+
+            if let ops = (event as? LocalChangeEvent)?.value[0].operations {
+                XCTAssertEqual(ops[0] as! AddOpInfo, AddOpInfo(path: "$.arr", index: 0))
+                XCTAssertEqual(ops[1] as! AddOpInfo, AddOpInfo(path: "$.arr", index: 1))
+                XCTAssertEqual(ops[2] as! RemoveOpInfo, RemoveOpInfo(path: "$.arr", key: nil, index: 1))
+            } else {
+                XCTAssert(false, "No operations.")
+            }
+        }
 
         try await target.update { root in
             root.arr = []
@@ -814,6 +834,78 @@ class DocumentTests: XCTestCase {
                            """)
         }
     }
+
+    func test_change_paths_test_for_counter() async throws {
+        let target = Document(key: "test-doc")
+
+        await target.subscribe { event in
+            XCTAssertEqual(event.type, .localChange)
+
+            if let ops = (event as? LocalChangeEvent)?.value[0].operations {
+                XCTAssertEqual(ops[0] as! SetOpInfo, SetOpInfo(path: "$", key: "cnt"))
+                XCTAssertEqual(ops[1] as! IncreaseOpInfo, IncreaseOpInfo(path: "$.cnt", value: 1))
+                XCTAssertEqual(ops[2] as! IncreaseOpInfo, IncreaseOpInfo(path: "$.cnt", value: 10))
+                XCTAssertEqual(ops[3] as! IncreaseOpInfo, IncreaseOpInfo(path: "$.cnt", value: -3))
+            } else {
+                XCTAssert(false, "No operations.")
+            }
+        }
+
+        try await target.update { root in
+            root.cnt = JSONCounter(value: Int64(0))
+            (root.cnt as? JSONCounter<Int64>)?.increase(value: 1)
+            (root.cnt as? JSONCounter<Int64>)?.increase(value: 10)
+            (root.cnt as? JSONCounter<Int64>)?.increase(value: -3)
+        }
+    }
+
+    func test_change_paths_test_for_text() async throws {
+        let target = Document(key: "test-doc")
+
+        await target.subscribe { event in
+            XCTAssertEqual(event.type, .localChange)
+
+            if let ops = (event as? LocalChangeEvent)?.value[0].operations {
+                XCTAssertEqual(ops[0] as! SetOpInfo, SetOpInfo(path: "$", key: "text"))
+                XCTAssertEqual(ops[1] as! EditOpInfo, EditOpInfo(path: "$.text", from: 0, to: 0, attributes: nil, content: "hello world"))
+                XCTAssertEqual(ops[2] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 11, to: 11))
+                XCTAssertEqual(ops[3] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 0, to: 2))
+            } else {
+                XCTAssert(false, "No operations.")
+            }
+        }
+
+        try await target.update { root in
+            root.text = JSONText()
+            (root.text as? JSONText)?.edit(0, 0, "hello world")
+            (root.text as? JSONText)?.select(0, 2)
+        }
+    }
+
+    func test_change_paths_test_for_text_with_attributes() async throws {
+        let target = Document(key: "test-doc")
+
+        await target.subscribe { event in
+            XCTAssertEqual(event.type, .localChange)
+
+            if let ops = (event as? LocalChangeEvent)?.value[0].operations {
+                XCTAssertEqual(ops[0] as! SetOpInfo, SetOpInfo(path: "$", key: "textWithAttr"))
+                XCTAssertEqual(ops[1] as! EditOpInfo, EditOpInfo(path: "$.textWithAttr", from: 0, to: 0, attributes: nil, content: "hello world"))
+                XCTAssertEqual(ops[2] as! SelectOpInfo, SelectOpInfo(path: "$.textWithAttr", from: 11, to: 11))
+                XCTAssertEqual(ops[3] as! StyleOpInfo, StyleOpInfo(path: "$.textWithAttr", from: 0, to: 1, attributes: ["bold": "true"]))
+            } else {
+                XCTAssert(false, "No operations.")
+            }
+        }
+
+        try await target.update { root in
+            root.textWithAttr = JSONText()
+            (root.textWithAttr as? JSONText)?.edit(0, 0, "hello world")
+            (root.textWithAttr as? JSONText)?.setStyle(0, 1, ["bold": true])
+        }
+    }
+
+    // swiftlint: enable force_cast
 
     func test_insert_elements_before_a_specific_node_of_array() async throws {
         let target = Document(key: "test-doc")

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -114,7 +114,7 @@ final class JSONTextTest: XCTestCase {
         try await doc.update { root in root.text = JSONText() }
 
         await doc.subscribe(targetPath: "$.text") {
-            ($0 as! ChangeEventable).value.forEach { changeInfo in
+            ($0 as! ChangeEvent).value.forEach { changeInfo in
                 view.applyChanges(operations: changeInfo.operations)
             }
         }
@@ -143,7 +143,7 @@ final class JSONTextTest: XCTestCase {
         try await doc.update { root in root.text = JSONText() }
 
         await doc.subscribe(targetPath: "$.text") {
-            ($0 as! ChangeEventable).value.forEach { changeInfo in
+            ($0 as! ChangeEvent).value.forEach { changeInfo in
                 view.applyChanges(operations: changeInfo.operations)
             }
         }
@@ -180,7 +180,7 @@ final class JSONTextTest: XCTestCase {
         try await doc.update { root in root.text = JSONText() }
 
         await doc.subscribe(targetPath: "$.text") {
-            ($0 as! ChangeEventable).value.forEach { changeInfo in
+            ($0 as! ChangeEvent).value.forEach { changeInfo in
                 view.applyChanges(operations: changeInfo.operations)
             }
         }
@@ -216,7 +216,7 @@ final class JSONTextTest: XCTestCase {
         }
 
         await doc.subscribe(targetPath: "$.text") { event in
-            XCTAssertEqual((event as! ChangeEventable).value[0].operations[0] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 2, to: 4))
+            XCTAssertEqual((event as! ChangeEvent).value[0].operations[0] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 2, to: 4))
         }
 
         try await doc.update { root in (root.text as? JSONText)?.select(2, 4) }

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -21,6 +21,7 @@ import XCTest
 final class JSONTextTest: XCTestCase {
     var cancellables = Set<AnyCancellable>()
 
+    // swiftlint: disable force_cast
     func test_should_handle_edit_operations() async throws {
         let doc = Document(key: "test-doc")
 
@@ -112,13 +113,11 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
 
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "ABC"),
@@ -143,13 +142,11 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
 
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "A"),
@@ -182,13 +179,11 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
 
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "1A1BCXEF1"),
@@ -220,18 +215,9 @@ final class JSONTextTest: XCTestCase {
             (root.text as? JSONText)?.edit(0, 0, "ABCD")
         }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            let first = $0.first
-
-            if first?.type == .selection {
-                XCTAssertEqual(first?.from, 2)
-                XCTAssertEqual(first?.to, 4)
-            }
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") { event in
+            XCTAssertEqual((event as! ChangeEventable).value[0].operations[0] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 2, to: 4))
+        }
 
         try await doc.update { root in (root.text as? JSONText)?.select(2, 4) }
     }
@@ -257,4 +243,5 @@ final class JSONTextTest: XCTestCase {
         XCTAssertEqual("{\"k1\":[{\"attrs\":{\"b\":\"1\"},\"val\":\"ABC\"},{\"val\":\"\\n\"},{\"attrs\":{\"b\":\"1\"},\"val\":\"D\"}]}",
                        docContent)
     }
+    // swiftlint: enable force_cast
 }

--- a/Tests/Unit/Util/Helper.swift
+++ b/Tests/Unit/Util/Helper.swift
@@ -24,18 +24,18 @@ import Yorkie
 class TextView {
     private var value: String = ""
 
-    public func applyChanges(changes: [TextChange], enableLog: Bool = false) {
+    public func applyChanges(operations: [any OperationInfo], enableLog: Bool = false) {
         let oldValue = self.value
         var changeLogs = [String]()
-        changes.forEach { change in
-            if change.type == .content {
+        operations.forEach { operation in
+            if let operation = operation as? EditOpInfo {
                 self.value = [
-                    self.value.substring(from: 0, to: change.from - 1),
-                    change.content ?? "",
-                    self.value.substring(from: change.to, to: self.value.count - 1)
+                    self.value.substring(from: 0, to: operation.from - 1),
+                    operation.content ?? "",
+                    self.value.substring(from: operation.to, to: self.value.count - 1)
                 ].joined(separator: "")
 
-                changeLogs.append("{f:\(change.from), t:\(change.to), c:\(change.content ?? "")}")
+                changeLogs.append("{f:\(operation.from), t:\(operation.to), c:\(operation.content ?? "")}")
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  - provide a new API that allows users to subscribe to the document with a specific target path.
  - improve the event value of Local/RemoteChange.
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #74 #76 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
document.eventStream is removed. Use document.subscribe() to catch the events.
Please refer to the samples.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
