### PR TITLE
Remove strong reference cycle

### DIFF
--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -217,7 +217,7 @@ typealias TreePosStructRange = (CRDTTreePosStruct, CRDTTreePosStruct)
  */
 final class CRDTTreeNode: IndexTreeNode {
     var size: Int
-    var parent: CRDTTreeNode?
+    weak var parent: CRDTTreeNode?
     var type: TreeNodeType
     var value: String {
         get {

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -216,24 +216,24 @@ class RGATreeSplitNode<T: RGATreeSplitValue>: SplayNode<T> {
     /**
      * `prev` returns a previous node of this node.
      */
-    private(set) var prev: RGATreeSplitNode<T>?
+    private(set) weak var prev: RGATreeSplitNode<T>?
 
     /**
      * `next`  returns a next node of this node.
      */
-    private(set) var next: RGATreeSplitNode<T>? {
+    private(set) weak var next: RGATreeSplitNode<T>? {
         didSet {}
     }
 
     /**
      * `insPrev` returns a previous node of this node insertion.
      */
-    private(set) var insPrev: RGATreeSplitNode<T>?
+    private(set) weak var insPrev: RGATreeSplitNode<T>?
 
     /**
      * `insNext` returns a next node of this node insertion.
      */
-    private(set) var insNext: RGATreeSplitNode<T>?
+    private(set) weak var insNext: RGATreeSplitNode<T>?
 
     init(_ id: RGATreeSplitNodeID, _ value: T? = nil, _ removedAt: TimeTicket? = nil) {
         self.id = id

--- a/Sources/Util/LLRBTree.swift
+++ b/Sources/Util/LLRBTree.swift
@@ -35,7 +35,7 @@ class LLRBTree<K: Comparable, V> {
     class Node<K, V>: CustomDebugStringConvertible {
         var key: K
         var value: V
-        var parent: Node<K, V>?
+        weak var parent: Node<K, V>?
         var left: Node<K, V>?
         var right: Node<K, V>?
         var isRed: Bool

--- a/Sources/Util/SplayTree.swift
+++ b/Sources/Util/SplayTree.swift
@@ -24,7 +24,7 @@ class SplayNode<V>: CustomDebugStringConvertible {
 
     fileprivate var left: SplayNode<V>?
     fileprivate var right: SplayNode<V>?
-    fileprivate var parent: SplayNode<V>?
+    fileprivate weak var parent: SplayNode<V>?
     fileprivate(set) var weight: Int = 0
 
     init(_ value: V) {

--- a/Sources/Util/Trie.swift
+++ b/Sources/Util/Trie.swift
@@ -22,7 +22,7 @@ import Foundation
 class TrieNode<V: Hashable> {
     fileprivate var value: V
     fileprivate var children: [V: TrieNode<V>]
-    fileprivate var parent: TrieNode<V>?
+    fileprivate weak var parent: TrieNode<V>?
     fileprivate var isTerminal: Bool
 
     init(value: V, parent: TrieNode<V>? = nil) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Remove memory leaks caused by strong reference cycles of Trees.
- Set parents as weak to prevent a strong reference cycle. 
- Set prev and next of RGATreeSplit too.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
