### PR TITLE
Fix converter to get tree from snapshot

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -828,6 +828,8 @@ extension Converter {
             return fromText(element)
         } else if case let .counter(element) = pbElement.body {
             return try fromCounter(element)
+        } else if case let .tree(element) = pbElement.body {
+            return try fromTree(element)
         } else {
             throw YorkieError.unimplemented(message: "unimplemented element: \(pbElement)")
         }

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -317,7 +317,7 @@ final class ClientIntegrationTests: XCTestCase {
         try await c2.deactivate()
         try await c3.deactivate()
     }
-    
+
     func test_can_be_built_from_a_snapshot() async throws {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
 
@@ -338,7 +338,7 @@ final class ClientIntegrationTests: XCTestCase {
             root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "abc")]))
             root.text = JSONText()
         }
-        
+
         for index in 0 ..< snapshotThreshold {
             try await doc1.update { root, _ in
                 try (root.tree as? JSONTree)?.edit(0, 0, [JSONTreeTextNode(value: "\(index),")])
@@ -348,11 +348,10 @@ final class ClientIntegrationTests: XCTestCase {
 
         try await c1.sync()
         try await c2.sync()
-        
+
         let result1 = await doc1.toSortedJSON()
         let result2 = await doc2.toSortedJSON()
 
         XCTAssertEqual(result1, result2)
     }
-
 }

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -317,4 +317,42 @@ final class ClientIntegrationTests: XCTestCase {
         try await c2.deactivate()
         try await c3.deactivate()
     }
+    
+    func test_can_be_built_from_a_snapshot() async throws {
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+
+        let c1 = Client(rpcAddress: rpcAddress, options: ClientOptions())
+        let c2 = Client(rpcAddress: rpcAddress, options: ClientOptions())
+
+        try await c1.activate()
+        try await c2.activate()
+
+        let doc1 = Document(key: docKey)
+        try await c1.attach(doc1, [:], false)
+        let doc2 = Document(key: docKey)
+        try await c2.attach(doc2, [:], false)
+
+        let snapshotThreshold = 500
+
+        try await doc1.update { root, _ in
+            root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "abc")]))
+            root.text = JSONText()
+        }
+        
+        for index in 0 ..< snapshotThreshold {
+            try await doc1.update { root, _ in
+                try (root.tree as? JSONTree)?.edit(0, 0, [JSONTreeTextNode(value: "\(index),")])
+                (root.text as? JSONText)?.edit(0, 0, "\(index),")
+            }
+        }
+
+        try await c1.sync()
+        try await c2.sync()
+        
+        let result1 = await doc1.toSortedJSON()
+        let result2 = await doc2.toSortedJSON()
+
+        XCTAssertEqual(result1, result2)
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Fix converter to get tree from snapshot
- Convert pbElement to JSONTree codes are missing.
- adding TC for the snapshot.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
