### PR TITLE
Escape the string during toJSON.

### DIFF
--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -363,21 +363,21 @@ final class CRDTTreeNode: IndexTreeNode {
 
     var toJSONString: String {
         if self.type == DefaultTreeNodeType.text.rawValue {
-            return "{\"type\":\"\(self.type)\",\"value\":\"\(self.value)\"}"
+            return "{\"type\":\(self.type.toJSONString),\"value\":\(self.value.toJSONString)}"
         } else {
             var childrenString = ""
             if children.isEmpty == false {
                 childrenString = children.compactMap { $0.toJSONString }.joined(separator: ",")
             }
 
-            var resultString = "{\"type\":\"\(self.type)\",\"children\":[\(childrenString)]"
+            var resultString = "{\"type\":\(self.type.toJSONString),\"children\":[\(childrenString)]"
 
             if let attributes = self.attrs?.toObject().mapValues({ $0.value }), attributes.isEmpty == false {
                 let sortedKeys = attributes.keys.sorted()
 
                 let attrsString = sortedKeys.compactMap { key in
                     if let value = attributes[key] {
-                        return "\"\(key)\":\(value)"
+                        return "\(key.toJSONString):\(value)"
                     } else {
                         return nil
                     }

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -109,7 +109,7 @@ public struct JSONTreeElementNode: JSONTreeNode {
                 } else if let value = attributes[key] as? Bool {
                     return "\"\(key)\":\(value)"
                 } else if let value = attributes[key] as? String {
-                    return "\"\(key)\":\"\(value)\""
+                    return "\"\(key)\":\(value.toJSONString)"
                 } else {
                     return "\"\(key)\":null"
                 }
@@ -136,7 +136,7 @@ public struct JSONTreeTextNode: JSONTreeNode {
     }
 
     public var toJSONString: String {
-        return "{\"type\":\"\(self.type)\",\"value\":\"\(self.value)\"}"
+        return "{\"type\":\(self.type.toJSONString),\"value\":\(value.toJSONString)}"
     }
 }
 

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -94,24 +94,24 @@ public struct JSONTreeElementNode: JSONTreeNode {
             childrenString = self.children.compactMap { $0.toJSONString }.joined(separator: ",")
         }
 
-        var resultString = "{\"type\":\"\(self.type)\",\"children\":[\(childrenString)]"
+        var resultString = "{\"type\":\(self.type.toJSONString),\"children\":[\(childrenString)]"
 
         if self.attributes.isEmpty == false {
             let sortedKeys = self.attributes.keys.sorted()
 
             let attrsString = sortedKeys.compactMap { key in
                 if let attrs = attributes[key] as? Encodable, let value = attrs.toJSONString {
-                    return "\"\(key)\":\(value)"
+                    return "\(key.toJSONString):\(value)"
                 } else if let value = attributes[key] as? Int {
-                    return "\"\(key)\":\(value)"
+                    return "\(key.toJSONString):\(value)"
                 } else if let value = attributes[key] as? Double {
-                    return "\"\(key)\":\(value)"
+                    return "\(key.toJSONString):\(value)"
                 } else if let value = attributes[key] as? Bool {
-                    return "\"\(key)\":\(value)"
+                    return "\(key.toJSONString):\(value)"
                 } else if let value = attributes[key] as? String {
-                    return "\"\(key)\":\(value.toJSONString)"
+                    return "\(key.toJSONString):\(value.toJSONString)"
                 } else {
-                    return "\"\(key)\":null"
+                    return "\(key.toJSONString):null"
                 }
             }.joined(separator: ",")
 
@@ -136,7 +136,7 @@ public struct JSONTreeTextNode: JSONTreeNode {
     }
 
     public var toJSONString: String {
-        return "{\"type\":\(self.type.toJSONString),\"value\":\(value.toJSONString)}"
+        return "{\"type\":\(self.type.toJSONString),\"value\":\(self.value.toJSONString)}"
     }
 }
 

--- a/Sources/Util/String+Extensions.swift
+++ b/Sources/Util/String+Extensions.swift
@@ -45,13 +45,14 @@ extension String {
 
         return self
     }
-    
+
     var toJSONString: String {
         if let jsonData = try? JSONSerialization.data(withJSONObject: self, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
-           let escapedValue = String(bytes: jsonData, encoding: .utf8) {
+           let escapedValue = String(bytes: jsonData, encoding: .utf8)
+        {
             return escapedValue
         }
-        
+
         return ""
     }
 }

--- a/Sources/Util/String+Extensions.swift
+++ b/Sources/Util/String+Extensions.swift
@@ -45,4 +45,13 @@ extension String {
 
         return self
     }
+    
+    var toJSONString: String {
+        if let jsonData = try? JSONSerialization.data(withJSONObject: self, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
+           let escapedValue = String(bytes: jsonData, encoding: .utf8) {
+            return escapedValue
+        }
+        
+        return ""
+    }
 }

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -70,7 +70,7 @@ final class CRDTTreeNodeTests: XCTestCase {
         XCTAssertEqual(right?.id, CRDTTreeNodeID(createdAt: TimeTicket.initial, offset: 5))
     }
 
-    func test_can_be_escaped_newline_() {
+    func test_can_be_escaped_newline() {
         let node = CRDTTreeNode(id: DTP, type: DefaultTreeNodeType.text.rawValue, value: "\n")
 
         XCTAssertEqual(node.id, DTP)

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -69,6 +69,19 @@ final class CRDTTreeNodeTests: XCTestCase {
         XCTAssertEqual(left.id, CRDTTreeNodeID(createdAt: TimeTicket.initial, offset: 0))
         XCTAssertEqual(right?.id, CRDTTreeNodeID(createdAt: TimeTicket.initial, offset: 5))
     }
+
+    func test_can_be_escaped_newline_() {
+        let node = CRDTTreeNode(id: DTP, type: DefaultTreeNodeType.text.rawValue, value: "\n")
+
+        XCTAssertEqual(node.id, DTP)
+        XCTAssertEqual(node.type, DefaultTreeNodeType.text.rawValue)
+        XCTAssertEqual(node.value, "\n")
+        XCTAssertEqual(node.size, 1)
+        XCTAssertEqual(node.isText, true)
+        XCTAssertEqual(node.isRemoved, false)
+
+        XCTAssertEqual(node.toJSONString, "{\"type\":\"text\",\"value\":\"\\n\"}")
+    }
 }
 
 final class CRDTTreeTests: XCTestCase {

--- a/Tests/Unit/Document/JONSTreeTests.swift
+++ b/Tests/Unit/Document/JONSTreeTests.swift
@@ -38,4 +38,10 @@ final class JONSTreeTests: XCTestCase {
 
         XCTAssertEqual(elementNode.toJSONString, "{\"type\":\"doc\",\"children\":[{\"type\":\"p\",\"children\":[]},{\"type\":\"text\",\"value\":\"Y\"}],\"attributes\":{\"boolean\":true,\"doubleValue\":10.5,\"intValue\":100,\"point\":{\"x\":100,\"y\":200},\"string\":\"testString\"}}")
     }
+    
+    func test_json_newline_string() throws {
+        let textNode = JSONTreeTextNode(value: "\n")
+
+        XCTAssertEqual(textNode.toJSONString, "{\"type\":\"text\",\"value\":\"\\n\"}")
+    }
 }

--- a/Tests/Unit/Document/JONSTreeTests.swift
+++ b/Tests/Unit/Document/JONSTreeTests.swift
@@ -38,7 +38,7 @@ final class JONSTreeTests: XCTestCase {
 
         XCTAssertEqual(elementNode.toJSONString, "{\"type\":\"doc\",\"children\":[{\"type\":\"p\",\"children\":[]},{\"type\":\"text\",\"value\":\"Y\"}],\"attributes\":{\"boolean\":true,\"doubleValue\":10.5,\"intValue\":100,\"point\":{\"x\":100,\"y\":200},\"string\":\"testString\"}}")
     }
-    
+
     func test_json_newline_string() throws {
         let textNode = JSONTreeTextNode(value: "\n")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- By the JSON spec. special characters must be escaped with a slash. (eg. newline => \n) (https://www.json.org/json-en.html)
- The toJSON in JSON Node makes JSON string without escaping now. So toJSON string can't be parsed. 
  - eg. JSONTreeTextNode(value: "\n").toJSONString
```
{"type": "text", "value": "
"}
```
- I added toJSONString var in String Extension. And explicitly escape the string in toJSONString.
- I also apply a similar modification to the CRDTTree.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
