### PR TITLE
Fix string style value error of Tree Node attributes 

### DIFF
--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -17,30 +17,6 @@
 import Combine
 import Foundation
 
-public typealias Attributes = Codable
-
-/**
- * `stringifyAttributes` makes values of attributes to JSON parsable string.
- */
-func stringifyAttributes(_ attributes: Attributes) -> [String: String] {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = .sortedKeys
-
-    guard let jsonData = try? encoder.encode(attributes),
-          let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: .fragmentsAllowed) as? [String: Any]
-    else {
-        return [:]
-    }
-
-    return jsonObject.mapValues {
-        if let result = try? JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]) {
-            return String(data: result, encoding: .utf8) ?? ""
-        } else {
-            return ""
-        }
-    }
-}
-
 class TextChange {
     /**
      * `TextChangeType` is the type of TextChange.
@@ -55,9 +31,9 @@ class TextChange {
     public let from: Int
     public let to: Int
     public var content: String?
-    public var attributes: Attributes?
+    public var attributes: Codable?
 
-    init(type: TextChangeType, actor: ActorID, from: Int, to: Int, content: String? = nil, attributes: Attributes? = nil) {
+    init(type: TextChangeType, actor: ActorID, from: Int, to: Int, content: String? = nil, attributes: Codable? = nil) {
         self.type = type
         self.actor = actor
         self.from = from
@@ -160,7 +136,7 @@ public final class TextValue: RGATreeSplitValue, CustomStringConvertible {
 }
 
 final class CRDTText: CRDTGCElement {
-    public typealias TextVal = (attributes: Attributes, content: String)
+    public typealias TextVal = (attributes: Codable, content: String)
 
     var createdAt: TimeTicket
     var movedAt: TimeTicket?

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -416,11 +416,7 @@ final class CRDTTreeNode: IndexTreeNode {
         if let attrs = node.attrs?.toObject() {
             for key in attrs.keys.sorted() {
                 if let value = attrs[key]?.value {
-                    if value.first == "\"", value.last == "\"" {
-                        xml += " \(key)=\(value)"
-                    } else {
-                        xml += " \(key)=\"\(value)\""
-                    }
+                    xml += " \(key)=\(value)"
                 }
             }
         }

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -61,7 +61,7 @@ public class JSONText {
      * `edit` edits this text with the given content.
      */
     @discardableResult
-    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Attributes? = nil) -> (Int, Int)? {
+    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) -> (Int, Int)? {
         guard let context, let text else {
             Logger.critical("it is not initialized yet")
             return nil
@@ -83,7 +83,7 @@ public class JSONText {
 
         var attrs: [String: String]?
         if let attributes {
-            attrs = stringifyAttributes(attributes)
+            attrs = StringValueTypeDictionary.stringifyAttributes(attributes)
         }
 
         guard let (maxCreatedAtMapByActor, _, rangeAfterEdit) = try? text.edit(range, content, ticket, attrs) else {
@@ -97,7 +97,7 @@ public class JSONText {
                                      toPos: range.1,
                                      maxCreatedAtMapByActor: maxCreatedAtMapByActor,
                                      content: content,
-                                     attributes: attributes != nil ? stringifyAttributes(attributes!) : nil,
+                                     attributes: attrs,
                                      executedAt: ticket)
         )
 
@@ -128,7 +128,7 @@ public class JSONText {
      * `setStyle` styles this text with the given attributes.
      */
     @discardableResult
-    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Attributes) -> Bool {
+    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) -> Bool {
         guard let context, let text else {
             Logger.critical("it is not initialized yet")
             return false
@@ -148,7 +148,7 @@ public class JSONText {
 
         let ticket = context.issueTimeTicket
         let maxCreatedAtMapByActor: [String: TimeTicket]
-        let stringAttrs = stringifyAttributes(attributes)
+        let stringAttrs = StringValueTypeDictionary.stringifyAttributes(attributes)
         do {
             (maxCreatedAtMapByActor, _) = try text.setStyle(range, stringAttrs, ticket)
         } catch {

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -61,7 +61,7 @@ public class JSONText {
      * `edit` edits this text with the given content.
      */
     @discardableResult
-    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: TextAttributes? = nil) -> (Int, Int)? {
+    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Attributes? = nil) -> (Int, Int)? {
         guard let context, let text else {
             Logger.critical("it is not initialized yet")
             return nil
@@ -128,7 +128,7 @@ public class JSONText {
      * `setStyle` styles this text with the given attributes.
      */
     @discardableResult
-    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: TextAttributes) -> Bool {
+    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Attributes) -> Bool {
         guard let context, let text else {
             Logger.critical("it is not initialized yet")
             return false
@@ -148,8 +148,9 @@ public class JSONText {
 
         let ticket = context.issueTimeTicket
         let maxCreatedAtMapByActor: [String: TimeTicket]
+        let stringAttrs = stringifyAttributes(attributes)
         do {
-            (maxCreatedAtMapByActor, _) = try text.setStyle(range, attributes, ticket)
+            (maxCreatedAtMapByActor, _) = try text.setStyle(range, stringAttrs, ticket)
         } catch {
             Logger.critical("can't set Style")
             return false
@@ -159,7 +160,7 @@ public class JSONText {
                                                fromPos: range.0,
                                                toPos: range.1,
                                                maxCreatedAtMapByActor: maxCreatedAtMapByActor,
-                                               attributes: stringifyAttributes(attributes),
+                                               attributes: stringAttrs,
                                                executedAt: ticket))
 
         return true

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -89,7 +89,7 @@ public struct JSONTreeElementNode: JSONTreeNode {
 
     public init(type: TreeNodeType, children: [any JSONTreeNode] = [], attributes: Codable) {
         self.type = type
-        self.attributes = stringifyAttributes(attributes)
+        self.attributes = StringValueTypeDictionary.stringifyAttributes(attributes)
         self.children = children
     }
 
@@ -302,8 +302,8 @@ public class JSONTree {
         return tree.indexTree
     }
 
-    public func styleByPath(_ path: [Int], _ attributes: Attributes) throws {
-        try self.styleByPathInternal(path, stringifyAttributes(attributes))
+    public func styleByPath(_ path: [Int], _ attributes: Codable) throws {
+        try self.styleByPathInternal(path, StringValueTypeDictionary.stringifyAttributes(attributes))
     }
 
     public func styleByPath(_ path: [Int], _ attributes: [String: Any]) throws {
@@ -339,8 +339,8 @@ public class JSONTree {
     /**
      * `style` sets the attributes to the elements of the given range.
      */
-    public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: Attributes) throws {
-        try self.styleInternal(fromIdx, toIdx, stringifyAttributes(attributes))
+    public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) throws {
+        try self.styleInternal(fromIdx, toIdx, StringValueTypeDictionary.stringifyAttributes(attributes))
     }
 
     public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: [String: Any]) throws {

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -302,10 +302,18 @@ public class JSONTree {
         return tree.indexTree
     }
 
+    public func styleByPath(_ path: [Int], _ attributes: Attributes) throws {
+        try self.styleByPathInternal(path, stringifyAttributes(attributes))
+    }
+
+    public func styleByPath(_ path: [Int], _ attributes: [String: Any]) throws {
+        try self.styleByPathInternal(path, attributes.stringValueTypeDictionary)
+    }
+
     /**
      * `styleByPath` sets the attributes to the elements of the given path.
      */
-    public func styleByPath(_ path: [Int], _ attributes: Attributes) throws {
+    public func styleByPathInternal(_ path: [Int], _ stringAttrs: [String: String]) throws {
         guard let context, let tree else {
             throw YorkieError.unexpected(message: "it is not initialized yet")
         }
@@ -316,8 +324,6 @@ public class JSONTree {
 
         let (fromPos, toPos) = try tree.pathToPosRange(path)
         let ticket = context.issueTimeTicket
-
-        let stringAttrs = stringifyAttributes(attributes)
 
         try tree.style((fromPos, toPos), stringAttrs, ticket)
 

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -111,7 +111,7 @@ public struct JSONTreeElementNode: JSONTreeNode {
                     if object is [String: Any] {
                         return "\(key.toJSONString):\(value)"
                     } else {
-                        return "\(key.toJSONString):\(convertJSONString(object))"
+                        return "\(key.toJSONString):\(convertToJSONString(object))"
                     }
                 } else {
                     return "\(key.toJSONString):null"

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -36,14 +36,13 @@ extension CRDTTreeNode {
         if self.isText {
             return JSONTreeTextNode(value: self.value)
         } else {
-            var attrs = [String: String]()
+            var attrs = [String: Any]()
             self.attrs?.forEach {
-                attrs[$0.key] = $0.value
+                attrs[$0.key] = $0.value.toJSONObject
             }
 
             return JSONTreeElementNode(type: self.type,
-                                       attributes: attrs.toJSONObejct,
-                                       children: self.children.compactMap { $0.toJSONTreeNode })
+                                       children: self.children.compactMap { $0.toJSONTreeNode }, attributes: attrs)
         }
     }
 }
@@ -53,7 +52,7 @@ extension CRDTTreeNode {
  */
 public struct JSONTreeElementNode: JSONTreeNode {
     public let type: TreeNodeType
-    public let attributes: [String: Any?]
+    public let attributes: [String: String]
     public let children: [any JSONTreeNode]
 
     public static func == (lhs: JSONTreeElementNode, rhs: JSONTreeElementNode) -> Bool {
@@ -82,9 +81,15 @@ public struct JSONTreeElementNode: JSONTreeNode {
         return true
     }
 
-    public init(type: TreeNodeType, attributes: [String: Any?] = [:], children: [any JSONTreeNode] = []) {
+    public init(type: TreeNodeType, children: [any JSONTreeNode] = [], attributes: [String: Any] = [:]) {
         self.type = type
-        self.attributes = attributes
+        self.attributes = attributes.stringValueTypeDictionary
+        self.children = children
+    }
+
+    public init(type: TreeNodeType, children: [any JSONTreeNode] = [], attributes: Codable) {
+        self.type = type
+        self.attributes = stringifyAttributes(attributes)
         self.children = children
     }
 
@@ -100,20 +105,14 @@ public struct JSONTreeElementNode: JSONTreeNode {
             let sortedKeys = self.attributes.keys.sorted()
 
             let attrsString = sortedKeys.compactMap { key in
-                if let attrs = attributes[key] as? Encodable, let value = attrs.toJSONString {
-                    return "\(key.toJSONString):\(value)"
-                } else if let value = attributes[key] as? Any, JSONSerialization.isValidJSONObject(value),
-                          let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys, .withoutEscapingSlashes])
-                {
-                    return "\(key.toJSONString):\(String(data: data, encoding: .utf8) ?? "null")"
-                } else if let value = attributes[key] as? Int {
-                    return "\(key.toJSONString):\(value)"
-                } else if let value = attributes[key] as? Double {
-                    return "\(key.toJSONString):\(value)"
-                } else if let value = attributes[key] as? Bool {
-                    return "\(key.toJSONString):\(value)"
-                } else if let value = attributes[key] as? String {
-                    return "\(key.toJSONString):\(value.toJSONString)"
+                if let value = self.attributes[key] {
+                    let object = value.toJSONObject
+
+                    if object is [String: Any] {
+                        return "\(key.toJSONString):\(value)"
+                    } else {
+                        return "\(key.toJSONString):\(convertJSONString(object))"
+                    }
                 } else {
                     return "\(key.toJSONString):null"
                 }
@@ -159,7 +158,7 @@ func buildDescendants(treeNode: any JSONTreeNode, parent: CRDTTreeNode, context:
     } else if let node = treeNode as? JSONTreeElementNode {
         let attrs = RHT()
 
-        for (key, value) in node.attributes.stringValueTypeDictionary {
+        for (key, value) in node.attributes {
             attrs.set(key: key, value: value, executedAt: ticket)
         }
 
@@ -187,7 +186,7 @@ func createCRDTTreeNode(context: ChangeContext, content: any JSONTreeNode) throw
     } else if let node = content as? JSONTreeElementNode {
         let attrs = RHT()
 
-        for (key, value) in node.attributes.stringValueTypeDictionary {
+        for (key, value) in node.attributes {
             attrs.set(key: key, value: value, executedAt: ticket)
         }
 
@@ -306,7 +305,7 @@ public class JSONTree {
     /**
      * `styleByPath` sets the attributes to the elements of the given path.
      */
-    public func styleByPath(_ path: [Int], _ attributes: [String: Any?]) throws {
+    public func styleByPath(_ path: [Int], _ attributes: Attributes) throws {
         guard let context, let tree else {
             throw YorkieError.unexpected(message: "it is not initialized yet")
         }
@@ -318,7 +317,7 @@ public class JSONTree {
         let (fromPos, toPos) = try tree.pathToPosRange(path)
         let ticket = context.issueTimeTicket
 
-        let stringAttrs = attributes.stringValueTypeDictionary
+        let stringAttrs = stringifyAttributes(attributes)
 
         try tree.style((fromPos, toPos), stringAttrs, ticket)
 
@@ -334,7 +333,15 @@ public class JSONTree {
     /**
      * `style` sets the attributes to the elements of the given range.
      */
-    public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: [String: Any?]) throws {
+    public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: Attributes) throws {
+        try self.styleInternal(fromIdx, toIdx, stringifyAttributes(attributes))
+    }
+
+    public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: [String: Any]) throws {
+        try self.styleInternal(fromIdx, toIdx, attributes.stringValueTypeDictionary)
+    }
+
+    func styleInternal(_ fromIdx: Int, _ toIdx: Int, _ stringAttrs: [String: String]) throws {
         guard let context, let tree else {
             throw YorkieError.unexpected(message: "it is not initialized yet")
         }
@@ -346,8 +353,6 @@ public class JSONTree {
         let fromPos = try tree.findPos(fromIdx)
         let toPos = try tree.findPos(toIdx)
         let ticket = context.issueTimeTicket
-
-        let stringAttrs = attributes.stringValueTypeDictionary
 
         try tree.style((fromPos, toPos), stringAttrs, ticket)
 

--- a/Sources/Document/Operation/Operation.swift
+++ b/Sources/Document/Operation/Operation.swift
@@ -189,7 +189,7 @@ public struct TreeStyleOpInfo: OperationInfo {
     public let from: Int
     public let to: Int
     public let fromPath: [Int]
-    public let value: [String: Codable]
+    public let value: [String: Any]
 
     public static func == (lhs: TreeStyleOpInfo, rhs: TreeStyleOpInfo) -> Bool {
         if lhs.type != rhs.type {

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -67,9 +67,9 @@ class TreeStyleOperation: Operation {
         }
 
         return changes.compactMap { change in
-            let attributes: [String: Codable] = {
+            let attributes: [String: Any] = {
                 if case .attributes(let attributes) = change.value {
-                    return attributes
+                    return attributes.toJSONObejct
                 } else {
                     return [:]
                 }

--- a/Sources/Util/Dictionary+Extension.swift
+++ b/Sources/Util/Dictionary+Extension.swift
@@ -64,4 +64,26 @@ extension StringValueTypeDictionary {
     var toJSONObejct: [String: Any] {
         self.compactMapValues { $0.toJSONObject }
     }
+
+    /**
+     * `stringifyAttributes` makes values of attributes to JSON parsable string.
+     */
+    static func stringifyAttributes(_ attributes: Codable) -> [String: String] {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        guard let jsonData = try? encoder.encode(attributes),
+              let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: .fragmentsAllowed) as? [String: Any]
+        else {
+            return [:]
+        }
+
+        return jsonObject.mapValues {
+            if let result = try? JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]) {
+                return String(data: result, encoding: .utf8) ?? ""
+            } else {
+                return ""
+            }
+        }
+    }
 }

--- a/Sources/Util/Dictionary+Extension.swift
+++ b/Sources/Util/Dictionary+Extension.swift
@@ -46,7 +46,7 @@ extension AnyValueTypeDictionary {
             {
                 convertedDictionary[key] = stringValue
             } else {
-                convertedDictionary[key] = "null"
+                convertedDictionary[key] = convertToJSONString(value)
             }
         }
 

--- a/Sources/Util/Dictionary+Extension.swift
+++ b/Sources/Util/Dictionary+Extension.swift
@@ -16,39 +16,35 @@
 
 import Foundation
 
-typealias AnyValueTypeDictionary = [String: Any?]
+typealias AnyValueTypeDictionary = [String: Any]
 
 extension AnyValueTypeDictionary {
     var stringValueTypeDictionary: [String: String] {
         self.convertToDictionaryStringValues(self)
     }
 
-    func convertToDictionaryStringValues(_ dictionary: [String: Any?]) -> [String: String] {
+    func convertToDictionaryStringValues(_ dictionary: [String: Any]) -> [String: String] {
         var convertedDictionary: [String: String] = [:]
 
         for (key, value) in dictionary {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+
             if let value = value as? Encodable,
-               let jsonData = try? JSONEncoder().encode(value),
+               let jsonData = try? encoder.encode(value),
                let stringValue = String(data: jsonData, encoding: .utf8)
             {
                 convertedDictionary[key] = stringValue
             } else if let value = value as? [String: Any],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
+                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
                       let stringValue = String(data: jsonData, encoding: .utf8)
             {
                 convertedDictionary[key] = stringValue
             } else if let value = value as? [[String: Any]],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
+                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
                       let stringValue = String(data: jsonData, encoding: .utf8)
             {
                 convertedDictionary[key] = stringValue
-            } else if let value {
-                if value is String {
-                    convertedDictionary[key] = String("\"\(value)\"")
-                } else {
-                    convertedDictionary[key] = String("\(value)")
-                }
-                print("Warning: non-encodable value for key '\(key)': \(value)")
             } else {
                 convertedDictionary[key] = "null"
             }

--- a/Sources/Util/Dictionary+Extension.swift
+++ b/Sources/Util/Dictionary+Extension.swift
@@ -27,27 +27,7 @@ extension AnyValueTypeDictionary {
         var convertedDictionary: [String: String] = [:]
 
         for (key, value) in dictionary {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-
-            if let value = value as? Encodable,
-               let jsonData = try? encoder.encode(value),
-               let stringValue = String(data: jsonData, encoding: .utf8)
-            {
-                convertedDictionary[key] = stringValue
-            } else if let value = value as? [String: Any],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
-                      let stringValue = String(data: jsonData, encoding: .utf8)
-            {
-                convertedDictionary[key] = stringValue
-            } else if let value = value as? [[String: Any]],
-                      let jsonData = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
-                      let stringValue = String(data: jsonData, encoding: .utf8)
-            {
-                convertedDictionary[key] = stringValue
-            } else {
-                convertedDictionary[key] = convertToJSONString(value)
-            }
+            convertedDictionary[key] = convertToJSONString(value)
         }
 
         return convertedDictionary
@@ -81,28 +61,6 @@ extension AnyValueTypeDictionary {
 typealias StringValueTypeDictionary = [String: String]
 
 extension StringValueTypeDictionary {
-    var anyValueTypeDictionary: AnyValueTypeDictionary {
-        var result = AnyValueTypeDictionary()
-
-        for item in self {
-            if let value = Int(item.value) {
-                result[item.key] = value
-            } else if let value = Double(item.value) {
-                result[item.key] = value
-            } else if let value = Bool(item.value) {
-                result[item.key] = value
-            } else if let data = item.value.data(using: .utf8),
-                      let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-            {
-                result[item.key] = object
-            } else {
-                result[item.key] = item.value
-            }
-        }
-
-        return result
-    }
-
     var toJSONObejct: [String: Any] {
         self.compactMapValues { $0.toJSONObject }
     }

--- a/Sources/Util/String+Extensions.swift
+++ b/Sources/Util/String+Extensions.swift
@@ -47,12 +47,15 @@ extension String {
     }
 
     var toJSONString: String {
-        if let jsonData = try? JSONSerialization.data(withJSONObject: self, options: [.fragmentsAllowed, .withoutEscapingSlashes]),
-           let escapedValue = String(bytes: jsonData, encoding: .utf8)
-        {
-            return escapedValue
-        }
-
-        return ""
+        convertJSONString(self)
     }
+}
+
+func convertJSONString(_ data: Any) -> String {
+    if let jsonData = try? JSONSerialization.data(withJSONObject: data, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
+       let escapedValue = String(bytes: jsonData, encoding: .utf8)
+    {
+        return escapedValue
+    }
+    return ""
 }

--- a/Sources/Util/String+Extensions.swift
+++ b/Sources/Util/String+Extensions.swift
@@ -47,15 +47,15 @@ extension String {
     }
 
     var toJSONString: String {
-        convertJSONString(self)
+        convertToJSONString(self)
     }
 }
 
-func convertJSONString(_ data: Any) -> String {
+func convertToJSONString(_ data: Any) -> String {
     if let jsonData = try? JSONSerialization.data(withJSONObject: data, options: [.fragmentsAllowed, .withoutEscapingSlashes, .sortedKeys]),
        let escapedValue = String(bytes: jsonData, encoding: .utf8)
     {
         return escapedValue
     }
-    return ""
+    return "null"
 }

--- a/Tests/Integration/IntegrationHelper.swift
+++ b/Tests/Integration/IntegrationHelper.swift
@@ -100,7 +100,7 @@ struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
             XCTAssertEqual(value.count, operation.value.count)
             if operation.value.count - 1 >= 0 {
                 for key in operation.value.keys {
-                    XCTAssertEqual(value[key]?.toJSONString, convertToJSONString(operation.value[key] as Any))
+                    XCTAssertEqual(value[key]?.toJSONString, convertToJSONString(operation.value[key] ?? NSNull()))
                 }
             }
         }

--- a/Tests/Integration/IntegrationHelper.swift
+++ b/Tests/Integration/IntegrationHelper.swift
@@ -100,7 +100,7 @@ struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
             XCTAssertEqual(value.count, operation.value.count)
             if operation.value.count - 1 >= 0 {
                 for key in operation.value.keys {
-                    XCTAssertEqual(value[key]?.toJSONString, operation.value[key]?.toJSONString)
+                    XCTAssertEqual(value[key]?.toJSONString, convertJSONString(operation.value[key] as Any))
                 }
             }
         }

--- a/Tests/Integration/IntegrationHelper.swift
+++ b/Tests/Integration/IntegrationHelper.swift
@@ -100,7 +100,7 @@ struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
             XCTAssertEqual(value.count, operation.value.count)
             if operation.value.count - 1 >= 0 {
                 for key in operation.value.keys {
-                    XCTAssertEqual(value[key]?.toJSONString, convertJSONString(operation.value[key] as Any))
+                    XCTAssertEqual(value[key]?.toJSONString, convertToJSONString(operation.value[key] as Any))
                 }
             }
         }

--- a/Tests/Integration/TreeIntegrationTests.swift
+++ b/Tests/Integration/TreeIntegrationTests.swift
@@ -887,13 +887,15 @@ final class TreeIntegrationStyleTests: XCTestCase {
             try (root.t as? JSONTree)?.style(2, 3, ["c": "d", "z": 3, "b": false])
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn b=false c=\"d\" z=3></tn></p></tc></doc>")
 
-            struct styles: Codable {
+            // swiftlint: disable identifier_name
+            struct Styles: Codable {
                 let c: String
                 let z: Int
                 let b: Bool
             }
+            // swiftlint: enable identifier_name
 
-            try (root.t as? JSONTree)?.style(2, 3, styles(c: "d", z: 3, b: false))
+            try (root.t as? JSONTree)?.style(2, 3, Styles(c: "d", z: 3, b: false))
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn b=false c=\"d\" z=3></tn></p></tc></doc>")
         }
     }

--- a/Tests/Integration/TreeIntegrationTests.swift
+++ b/Tests/Integration/TreeIntegrationTests.swift
@@ -135,12 +135,11 @@ final class TreeIntegrationTests: XCTestCase {
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "p",
                                                                    children: [
-                                                                       JSONTreeElementNode(type: "span", attributes: ["bold": true],
-                                                                                           children: [JSONTreeTextNode(value: "hello")])
+                                                                       JSONTreeElementNode(type: "span", children: [JSONTreeTextNode(value: "hello")], attributes: ["bold": true])
                                                                    ])])
             )
 
-            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><p><span bold=\"true\">hello</span></p></doc>")
+            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><p><span bold=true>hello</span></p></doc>")
         }
     }
 
@@ -855,14 +854,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "p",
                                                                    children: [JSONTreeElementNode(type: "span",
-                                                                                                  attributes: ["bold": "true"],
-                                                                                                  children: [JSONTreeTextNode(value: "hello")])])])
+                                                                                                  children: [JSONTreeTextNode(value: "hello")], attributes: ["bold": true])])])
             )
         }
 
         let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
 
-        XCTAssertEqual(docXML, /* html */ "<doc><p><span bold=\"true\">hello</span></p></doc>")
+        XCTAssertEqual(docXML, /* html */ "<doc><p><span bold=true>hello</span></p></doc>")
     }
 
     func test_can_be_edited_with_index() async throws {
@@ -874,9 +872,8 @@ final class TreeIntegrationStyleTests: XCTestCase {
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "tc",
                                                                    children: [JSONTreeElementNode(type: "p",
-                                                                                                  attributes: ["a": "b"],
                                                                                                   children: [JSONTreeElementNode(type: "tn",
-                                                                                                                                 children: [])])])])
+                                                                                                                                 children: [])], attributes: ["a": "b"])])])
             )
 
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\"><tn></tn></p></tc></doc>")
@@ -887,14 +884,17 @@ final class TreeIntegrationStyleTests: XCTestCase {
             try (root.t as? JSONTree)?.style(1, 2, ["c": "q"])
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn></tn></p></tc></doc>")
 
-            try (root.t as? JSONTree)?.style(2, 3, ["z": "m"])
-            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn z=\"m\"></tn></p></tc></doc>")
+            try (root.t as? JSONTree)?.style(2, 3, ["c": "d", "z": 3, "b": false])
+            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn b=false c=\"d\" z=3></tn></p></tc></doc>")
 
-            try (root.t as? JSONTree)?.style(2, 3, ["z": 3])
-            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn z=\"3\"></tn></p></tc></doc>")
+            struct styles: Codable {
+                let c: String
+                let z: Int
+                let b: Bool
+            }
 
-            try (root.t as? JSONTree)?.style(2, 3, ["z": nil])
-            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn z=\"null\"></tn></p></tc></doc>")
+            try (root.t as? JSONTree)?.style(2, 3, styles(c: "d", z: 3, b: false))
+            XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\" c=\"q\"><tn b=false c=\"d\" z=3></tn></p></tc></doc>")
         }
     }
 
@@ -907,9 +907,8 @@ final class TreeIntegrationStyleTests: XCTestCase {
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "tc",
                                                                    children: [JSONTreeElementNode(type: "p",
-                                                                                                  attributes: ["a": "b"],
                                                                                                   children: [JSONTreeElementNode(type: "tn",
-                                                                                                                                 children: [])])])])
+                                                                                                                                 children: [])], attributes: ["a": "b"])])])
             )
 
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p a=\"b\"><tn></tn></p></tc></doc>")
@@ -933,8 +932,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [JSONTreeElementNode(type: "p",
-                                                                       attributes: ["italic": "true"],
-                                                                       children: [JSONTreeTextNode(value: "hello")])])
+                                                                       children: [JSONTreeTextNode(value: "hello")], attributes: ["italic": "true"])])
                 )
             }
 
@@ -3509,8 +3507,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: DefaultTreeNodeType.root.rawValue,
                                         children: [
-                                            JSONTreeElementNode(type: "t", attributes: ["id": "1", "value": "init"], children: []),
-                                            JSONTreeElementNode(type: "t", attributes: ["id": "2", "value": "init"], children: [])
+                                            JSONTreeElementNode(type: "t", attributes: ["id": "1", "value": "init"]),
+                                            JSONTreeElementNode(type: "t", children: [], attributes: ["id": "2", "value": "init"])
                                         ])
                 )
             }
@@ -3523,7 +3521,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
 
             await subscribeDocs(d1,
                                 d2,
-                                [TreeStyleOpInfoForDebug(from: 0, to: 1, value: ["value": "\"changed\""], fromPath: nil),
+                                [TreeStyleOpInfoForDebug(from: 0, to: 1, value: ["value": "changed"], fromPath: nil),
                                  TreeEditOpInfoForDebug(from: 0, to: 2, value: nil, fromPath: nil, toPath: nil)],
                                 [TreeEditOpInfoForDebug(from: 0, to: 2, value: nil, fromPath: nil, toPath: nil)])
 

--- a/Tests/Unit/Document/JONSTreeTests.swift
+++ b/Tests/Unit/Document/JONSTreeTests.swift
@@ -24,16 +24,15 @@ final class JONSTreeTests: XCTestCase {
         XCTAssertEqual(textNode.toJSONString, "{\"type\":\"text\",\"value\":\"X\"}")
 
         let elementNode = JSONTreeElementNode(type: "doc",
-                                              attributes: [
+                                              children: [
+                                                  JSONTreeElementNode(type: "p"),
+                                                  JSONTreeTextNode(value: "Y")
+                                              ], attributes: [
                                                   "intValue": 100,
                                                   "doubleValue": 10.5,
                                                   "boolean": true,
                                                   "string": "testString",
                                                   "point": ["x": 100, "y": 200]
-                                              ],
-                                              children: [
-                                                  JSONTreeElementNode(type: "p"),
-                                                  JSONTreeTextNode(value: "Y")
                                               ])
 
         XCTAssertEqual(elementNode.toJSONString, "{\"type\":\"doc\",\"children\":[{\"type\":\"p\",\"children\":[]},{\"type\":\"text\",\"value\":\"Y\"}],\"attributes\":{\"boolean\":true,\"doubleValue\":10.5,\"intValue\":100,\"point\":{\"x\":100,\"y\":200},\"string\":\"testString\"}}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Fix incorrect string value return of Tree Node style operation. (eg. "text" is returned as "\"text\"") 
- Refactor attribute managing logics.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
