### PR TITLE
Prevent remote-change events from occurring in push-only mode

### DIFF
--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -68,7 +68,7 @@ public enum SyncMode {
     case pushOnly
 }
 
-struct Attachment {
+class Attachment {
     var doc: Document
     var docID: String
     var isRealtimeSync: Bool
@@ -76,6 +76,16 @@ struct Attachment {
     var remoteChangeEventReceived: Bool
     var remoteWatchStream: GRPCAsyncServerStreamingCall<WatchDocumentRequest, WatchDocumentResponse>?
     var watchLoopReconnectTimer: Timer?
+
+    init(doc: Document, docID: String, isRealtimeSync: Bool, realtimeSyncMode: SyncMode, remoteChangeEventReceived: Bool, remoteWatchStream: GRPCAsyncServerStreamingCall<WatchDocumentRequest, WatchDocumentResponse>? = nil, watchLoopReconnectTimer: Timer? = nil) {
+        self.doc = doc
+        self.docID = docID
+        self.isRealtimeSync = isRealtimeSync
+        self.realtimeSyncMode = realtimeSyncMode
+        self.remoteChangeEventReceived = remoteChangeEventReceived
+        self.remoteWatchStream = remoteWatchStream
+        self.watchLoopReconnectTimer = watchLoopReconnectTimer
+    }
 }
 
 /**
@@ -811,7 +821,7 @@ public actor Client {
 
             // NOTE(chacha912, hackerwins): If syncLoop already executed with
             // PushPull, ignore the response when the syncMode is PushOnly.
-            if responsePack.hasChanges(), syncMode == .pushOnly {
+            if responsePack.hasChanges(), attachment.realtimeSyncMode == .pushOnly {
                 return doc
             }
 

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -429,4 +429,108 @@ final class ClientIntegrationTests: XCTestCase {
 
         XCTAssertEqual(result1, result2)
     }
+
+    // NOTE: Since sync() have to wait to finish. We can't make the situation now.
+    func disable_test_should_prevent_remote_changes_in_push_only_mode() async throws {
+        let c1 = Client(rpcAddress: rpcAddress, options: ClientOptions())
+        let c2 = Client(rpcAddress: rpcAddress, options: ClientOptions())
+
+        try await c1.activate()
+        try await c2.activate()
+
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+        try await c1.attach(d1)
+        try await c2.attach(d2)
+
+        //
+        let expect1 = expectation(description: "d2 1")
+        let expect2 = expectation(description: "d1 3")
+
+        var d1EventCount = 0
+        var d1lastEvent: DocEvent?
+        await d1.subscribe { event in
+            d1EventCount += 1
+            d1lastEvent = event
+
+            if d1EventCount == 3 {
+                expect2.fulfill()
+            }
+        }
+
+        var d2EventCount = 0
+        var d2lastEvent: DocEvent?
+        await d2.subscribe { event in
+            d2EventCount += 1
+            d2lastEvent = event
+
+            if d2EventCount == 1 {
+                expect1.fulfill()
+            }
+        }
+
+        try await d1.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "12")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "34")])
+                ]))
+        }
+
+        await fulfillment(of: [expect1], timeout: 2)
+        XCTAssert(d2lastEvent is RemoteChangeEvent)
+
+        var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+        var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+
+        XCTAssertEqual(d1XML, /* html */ "<doc><p>12</p><p>34</p></doc>")
+        XCTAssertEqual(d2XML, /* html */ "<doc><p>12</p><p>34</p></doc>")
+
+        try await d1.update { root, _ in
+            try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "a"))
+        }
+
+        try await c1.sync()
+
+        // Simulate the situation in the runSyncLoop where a pushpull request has been sent
+        // but a response has not yet been received.
+        // NOTE: Since sync() have to wait to finish. We can't make the situation now.
+        try await c2.sync()
+
+        // In push-only mode, remote-change events should not occur.
+        try await c2.pauseRemoteChanges(d2)
+        var remoteChangeOccured = false
+
+        await d2.subscribe { event in
+            if event.type == .remoteChange {
+                remoteChangeOccured = true
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 5_000_000_000)
+        await d2.unsubscribe()
+        XCTAssert(remoteChangeOccured == false)
+
+        try await c2.resumeRemoteChanges(d2)
+
+        try await d2.update { root, _ in
+            try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "b"))
+        }
+
+        await fulfillment(of: [expect2], timeout: 2)
+        XCTAssert(d1lastEvent is RemoteChangeEvent)
+
+        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+
+        XCTAssertEqual(d1XML, /* html */ "<doc><p>1ba2</p><p>34</p></doc>")
+        XCTAssertEqual(d2XML, /* html */ "<doc><p>1ba2</p><p>34</p></doc>")
+
+        await d1.unsubscribe()
+        await d2.unsubscribe()
+
+        try await c1.deactivate()
+        try await c2.deactivate()
+    }
 }

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -430,8 +430,7 @@ final class ClientIntegrationTests: XCTestCase {
         XCTAssertEqual(result1, result2)
     }
 
-    // NOTE: Since sync() have to wait to finish. We can't make the situation now.
-    func disable_test_should_prevent_remote_changes_in_push_only_mode() async throws {
+    func test_should_prevent_remote_changes_in_push_only_mode() async throws {
         let c1 = Client(rpcAddress: rpcAddress, options: ClientOptions())
         let c2 = Client(rpcAddress: rpcAddress, options: ClientOptions())
 
@@ -444,9 +443,9 @@ final class ClientIntegrationTests: XCTestCase {
         try await c1.attach(d1)
         try await c2.attach(d2)
 
-        //
         let expect1 = expectation(description: "d2 1")
         let expect2 = expectation(description: "d1 3")
+        let expect3 = expectation(description: "wait task")
 
         var d1EventCount = 0
         var d1lastEvent: DocEvent?
@@ -493,26 +492,32 @@ final class ClientIntegrationTests: XCTestCase {
 
         try await c1.sync()
 
-        // Simulate the situation in the runSyncLoop where a pushpull request has been sent
-        // but a response has not yet been received.
-        // NOTE: Since sync() have to wait to finish. We can't make the situation now.
-        try await c2.sync()
+        // The Task at below will be performed when the pushPull API sent the request and wait a response in the syncInternal().
+        Task {
+            // In push-only mode, remote-change events should not occur.
+            try await c2.pauseRemoteChanges(d2)
+            var remoteChangeOccured = false
 
-        // In push-only mode, remote-change events should not occur.
-        try await c2.pauseRemoteChanges(d2)
-        var remoteChangeOccured = false
-
-        await d2.subscribe { event in
-            if event.type == .remoteChange {
-                remoteChangeOccured = true
+            await d2.subscribe { event in
+                if event.type == .remoteChange {
+                    remoteChangeOccured = true
+                }
             }
+
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+            await d2.unsubscribe()
+            XCTAssert(remoteChangeOccured == false)
+
+            try await c2.resumeRemoteChanges(d2)
+
+            expect3.fulfill()
         }
 
-        try await Task.sleep(nanoseconds: 5_000_000_000)
-        await d2.unsubscribe()
-        XCTAssert(remoteChangeOccured == false)
+        // Simulate the situation in the runSyncLoop where a pushpull request has been sent
+        // but a response has not yet been received.
+        try await c2.sync()
 
-        try await c2.resumeRemoteChanges(d2)
+        await fulfillment(of: [expect3])
 
         try await d2.update { root, _ in
             try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "b"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  - https://github.com/yorkie-team/yorkie-js-sdk/pull/759
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
- Change the "Attachment" from struct to class to prevent copying when it is passed via function parameter.
- Since the sync() can't run without waiting, The added TC can't make an issue situation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
