### PR TITLE
Replace Text event Stream with Document.subscribe 

### DIFF
--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -27,7 +27,6 @@ enum TextOperation {
 class TextViewModel {
     private var client: Client
     private let document: Document
-    private var textEventStream = PassthroughSubject<[TextChange], Never>()
 
     private weak var operationSubject: PassthroughSubject<[TextOperation], Never>?
 

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -38,11 +38,7 @@ func stringifyAttributes(_ attributes: TextAttributes) -> [String: String] {
     }
 }
 
-/**
- * `TextChange` is the value passed as an argument to `Text.onChanges()`.
- * `Text.onChanges()` is called when the `Text` is modified.
- */
-public class TextChange {
+class TextChange {
     /**
      * `TextChangeType` is the type of TextChange.
      */

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -152,8 +152,6 @@ final class CRDTText: CRDTTextElement {
     var movedAt: TimeTicket?
     var removedAt: TimeTicket?
 
-    weak var eventStream: PassthroughSubject<[TextChange], Never>?
-
     /**
      * `rgaTreeSplit` returns rgaTreeSplit.
      *
@@ -219,12 +217,6 @@ final class CRDTText: CRDTTextElement {
             changes.append(selectionChange)
         }
 
-        if let eventStream {
-            self.remoteChangeLock = true
-            eventStream.send(changes)
-            self.remoteChangeLock = false
-        }
-
         return (latestCreatedAtMap, changes)
     }
 
@@ -274,12 +266,6 @@ final class CRDTText: CRDTTextElement {
             }
         }
 
-        if let eventStream {
-            self.remoteChangeLock = true
-            eventStream.send(changes)
-            self.remoteChangeLock = false
-        }
-
         return changes
     }
 
@@ -292,17 +278,7 @@ final class CRDTText: CRDTTextElement {
             return nil
         }
 
-        if let change = try self.selectPriv(range, updatedAt) {
-            if let eventStream {
-                self.remoteChangeLock = true
-                eventStream.send([change])
-                self.remoteChangeLock = false
-            }
-
-            return change
-        }
-
-        return nil
+        return try self.selectPriv(range, updatedAt)
     }
 
     /**

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -189,17 +189,6 @@ public class JSONText {
     }
 
     /**
-     * `setEventStream` registers a event Stream of TextChange events.
-     */
-    public func setEventStream(eventStream: PassthroughSubject<[TextChange], Never>?) {
-        guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
-            return
-        }
-        text.eventStream = eventStream
-    }
-
-    /**
      * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
      */
     func createRange(_ fromIdx: Int, _ toIdx: Int) -> RGATreeSplitNodeRange? {

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -112,14 +112,12 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
-
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
+        
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "ABC"),
             (from: 3, to: 3, content: "DEF"),
@@ -143,13 +141,11 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
 
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "A"),
@@ -182,13 +178,11 @@ final class JSONTextTest: XCTestCase {
 
         try await doc.update { root in root.text = JSONText() }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            view.applyChanges(changes: $0)
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") {
+            ($0 as! ChangeEventable).value.forEach { changeInfo in
+                view.applyChanges(operations: changeInfo.operations)
+            }
+        }
 
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "1A1BCXEF1"),
@@ -220,18 +214,9 @@ final class JSONTextTest: XCTestCase {
             (root.text as? JSONText)?.edit(0, 0, "ABCD")
         }
 
-        let eventStream = PassthroughSubject<[TextChange], Never>()
-
-        eventStream.sink {
-            let first = $0.first
-
-            if first?.type == .selection {
-                XCTAssertEqual(first?.from, 2)
-                XCTAssertEqual(first?.to, 4)
-            }
-        }.store(in: &self.cancellables)
-
-        await(doc.getRoot()["text"] as? JSONText)?.setEventStream(eventStream: eventStream)
+        await doc.subscribe(targetPath: "$.text") { event in
+            XCTAssertEqual((event as! ChangeEventable).value[0].operations[0] as! SelectOpInfo, SelectOpInfo(path: "$.text", from: 2, to: 4))
+        }
 
         try await doc.update { root in (root.text as? JSONText)?.select(2, 4) }
     }

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -21,6 +21,7 @@ import XCTest
 final class JSONTextTest: XCTestCase {
     var cancellables = Set<AnyCancellable>()
 
+    // swiftlint: disable force_cast
     func test_should_handle_edit_operations() async throws {
         let doc = Document(key: "test-doc")
 
@@ -117,7 +118,7 @@ final class JSONTextTest: XCTestCase {
                 view.applyChanges(operations: changeInfo.operations)
             }
         }
-        
+
         let commands: [(from: Int, to: Int, content: String)] = [
             (from: 0, to: 0, content: "ABC"),
             (from: 3, to: 3, content: "DEF"),
@@ -242,4 +243,5 @@ final class JSONTextTest: XCTestCase {
         XCTAssertEqual("{\"k1\":[{\"attrs\":{\"b\":\"1\"},\"val\":\"ABC\"},{\"val\":\"\\n\"},{\"attrs\":{\"b\":\"1\"},\"val\":\"D\"}]}",
                        docContent)
     }
+    // swiftlint: enable force_cast
 }

--- a/Tests/Unit/Util/Helper.swift
+++ b/Tests/Unit/Util/Helper.swift
@@ -24,18 +24,18 @@ import Yorkie
 class TextView {
     private var value: String = ""
 
-    public func applyChanges(changes: [TextChange], enableLog: Bool = false) {
+    public func applyChanges(operations: [any OperationInfo], enableLog: Bool = false) {
         let oldValue = self.value
         var changeLogs = [String]()
-        changes.forEach { change in
-            if change.type == .content {
+        operations.forEach { operation in
+            if let operation = operation as? EditOpInfo {
                 self.value = [
-                    self.value.substring(from: 0, to: change.from - 1),
-                    change.content ?? "",
-                    self.value.substring(from: change.to, to: self.value.count - 1)
+                    self.value.substring(from: 0, to: operation.from - 1),
+                    operation.content ?? "",
+                    self.value.substring(from: operation.to, to: self.value.count - 1)
                 ].joined(separator: "")
 
-                changeLogs.append("{f:\(change.from), t:\(change.to), c:\(change.content ?? "")}")
+                changeLogs.append("{f:\(operation.from), t:\(operation.to), c:\(operation.content ?? "")}")
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Replace event stream of Text(onChange) with Document.subscribe
 - Hide TextChange class

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #79 

**Special notes for your reviewer**:
The target branch will be changed to main after previous PR merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The event Stream of Text was removed. Use Document.subscribe instead.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
