### PR TITLE
Support concurrent formatting of Text

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -396,6 +396,9 @@ extension Converter {
             pbStyleOperation.parentCreatedAt = toTimeTicket(styleOperation.parentCreatedAt)
             pbStyleOperation.from = toTextNodePos(pos: styleOperation.fromPos)
             pbStyleOperation.to = toTextNodePos(pos: styleOperation.toPos)
+            styleOperation.maxCreatedAtMapByActor.forEach {
+                pbStyleOperation.createdAtMapByActor[$0.key] = toTimeTicket($0.value)
+            }
             styleOperation.attributes.forEach {
                 pbStyleOperation.attributes[$0.key] = $0.value
             }
@@ -481,6 +484,7 @@ extension Converter {
                 return StyleOperation(parentCreatedAt: fromTimeTicket(pbStyleOperation.parentCreatedAt),
                                       fromPos: fromTextNodePos(pbStyleOperation.from),
                                       toPos: fromTextNodePos(pbStyleOperation.to),
+                                      maxCreatedAtMapByActor: pbStyleOperation.createdAtMapByActor.mapValues({ fromTimeTicket($0) }),
                                       attributes: pbStyleOperation.attributes,
                                       executedAt: fromTimeTicket(pbStyleOperation.executedAt))
             } else if case let .increase(pbIncreaseOperation) = pbOperation.body {

--- a/Sources/API/V1/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/yorkie/v1/resources.pb.swift
@@ -103,7 +103,7 @@ enum Yorkie_V1_ValueType: SwiftProtobuf.Enum {
 
 extension Yorkie_V1_ValueType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Yorkie_V1_ValueType] = [
+  static let allCases: [Yorkie_V1_ValueType] = [
     .null,
     .boolean,
     .integer,
@@ -158,7 +158,7 @@ enum Yorkie_V1_DocEventType: SwiftProtobuf.Enum {
 
 extension Yorkie_V1_DocEventType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Yorkie_V1_DocEventType] = [
+  static let allCases: [Yorkie_V1_DocEventType] = [
     .documentChanged,
     .documentWatched,
     .documentUnwatched,
@@ -787,6 +787,11 @@ struct Yorkie_V1_Operation {
     var hasExecutedAt: Bool {return _storage._executedAt != nil}
     /// Clears the value of `executedAt`. Subsequent reads from it will return its default value.
     mutating func clearExecutedAt() {_uniqueStorage()._executedAt = nil}
+
+    var createdAtMapByActor: Dictionary<String,Yorkie_V1_TimeTicket> {
+      get {return _storage._createdAtMapByActor}
+      set {_uniqueStorage()._createdAtMapByActor = newValue}
+    }
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1878,7 +1883,7 @@ struct Yorkie_V1_PresenceChange {
 
 extension Yorkie_V1_PresenceChange.ChangeType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Yorkie_V1_PresenceChange.ChangeType] = [
+  static let allCases: [Yorkie_V1_PresenceChange.ChangeType] = [
     .unspecified,
     .put,
     .delete,
@@ -2941,6 +2946,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
     3: .same(proto: "to"),
     4: .same(proto: "attributes"),
     5: .standard(proto: "executed_at"),
+    6: .standard(proto: "created_at_map_by_actor"),
   ]
 
   fileprivate class _StorageClass {
@@ -2949,6 +2955,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _to: Yorkie_V1_TextNodePos? = nil
     var _attributes: Dictionary<String,String> = [:]
     var _executedAt: Yorkie_V1_TimeTicket? = nil
+    var _createdAtMapByActor: Dictionary<String,Yorkie_V1_TimeTicket> = [:]
 
     static let defaultInstance = _StorageClass()
 
@@ -2960,6 +2967,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
       _to = source._to
       _attributes = source._attributes
       _executedAt = source._executedAt
+      _createdAtMapByActor = source._createdAtMapByActor
     }
   }
 
@@ -2983,6 +2991,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 3: try { try decoder.decodeSingularMessageField(value: &_storage._to) }()
         case 4: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._attributes) }()
         case 5: try { try decoder.decodeSingularMessageField(value: &_storage._executedAt) }()
+        case 6: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_TimeTicket>.self, value: &_storage._createdAtMapByActor) }()
         default: break
         }
       }
@@ -3010,6 +3019,9 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
       try { if let v = _storage._executedAt {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
       } }()
+      if !_storage._createdAtMapByActor.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_TimeTicket>.self, value: _storage._createdAtMapByActor, fieldNumber: 6)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3024,6 +3036,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if _storage._to != rhs_storage._to {return false}
         if _storage._attributes != rhs_storage._attributes {return false}
         if _storage._executedAt != rhs_storage._executedAt {return false}
+        if _storage._createdAtMapByActor != rhs_storage._createdAtMapByActor {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -111,6 +111,7 @@ message Operation {
     TextNodePos to = 3;
     map<string, string> attributes = 4;
     TimeTicket executed_at = 5;
+    map<string, TimeTicket> created_at_map_by_actor = 6;
   }
   message Increase {
     TimeTicket parent_created_at = 1;

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -124,7 +124,7 @@ public final class TextValue: RGATreeSplitValue, CustomStringConvertible {
         if attrs.isEmpty == false {
             var data = [String]()
 
-            attrs.forEach { key, value in
+            attrs.sorted(by: { $0.key < $1.key }).forEach { key, value in
                 if value.value.count > 2, value.value.first == "\"", value.value.last == "\"" {
                     data.append("\"\(key)\":\(value.value)")
                 } else {
@@ -327,7 +327,7 @@ final class CRDTText: CRDTGCElement {
         self.rgaTreeSplit.toTestString
     }
 
-    public var plainText: String {
+    public var toString: String {
         self.rgaTreeSplit.compactMap { $0.isRemoved ? nil : $0.value.toString }.joined(separator: "")
     }
 

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -353,6 +353,13 @@ class RGATreeSplitNode<T: RGATreeSplitValue>: SplayNode<T> {
     }
 
     /**
+     * `canStyle` checks if node is able to set style.
+     */
+    public func canStyle(_ editedAt: TimeTicket, _ latestCreatedAt: TimeTicket) -> Bool {
+        !self.createdAt.after(latestCreatedAt) && (self.removedAt == nil || editedAt.after(self.removedAt!))
+    }
+
+    /**
      * `remove` removes node of given edited time.
      */
     public func remove(_ editedAt: TimeTicket?) {

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -111,6 +111,7 @@ public class JSONText {
     /**
      * `delete` deletes the text in the given range.
      */
+    @discardableResult
     public func delete(_ fromIdx: Int, _ toIdx: Int) -> (Int, Int)? {
         self.edit(fromIdx, toIdx, "")
     }
@@ -118,6 +119,7 @@ public class JSONText {
     /**
      * `empty` makes the text empty.
      */
+    @discardableResult
     public func empty() -> (Int, Int)? {
         self.edit(0, self.length, "")
     }
@@ -198,8 +200,11 @@ public class JSONText {
         return text.toTestString
     }
 
-    public var plainText: String {
-        self.text?.plainText ?? ""
+    /**
+     * `toString` returns the string representation of this text.
+     */
+    public var toString: String {
+        self.text?.toString ?? ""
     }
 
     /**

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -147,8 +147,9 @@ public class JSONText {
         Logger.debug("STYL: f:\(fromIdx)->\(range.0.toTestString), t:\(toIdx)->\(range.1.toTestString) a:\(attributes)")
 
         let ticket = context.issueTimeTicket
+        let maxCreatedAtMapByActor: [String: TimeTicket]
         do {
-            try text.setStyle(range, attributes, ticket)
+            (maxCreatedAtMapByActor, _) = try text.setStyle(range, attributes, ticket)
         } catch {
             Logger.critical("can't set Style")
             return false
@@ -157,6 +158,7 @@ public class JSONText {
         context.push(operation: StyleOperation(parentCreatedAt: text.createdAt,
                                                fromPos: range.0,
                                                toPos: range.1,
+                                               maxCreatedAtMapByActor: maxCreatedAtMapByActor,
                                                attributes: stringifyAttributes(attributes),
                                                executedAt: ticket))
 

--- a/Sources/Document/Operation/StyleOperation.swift
+++ b/Sources/Document/Operation/StyleOperation.swift
@@ -30,14 +30,21 @@ struct StyleOperation: Operation {
     private(set) var toPos: RGATreeSplitPos
 
     /**
+     * `maxCreatedAtMapByActor` returns the map that stores the latest creation time
+     * by actor for the nodes included in the editing range.
+     */
+    private(set) var maxCreatedAtMapByActor: [String: TimeTicket]
+
+    /**
      * `attributes` returns the attributes of this Edit.
      */
     private(set) var attributes: [String: String]
 
-    init(parentCreatedAt: TimeTicket, fromPos: RGATreeSplitPos, toPos: RGATreeSplitPos, attributes: [String: String], executedAt: TimeTicket) {
+    init(parentCreatedAt: TimeTicket, fromPos: RGATreeSplitPos, toPos: RGATreeSplitPos, maxCreatedAtMapByActor: [String: TimeTicket], attributes: [String: String], executedAt: TimeTicket) {
         self.parentCreatedAt = parentCreatedAt
         self.fromPos = fromPos
         self.toPos = toPos
+        self.maxCreatedAtMapByActor = maxCreatedAtMapByActor
         self.attributes = attributes
         self.executedAt = executedAt
     }
@@ -60,7 +67,7 @@ struct StyleOperation: Operation {
             throw YorkieError.unexpected(message: log)
         }
 
-        let changes = try text.setStyle((self.fromPos, self.toPos), self.attributes, self.executedAt)
+        let (_, changes) = try text.setStyle((self.fromPos, self.toPos), self.attributes, self.executedAt, self.maxCreatedAtMapByActor)
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
             throw YorkieError.unexpected(message: "fail to get path")

--- a/Tests/Integration/TextIntegrationTests.swift
+++ b/Tests/Integration/TextIntegrationTests.swift
@@ -18,83 +18,666 @@ import XCTest
 @testable import Yorkie
 
 final class TextIntegrationTests: XCTestCase {
-    let rpcAddress = RPCAddress(host: "localhost", port: 8080)
-
-    var c1: Client!
-    var c2: Client!
-    var d1: Document!
-    var d2: Document!
-
-    func test_can_be_edit_plain_text() async throws {
-        let options = ClientOptions()
-        let docKey = "\(self.description)-\(Date().description)".toDocKey
-
-        self.c1 = Client(rpcAddress: self.rpcAddress, options: options)
-        self.c2 = Client(rpcAddress: self.rpcAddress, options: options)
-
-        self.d1 = Document(key: docKey)
-        self.d2 = Document(key: docKey)
-
-        try await self.c1.activate()
-        try await self.c2.activate()
-
-        try await self.c1.attach(self.d1, [:], false)
-        try await self.c2.attach(self.d2, [:], false)
-
-        try await self.d1.update { root, _ in
-            root.text = JSONText()
-            (root.text as? JSONText)?.edit(0, 0, "Hello")
-            (root.text as? JSONText)?.edit(1, 3, "12")
+    func test_should_handle_edit_operations() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "1234")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
         }
+    }
+    
+    func test_should_handle_concurrent_edit_operations() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(0, 0, "1234")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(2, 3, "XX")
+            }
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(2, 3, "YY")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(4, 5, "ZZ")
+            }
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(2, 3, "TT")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_should_handle_concurrent_insertion_and_deletion() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "AB")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"AB\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(0, 2, "")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(1, 1, "C")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"A\"},{\"val\":\"C\"},{\"val\":\"B\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"C\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_should_handle_concurrent_block_deletions() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "123")
+                (root.k1 as? JSONText)?.edit(3, 3, "456")
+                (root.k1 as? JSONText)?.edit(6, 6, "789")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"123\"},{\"val\":\"456\"},{\"val\":\"789\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(1, 7, "")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1\"},{\"val\":\"89\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(2, 5, "")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"12\"},{\"val\":\"6\"},{\"val\":\"789\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_should_maintain_the_correct_weight_for_nodes_newly_created_then_concurrently_removed() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+            }
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(0, 0, "O")
+                (root.k1 as? JSONText)?.edit(1, 1, "O")
+                (root.k1 as? JSONText)?.edit(2, 2, "O")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(1, 2, "X")
+                (root.k1 as? JSONText)?.edit(1, 2, "X")
+                (root.k1 as? JSONText)?.edit(1, 2, "")
+            }
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(0, 3, "N")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            let d1Check = await (d1.getRoot().k1 as? JSONText)?.checkWeight() ?? false
+            let d2Check = await (d2.getRoot().k1 as? JSONText)?.checkWeight() ?? false
+            XCTAssertTrue(d1Check)
+            XCTAssertTrue(d2Check)
+        }
+    }
+}
 
-        try await self.c1.sync()
-        try await self.c2.sync()
-
-        let result = (await d2.getRoot().text as? JSONText)?.plainText
-
-        XCTAssertEqual("H12lo", result!)
+final class TextIntegrationConcurrentTests: XCTestCase {
+    func test_ex1_concurrent_insertions_on_plain_text() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(4, 4, "quick ")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
     }
 
-    func test_can_be_edit_attributed_text() async throws {
-        let options = ClientOptions()
-        let docKey = "\(self.description)-\(Date().description)".toDocKey
-
-        self.c1 = Client(rpcAddress: self.rpcAddress, options: options)
-        self.c2 = Client(rpcAddress: self.rpcAddress, options: options)
-
-        self.d1 = Document(key: docKey)
-        self.d2 = Document(key: docKey)
-
-        try await self.c1.activate()
-        try await self.c2.activate()
-
-        try await self.c1.attach(self.d1, [:], false)
-        try await self.c2.attach(self.d2, [:], false)
-
-        try await self.d1.update { root, _ in
-            root.text = JSONText()
-            (root.text as? JSONText)?.edit(0, 0, "Hello", ["bold": true])
-            (root.text as? JSONText)?.edit(1, 3, "12")
-            (root.text as? JSONText)?.setStyle(1, 3, ["italic": true])
+    func test_ex2_concurrent_formatting_and_insertion() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(4, 4, "brown ")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"brown \"},{\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"val\":\"brown \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
+            // TODO(MoonGyu1): d1 and d2 should have the result below after applying mark operation
+            // assert.equal(
+            //   d1.toSortedJSON(),
+            //   '{"k1":[{"attrs":{"bold":true},"val":"The "},{"attrs":{"bold":true},"val":"brown "},{"attrs":{"bold":true},"val":"fox jumped."}]}',
+            //   'd1',
+            // );
+            XCTAssertEqual(d1JSON, d2JSON)
         }
-
-        try await self.c1.sync()
-        try await self.c2.sync()
-
-        try await self.d2.update { root, _ in
-            (root.text as? JSONText)?.setStyle(1, 3, ["italic": true])
+    }
+    
+    func test_ex3_overlapping_formatting_bold() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": true])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox\"},{\"attrs\":{\"bold\":true},\"val\":\" jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
         }
-
-        try await self.c2.sync()
-        try await self.c1.sync()
-
-        let resultD1 = (await d1.getRoot().text as? JSONText)?.values?.compactMap {
-            $0.toJSON
-        }.joined(separator: ",")
-        let resultD2 = (await d2.getRoot().text as? JSONText)?.values?.compactMap {
-            $0.toJSON
-        }.joined(separator: ",")
-
-        XCTAssertEqual(resultD1, resultD2)
+    }
+    
+    func test_ex4_overlapping_different_formatting_bold_and_italic() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["italic": true])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"italic\":true},\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true,\"italic\":true},\"val\":\"fox\"},{\"attrs\":{\"italic\":true},\"val\":\" jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex5_conflicting_overlaps_highlighting() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 7, ["highlight": "red"])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["highlight": "blue"])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox\"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\" jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex6_conflicting_overlaps_bold() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":false},\"val\":\"jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex6_conflicting_overlaps_bold_2() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
+            
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex7_multiple_instances_of_the_same_mark() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(0, 7, ["comment": "Alice's comment"])
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.setStyle(4, 15, ["comment": "Bob's comment"])
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox jumped.\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox\"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\" jumped.\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex8_text_insertion_at_span_boundaries_bold() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+                (root.k1 as? JSONText)?.setStyle(4, 14, ["bold": true])
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(4, 4, "quick ")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
+    }
+    
+    func test_ex9_text_insertion_at_span_boundaries_link() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try await d1.update { root, _ in
+                root.k1 = JSONText()
+                (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
+                (root.k1 as? JSONText)?.setStyle(4, 14, ["link": "https://www.google.com/search?q=jumping+fox"])
+            }
+            
+            try await c1.sync()
+            try await c2.sync()
+            
+            var d1JSON = await d1.toSortedJSON()
+            var d2JSON = await d2.toSortedJSON()
+            
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+            
+            try await d1.update { root, _ in
+                (root.k1 as? JSONText)?.edit(4, 4, "quick ")
+            }
+            
+            d1JSON = await d1.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            
+            try await d2.update { root, _ in
+                (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
+            }
+            
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            
+            d1JSON = await d1.toSortedJSON()
+            d2JSON = await d2.toSortedJSON()
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, d2JSON)
+        }
     }
 }

--- a/Tests/Integration/TextIntegrationTests.swift
+++ b/Tests/Integration/TextIntegrationTests.swift
@@ -24,148 +24,148 @@ final class TextIntegrationTests: XCTestCase {
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "1234")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_should_handle_concurrent_edit_operations() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "1234")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "XX")
             }
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "YY")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 5, "ZZ")
             }
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "TT")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_should_handle_concurrent_insertion_and_deletion() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "AB")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"AB\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 2, "")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 1, "C")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"A\"},{\"val\":\"C\"},{\"val\":\"B\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"C\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_should_handle_concurrent_block_deletions() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
@@ -174,72 +174,72 @@ final class TextIntegrationTests: XCTestCase {
                 (root.k1 as? JSONText)?.edit(3, 3, "456")
                 (root.k1 as? JSONText)?.edit(6, 6, "789")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"123\"},{\"val\":\"456\"},{\"val\":\"789\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 7, "")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1\"},{\"val\":\"89\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 5, "")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"12\"},{\"val\":\"6\"},{\"val\":\"789\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_should_maintain_the_correct_weight_for_nodes_newly_created_then_concurrently_removed() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
             }
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "O")
                 (root.k1 as? JSONText)?.edit(1, 1, "O")
                 (root.k1 as? JSONText)?.edit(2, 2, "O")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 2, "X")
                 (root.k1 as? JSONText)?.edit(1, 2, "X")
                 (root.k1 as? JSONText)?.edit(1, 2, "")
             }
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 3, "N")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
-            let d1Check = await (d1.getRoot().k1 as? JSONText)?.checkWeight() ?? false
-            let d2Check = await (d2.getRoot().k1 as? JSONText)?.checkWeight() ?? false
+
+            let d1Check = await(d1.getRoot().k1 as? JSONText)?.checkWeight() ?? false
+            let d2Check = await(d2.getRoot().k1 as? JSONText)?.checkWeight() ?? false
             XCTAssertTrue(d1Check)
             XCTAssertTrue(d2Check)
         }
@@ -253,34 +253,34 @@ final class TextIntegrationConcurrentTests: XCTestCase {
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
@@ -294,34 +294,34 @@ final class TextIntegrationConcurrentTests: XCTestCase {
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "brown ")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"brown \"},{\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"val\":\"brown \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
@@ -334,269 +334,269 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex3_overlapping_formatting_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": true])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox\"},{\"attrs\":{\"bold\":true},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex4_overlapping_different_formatting_bold_and_italic() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["italic": true])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"italic\":true},\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true,\"italic\":true},\"val\":\"fox\"},{\"attrs\":{\"italic\":true},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex5_conflicting_overlaps_highlighting() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["highlight": "red"])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["highlight": "blue"])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox\"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex6_conflicting_overlaps_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":false},\"val\":\"jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex6_conflicting_overlaps_bold_2() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
-            
+
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex7_multiple_instances_of_the_same_mark() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["comment": "Alice's comment"])
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["comment": "Bob's comment"])
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox jumped.\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox\"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex8_text_insertion_at_span_boundaries_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
@@ -604,41 +604,41 @@ final class TextIntegrationConcurrentTests: XCTestCase {
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
                 (root.k1 as? JSONText)?.setStyle(4, 14, ["bold": true])
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
-    
+
     func test_ex9_text_insertion_at_span_boundaries_link() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             try await d1.update { root, _ in
@@ -646,34 +646,34 @@ final class TextIntegrationConcurrentTests: XCTestCase {
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
                 (root.k1 as? JSONText)?.setStyle(4, 14, ["link": "https://www.google.com/search?q=jumping+fox"])
             }
-            
+
             try await c1.sync()
             try await c2.sync()
-            
+
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
-            
+
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
-            
+
             try await d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
-            
+
             d1JSON = await d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
-            
+
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
-            
+
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
-            
+
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
-            
+
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")

--- a/Tests/Unit/Document/DocumentTests.swift
+++ b/Tests/Unit/Document/DocumentTests.swift
@@ -905,7 +905,7 @@ class DocumentTests: XCTestCase {
 
         let text = try await target.getValueByPath("$.text") as? JSONText
 
-        XCTAssertEqual(text?.plainText, "hello world")
+        XCTAssertEqual(text?.toString, "hello world")
     }
 
     func test_change_paths_test_for_text_with_attributes() async throws {

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -222,48 +222,48 @@ final class JSONTextTest: XCTestCase {
         XCTAssertEqual("{\"k1\":[{\"attrs\":{\"b\":1},\"val\":\"ABC\"},{\"val\":\"\\n\"},{\"attrs\":{\"b\":1},\"val\":\"D\"}]}",
                        docContent)
     }
-    
+
     func test_should_handle_text_delete_operations() async throws {
         let doc = Document(key: "test-doc")
-        
+
         let docContent = await doc.toSortedJSON()
         XCTAssertEqual("{}", docContent)
-        
+
         try await doc.update { root, _ in
             root.k1 = JSONText()
             (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
         }
-        
-        var string = await (doc.getRoot().k1 as? JSONText)?.toString
+
+        var string = await(doc.getRoot().k1 as? JSONText)?.toString
         XCTAssertEqual("ABCD", string)
-        
+
         try await doc.update { root, _ in
             (root.k1 as? JSONText)?.delete(1, 3)
         }
-        
-        string = await (doc.getRoot().k1 as? JSONText)?.toString
+
+        string = await(doc.getRoot().k1 as? JSONText)?.toString
         XCTAssertEqual("AD", string)
     }
 
     func test_should_handle_text_empty_operations() async throws {
         let doc = Document(key: "test-doc")
-        
+
         let docContent = await doc.toSortedJSON()
         XCTAssertEqual("{}", docContent)
-        
+
         try await doc.update { root, _ in
             root.k1 = JSONText()
             (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
         }
-        
-        var string = await (doc.getRoot().k1 as? JSONText)?.toString
+
+        var string = await(doc.getRoot().k1 as? JSONText)?.toString
         XCTAssertEqual("ABCD", string)
-        
+
         try await doc.update { root, _ in
             (root.k1 as? JSONText)?.empty()
         }
-        
-        string = await (doc.getRoot().k1 as? JSONText)?.toString
+
+        string = await(doc.getRoot().k1 as? JSONText)?.toString
         XCTAssertEqual("", string)
     }
     // swiftlint: enable force_cast

--- a/Tests/Unit/Document/JSONTextTest.swift
+++ b/Tests/Unit/Document/JSONTextTest.swift
@@ -129,7 +129,7 @@ final class JSONTextTest: XCTestCase {
                 (root.text as? JSONText)?.edit(cmd.from, cmd.to, cmd.content)
             }
 
-            let text = await(doc.getRoot()["text"] as? JSONText)?.plainText
+            let text = await(doc.getRoot()["text"] as? JSONText)?.toString
             XCTAssertEqual(view.toString, text)
         }
     }
@@ -164,7 +164,7 @@ final class JSONTextTest: XCTestCase {
                 (root.text as? JSONText)?.edit(cmd.from, cmd.to, cmd.content)
             }
 
-            let text = await(doc.getRoot()["text"] as? JSONText)?.plainText
+            let text = await(doc.getRoot()["text"] as? JSONText)?.toString
             XCTAssertEqual(view.toString, text)
         }
     }
@@ -196,12 +196,12 @@ final class JSONTextTest: XCTestCase {
                 (root.text as? JSONText)?.edit(cmd.from, cmd.to, cmd.content)
             }
 
-            let text = await(doc.getRoot()["text"] as? JSONText)?.plainText
+            let text = await(doc.getRoot()["text"] as? JSONText)?.toString
             XCTAssertEqual(view.toString, text)
         }
     }
 
-    func test_should_handle_rich_text_edit_operations() async throws {
+    func test_should_handle_rich_text_edit_operations_with_attributes() async throws {
         let doc = Document(key: "test-doc")
 
         var docContent = await doc.toSortedJSON()
@@ -221,6 +221,50 @@ final class JSONTextTest: XCTestCase {
         docContent = await doc.toSortedJSON()
         XCTAssertEqual("{\"k1\":[{\"attrs\":{\"b\":1},\"val\":\"ABC\"},{\"val\":\"\\n\"},{\"attrs\":{\"b\":1},\"val\":\"D\"}]}",
                        docContent)
+    }
+    
+    func test_should_handle_text_delete_operations() async throws {
+        let doc = Document(key: "test-doc")
+        
+        let docContent = await doc.toSortedJSON()
+        XCTAssertEqual("{}", docContent)
+        
+        try await doc.update { root, _ in
+            root.k1 = JSONText()
+            (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
+        }
+        
+        var string = await (doc.getRoot().k1 as? JSONText)?.toString
+        XCTAssertEqual("ABCD", string)
+        
+        try await doc.update { root, _ in
+            (root.k1 as? JSONText)?.delete(1, 3)
+        }
+        
+        string = await (doc.getRoot().k1 as? JSONText)?.toString
+        XCTAssertEqual("AD", string)
+    }
+
+    func test_should_handle_text_empty_operations() async throws {
+        let doc = Document(key: "test-doc")
+        
+        let docContent = await doc.toSortedJSON()
+        XCTAssertEqual("{}", docContent)
+        
+        try await doc.update { root, _ in
+            root.k1 = JSONText()
+            (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
+        }
+        
+        var string = await (doc.getRoot().k1 as? JSONText)?.toString
+        XCTAssertEqual("ABCD", string)
+        
+        try await doc.update { root, _ in
+            (root.k1 as? JSONText)?.empty()
+        }
+        
+        string = await (doc.getRoot().k1 as? JSONText)?.toString
+        XCTAssertEqual("", string)
     }
     // swiftlint: enable force_cast
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- This is the Swift implementation of JS PR below.
  - https://github.com/yorkie-team/yorkie-js-sdk/pull/642
- Port every TC for Text from JS.
- toSortedJSON() of JSONText returns sorted attributes too. 
- change var name "plainText" of JSONText to "toString" to match the name of JS
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
