### PR TITLE
memory leak fixed for TextEditorViewController in TextEditorSample

### DIFF
--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -104,8 +104,13 @@ class TextViewModel {
     }
 
     func cleanup() async {
-        try! await self.client.detach(self.document)
-        try! await self.client.deactivate()
+        do {
+            try await self.client.detach(self.document)
+            try await self.client.deactivate()
+        } catch {
+            // handle error
+//            print(error.localizedDescription)
+        }
     }
 
     func edit(_ operaitions: [TextOperation]) async {

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/View/TextEditorViewController.swift
@@ -100,7 +100,7 @@ class TextEditorViewController: UIViewController {
         // Receive events from TextView Model.
         let subject = PassthroughSubject<[TextOperation], Never>()
 
-        subject.sink { elements in
+        subject.sink { [weak self] elements in
             Task {
                 await MainActor.run { [weak self] in
                     self?.updateTextStorage(elements)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- fixed memory leak issue: TextEditorViewController residing in memory after dismissed
-
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #88 

**Special notes for your reviewer**:
- Though TextEditorViewController is now freed from memory after being dismissed, memory leak still exists for TextViewModel and etc.  
     - I've found out that this case can happen when `func activateClient(_: , callOptions:)`in `YorkieServiceAsyncClient`never returns or throws an error. Adding a timeout for the callOptions parameter solves the problem but I don't think this issue is limited only to the sample. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
