### PR TITLE
Add forced sync when switching to realtime mode

### DIFF
--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -478,7 +478,8 @@ public actor Client {
             // NOTE(hackerwins): In manual mode, the client does not receive change events
             // from the server. Therefore, we need to set `remoteChangeEventReceived` to true
             // to sync the local and remote changes. This has limitations in that unnecessary
-            // syncs occur if the client and server do not have any changes.            self.attachmentMap[docKey]?.remoteChangeEventReceived = true
+            // syncs occur if the client and server do not have any changes.
+            self.attachmentMap[docKey]?.remoteChangeEventReceived = true
             try self.runWatchLoop(docKey)
         } else {
             try self.stopWatchLoop(docKey)

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -475,13 +475,10 @@ public actor Client {
         self.attachmentMap[docKey]?.isRealtimeSync = isRealtimeSync
 
         if isRealtimeSync {
-            // NOTE(chacha912): When re-establishing real-time sync, there might have been
-            // changes while the connection was off. Therefore, syncing needs to be performed
-            // once. Currently, if syncing is called here, it overlaps with `syncInternal`,
-            // causing the issue of the response being applied twice. (Ref: issues#603)
-            // Therefore, we set `remoteChangeEventReceived` to true, allowing syncing to
-            // occur in `syncInternal`.
-            self.attachmentMap[docKey]?.remoteChangeEventReceived = true
+            // NOTE(hackerwins): In manual mode, the client does not receive change events
+            // from the server. Therefore, we need to set `remoteChangeEventReceived` to true
+            // to sync the local and remote changes. This has limitations in that unnecessary
+            // syncs occur if the client and server do not have any changes.            self.attachmentMap[docKey]?.remoteChangeEventReceived = true
             try self.runWatchLoop(docKey)
         } else {
             try self.stopWatchLoop(docKey)

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -475,6 +475,13 @@ public actor Client {
         self.attachmentMap[docKey]?.isRealtimeSync = isRealtimeSync
 
         if isRealtimeSync {
+            // NOTE(chacha912): When re-establishing real-time sync, there might have been
+            // changes while the connection was off. Therefore, syncing needs to be performed
+            // once. Currently, if syncing is called here, it overlaps with `syncInternal`,
+            // causing the issue of the response being applied twice. (Ref: issues#603)
+            // Therefore, we set `remoteChangeEventReceived` to true, allowing syncing to
+            // occur in `syncInternal`.
+            self.attachmentMap[docKey]?.remoteChangeEventReceived = true
             try self.runWatchLoop(docKey)
         } else {
             try self.stopWatchLoop(docKey)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Previously, when using `resume`, remote changes made during the `pause` were not being applied. After resuming, if there have been any local or remote changes, a sync is triggered, and previous changes are applied.
This PR addresses this issue by triggering a sync during `resume`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
