### PR TITLE
Prevent escaping slash of URL

### DIFF
--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -30,7 +30,7 @@ func stringifyAttributes(_ attributes: TextAttributes) -> [String: String] {
     }
 
     return jsonObject.mapValues {
-        if let result = try? JSONSerialization.data(withJSONObject: $0, options: .fragmentsAllowed) {
+        if let result = try? JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .withoutEscapingSlashes]) {
             return String(data: result, encoding: .utf8) ?? ""
         } else {
             return ""

--- a/Sources/Util/Dictionary+Extension.swift
+++ b/Sources/Util/Dictionary+Extension.swift
@@ -33,12 +33,12 @@ extension AnyValueTypeDictionary {
             {
                 convertedDictionary[key] = stringValue
             } else if let value = value as? [String: Any],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value),
+                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
                       let stringValue = String(data: jsonData, encoding: .utf8)
             {
                 convertedDictionary[key] = stringValue
             } else if let value = value as? [[String: Any]],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value),
+                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
                       let stringValue = String(data: jsonData, encoding: .utf8)
             {
                 convertedDictionary[key] = stringValue

--- a/Tests/Integration/TextIntegrationTests.swift
+++ b/Tests/Integration/TextIntegrationTests.swift
@@ -653,7 +653,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             var d1JSON = await d1.toSortedJSON()
             var d2JSON = await d2.toSortedJSON()
 
-            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
             try await d1.update { root, _ in
@@ -661,14 +661,14 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             d1JSON = await d1.toSortedJSON()
-            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
 
             try await d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
 
             d2JSON = await d2.toSortedJSON()
-            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
 
             try await c1.sync()
             try await c2.sync()
@@ -676,7 +676,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
 
             d1JSON = await d1.toSortedJSON()
             d2JSON = await d2.toSortedJSON()
-            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https:\\/\\/www.google.com\\/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
+            XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- To prevent escaping shahs of URL.
  - eg. (http://abc.def -> http:\\/\\/abc.def)
  - apply "withoutEscapingSlashes" option when encoding dictionaries to JSON  
- I also made changes to the TCs. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
