### PR TITLE
Fix the Incorrectly generated attributes for toJsonString  of Tree

### DIFF
--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -102,6 +102,10 @@ public struct JSONTreeElementNode: JSONTreeNode {
             let attrsString = sortedKeys.compactMap { key in
                 if let attrs = attributes[key] as? Encodable, let value = attrs.toJSONString {
                     return "\(key.toJSONString):\(value)"
+                } else if let value = attributes[key] as? Any, JSONSerialization.isValidJSONObject(value),
+                          let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys, .withoutEscapingSlashes])
+                {
+                    return "\(key.toJSONString):\(String(data: data, encoding: .utf8) ?? "null")"
                 } else if let value = attributes[key] as? Int {
                     return "\(key.toJSONString):\(value)"
                 } else if let value = attributes[key] as? Double {

--- a/Tests/Unit/Document/JONSTreeTests.swift
+++ b/Tests/Unit/Document/JONSTreeTests.swift
@@ -44,4 +44,15 @@ final class JONSTreeTests: XCTestCase {
 
         XCTAssertEqual(textNode.toJSONString, "{\"type\":\"text\",\"value\":\"\\n\"}")
     }
+
+    func test_json_jsonSerialiaztion() throws {
+        let attr = RHT()
+
+        attr.set(key: "list", value: "{\"@ctype\":\"paragraphListStyle\",\"level\":0,\"type\":\"bullet\"}", executedAt: TimeTicket.initial)
+
+        let crdtTreeNode = CRDTTreeNode(id: .initial, type: "listNode", children: nil, attributes: attr)
+        let jsonTreeNode = crdtTreeNode.toJSONTreeNode
+
+        XCTAssertEqual(crdtTreeNode.toJSONString, jsonTreeNode.toJSONString)
+    }
 }

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,31 +1,14 @@
 version: '3.3'
 
 services:
-  envoy:
-    build:
-      context: ./
-      dockerfile: ./envoy.Dockerfile
-    image: 'grpcweb:envoy'
-    container_name: 'envoy'
-    restart: always
-    ports:
-      - '8080:8080'
-      - '9901:9901'
-    command: ['/etc/envoy/envoy-ci.yaml']
-    depends_on:
-      - yorkie
   yorkie:
     image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
-    command: [
-      'server',
-      '--mongo-connection-uri',
-      'mongodb://mongo:27017',
-    ]
+    command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always
     ports:
-      - '11101:11101'
-      - '11102:11102'
+      - '8080:8080'
+      - '8081:8081'
     depends_on:
       - mongo
   mongo:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,34 +1,11 @@
 version: '3.3'
 
 services:
-  envoy:
-    build:
-      context: ./
-      dockerfile: ./envoy.Dockerfile
-    image: 'grpcweb:envoy'
-    container_name: 'envoy'
-    restart: always
-    ports:
-      - '8080:8080'
-      - '9901:9901'
-    command: ['/etc/envoy/envoy.yaml']
-    depends_on:
-      - yorkie
-    # If you're using Mac or Windows, this special domain name("host.docker.internal" which makes containers able to connect to the host)
-    # is supported by default.
-    # But if you're using Linux and want an envoy container to communicate with the host,
-    # it may help to define "host.docker.internal" in extra_hosts. 
-    # (Actually, other hostnames are available, but in that case you should update clusters[].host configurations of envoy.yaml)
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   yorkie:
     image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
-    command: [
-      'server',
-      '--enable-pprof',
-    ]
+    command: ['server', '--enable-pprof']
     restart: always
     ports:
-      - '11101:11101'
-      - '11102:11102'
+      - '8080:8080'
+      - '8081:8081'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Fix the Incorrectly generated attributes for toJsonString  of Tree

The attributes of Tree node are contained as json String.
When initialize the JSONTreeNode, the json String converted to dictionary by toJSONObject in String+Extension.
https://github.com/yorkie-team/yorkie-ios-sdk/blob/ca1fbc01690ba9bd21c205d9916ef7d9ae956dd9/Sources/Util/String%2BExtensions.swift#L41-L47

The "jsonObject" that "JSONSerialization.jsonObject()" creates contains foundation types. (NSNumber, NSString...)
Since "jsonObject" isn't Encodable, they can't converted to string by old logic.
So I added JSONSerialization.data() to convert them to string. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
