### PR TITLE
Fix invalid TreeChanges in concurrent Tree.Style

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,13 +19,13 @@ disabled_rules:
   - opening_brace
   - large_tuple
   - todo
-  - function_body_length
 opt_in_rules:
   - empty_count
 # Rewrited rules
 cyclomatic_complexity: 
   warning: 25
-function_body_length: 100
+  error: 30
+function_body_length: 110
 type_body_length: 1000
 identifier_name:
   min_length: 2

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -584,16 +584,6 @@ class CRDTTree: CRDTGCElement {
             value = .attributes(attributes)
         }
 
-        try changes.append(TreeChange(actor: actorID,
-                                      type: .style,
-                                      from: self.toIndex(fromParent, fromLeft),
-                                      to: self.toIndex(toParent, toLeft),
-                                      fromPath: self.toPath(fromParent, fromLeft),
-                                      toPath: self.toPath(toParent, toLeft),
-                                      value: value,
-                                      splitLevel: 0) // dummy value.
-        )
-
         try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { token, _ in
             let (node, _) = token
             if node.isRemoved == false, node.isText == false, let attributes {
@@ -603,6 +593,16 @@ class CRDTTree: CRDTGCElement {
                 for (key, value) in attributes {
                     node.attrs?.set(key: key, value: value, executedAt: editedAt)
                 }
+
+                try changes.append(TreeChange(actor: actorID,
+                                              type: .style,
+                                              from: self.toIndex(fromParent, fromLeft),
+                                              to: self.toIndex(toParent, toLeft),
+                                              fromPath: self.toPath(fromParent, fromLeft),
+                                              toPath: self.toPath(toParent, toLeft),
+                                              value: value,
+                                              splitLevel: 0) // dummy value.
+                )
             }
         }
 

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -414,7 +414,7 @@ public class JSONTree {
      * `editByPath` edits this tree with the given node and path.
      */
     @discardableResult
-    public func editByPath(_ fromPath: [Int], _ toPath: [Int], _ content: (any JSONTreeNode)?, _ splitLevel: Int32 = 0) throws -> Bool {
+    public func editByPath(_ fromPath: [Int], _ toPath: [Int], _ content: (any JSONTreeNode)? = nil, _ splitLevel: Int32 = 0) throws -> Bool {
         try self.editBulkByPath(fromPath, toPath, content != nil ? [content!] : nil, splitLevel)
     }
 
@@ -422,7 +422,7 @@ public class JSONTree {
      * `editBulkByPath` edits this tree with the given node and path.
      */
     @discardableResult
-    public func editBulkByPath(_ fromPath: [Int], _ toPath: [Int], _ contents: [any JSONTreeNode]?, _ splitLevel: Int32 = 0) throws -> Bool {
+    public func editBulkByPath(_ fromPath: [Int], _ toPath: [Int], _ contents: [any JSONTreeNode]? = nil, _ splitLevel: Int32 = 0) throws -> Bool {
         guard let tree else {
             throw YorkieError.unexpected(message: "it is not initialized yet")
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix invalid `TreeChange`s in concurrent `Tree.Style`

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie-android-sdk/pull/149


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
