### PR TITLE
Add missing removedAt during Primitive deepcopy

### DIFF
--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -167,6 +167,7 @@ extension Primitive {
     func deepcopy() -> CRDTElement {
         let primitive = Primitive(value: self.value, createdAt: self.createdAt)
         primitive.setMovedAt(self.movedAt)
+        primitive.removedAt = self.removedAt
         return primitive
     }
 }

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -128,7 +128,7 @@ public class JSONObject {
         self.setToCRDTObject(key: key, value: primitive)
 
         let operation = SetOperation(key: key,
-                                     value: primitive,
+                                     value: primitive.deepcopy(),
                                      parentCreatedAt: self.target.createdAt,
                                      executedAt: ticket)
         self.context.push(operation: operation)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When performing a Primitive deepcopy, the absence of removedAt led to a problem where deleted elements reappeared. This PR addresses the issue by making sure that removedAt is included in the primitive deepcopy.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
