### PR TITLE
Increase GRPC max Receive message length

### DIFF
--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -205,6 +205,7 @@ public actor Client {
         var gRPCLogger = Logging.Logger(label: "gRPC")
         gRPCLogger.logLevel = .info
         builder.withBackgroundActivityLogger(gRPCLogger)
+        builder.withMaximumReceiveMessageLength(Int.max)
 
         let channel = builder.connect(host: rpcAddress.host, port: rpcAddress.port)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Changed the grpc default max receive message length, which is limited to 4 MB.
- We need the transition to ConnectRPC needs 
  - https://connectrpc.com/
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the gRPC client's ability to handle larger messages by setting the maximum receive message length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->