### PR TITLE
Fix incorrect calculation in indexTree.treePosToPath operation

### DIFF
--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -220,10 +220,10 @@ extension IndexTreeNode {
     }
 
     /**
-     * `hasTextChild` returns true if the node has an text child.
+     * `hasTextChild` returns true if the node's children consist of only text children.
      */
     var hasTextChild: Bool {
-        self.children.first { $0.isText } != nil
+        !self.children.isEmpty && !self.children.contains { !$0.isText }
     }
 
     /**
@@ -778,8 +778,13 @@ class IndexTree<T: IndexTreeNode> {
             }
 
             let sizeOfLeftSiblings = addSizeOfLeftSiblings(parent: node.parent!, offset: offset)
-            node = node.parent!
             path.append(sizeOfLeftSiblings + Int(treePos.offset))
+            node = node.parent!
+        } else if node.hasTextChild {
+            // TODO(hackerwins): The function does not consider the situation
+            // where Element and Text nodes are mixed in the Element's Children.
+            let sizeOfLeftSiblings = addSizeOfLeftSiblings(parent: node, offset: Int(treePos.offset))
+            path.append(sizeOfLeftSiblings)
         } else {
             path.append(Int(treePos.offset))
         }

--- a/Tests/Integration/IntegrationHelper.swift
+++ b/Tests/Integration/IntegrationHelper.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Foundation
+import XCTest
 @testable import Yorkie
 
 func withTwoClientsAndDocuments(_ title: String, _ callback: (Client, Document, Client, Document) async throws -> Void) async throws {
@@ -42,4 +42,114 @@ func withTwoClientsAndDocuments(_ title: String, _ callback: (Client, Document, 
 
     try await c1.deactivate()
     try await c2.deactivate()
+}
+
+protocol OperationInfoForDebug {}
+
+struct TreeEditOpInfoForDebug: OperationInfoForDebug {
+    let from: Int?
+    let to: Int?
+    let value: [any JSONTreeNode]?
+    let fromPath: [Int]?
+    let toPath: [Int]?
+
+    func compare(_ operation: TreeEditOpInfo) {
+        if let value = from {
+            XCTAssertEqual(value, operation.from)
+        }
+        if let value = to {
+            XCTAssertEqual(value, operation.to)
+        }
+        if let value = value {
+            XCTAssertEqual(value.count, operation.value.count)
+            if operation.value.count - 1 >= 0 {
+                for idx in 0 ... operation.value.count - 1 {
+                    if let exp = value[idx] as? JSONTreeTextNode, let oper = operation.value[idx] as? JSONTreeTextNode {
+                        XCTAssertEqual(exp, oper)
+                    } else if let exp = value[idx] as? JSONTreeElementNode, let oper = operation.value[idx] as? JSONTreeElementNode {
+                        XCTAssertEqual(exp, oper)
+                    } else {
+                        XCTAssertFalse(true)
+                    }
+                }
+            }
+        }
+        if let value = fromPath {
+            XCTAssertEqual(value, operation.fromPath)
+        }
+        if let value = toPath {
+            XCTAssertEqual(value, operation.toPath)
+        }
+    }
+}
+
+struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
+    let from: Int?
+    let to: Int?
+    let value: [String: Codable]?
+    let fromPath: [Int]?
+
+    func compare(_ operation: TreeStyleOpInfo) {
+        if let value = from {
+            XCTAssertEqual(value, operation.from)
+        }
+        if let value = to {
+            XCTAssertEqual(value, operation.to)
+        }
+        if let value = value {
+            XCTAssertEqual(value.count, operation.value.count)
+            if operation.value.count - 1 >= 0 {
+                for key in operation.value.keys {
+                    XCTAssertEqual(value[key]?.toJSONString, operation.value[key]?.toJSONString)
+                }
+            }
+        }
+        if let value = fromPath {
+            XCTAssertEqual(value, operation.fromPath)
+        }
+    }
+}
+
+func subscribeDocs(_ d1: Document, _ d2: Document, _ d1Expected: [any OperationInfoForDebug]?, _ d2Expected: [any OperationInfoForDebug]?) async {
+    var d1Operations: [any OperationInfo] = []
+    var d1Index = 0
+
+    await d1.subscribe("$.t") { event in
+        if let event = event as? LocalChangeEvent {
+            d1Operations.append(contentsOf: event.value.operations)
+        } else if let event = event as? RemoteChangeEvent {
+            d1Operations.append(contentsOf: event.value.operations)
+        }
+
+        while d1Index <= d1Operations.count - 1 {
+            if let d1Expected, let expected = d1Expected[safe: d1Index] as? TreeEditOpInfoForDebug, let operation = d1Operations[safe: d1Index] as? TreeEditOpInfo {
+                expected.compare(operation)
+            } else if let d1Expected, let expected = d1Expected[safe: d1Index] as? TreeStyleOpInfoForDebug, let operation = d1Operations[safe: d1Index] as? TreeStyleOpInfo {
+                expected.compare(operation)
+            }
+
+            d1Index += 1
+        }
+    }
+
+    var d2Operations: [any OperationInfo] = []
+    var d2Index = 0
+
+    await d2.subscribe("$.t") { event in
+        if let event = event as? LocalChangeEvent {
+            d2Operations.append(contentsOf: event.value.operations.compactMap { $0 as? TreeEditOpInfo })
+        } else if let event = event as? RemoteChangeEvent {
+            d2Operations.append(contentsOf: event.value.operations.compactMap { $0 as? TreeEditOpInfo })
+        }
+
+        while d2Index <= d2Operations.count - 1 {
+            if let d2Expected, let expected = d2Expected[safe: d2Index] as? TreeEditOpInfoForDebug, let operation = d2Operations[safe: d2Index] as? TreeEditOpInfo {
+                expected.compare(operation)
+            } else if let d2Expected, let expected = d2Expected[safe: d1Index] as? TreeStyleOpInfoForDebug, let operation = d2Operations[safe: d1Index] as? TreeStyleOpInfo {
+                expected.compare(operation)
+            }
+
+            d2Index += 1
+        }
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- https://github.com/yorkie-team/yorkie-js-sdk/pull/751
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
