### PR TITLE
Apply GCPair to TreeNode, TextNode

### DIFF
--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -698,7 +698,7 @@ extension Converter {
      * `fromText` converts the given Protobuf format to model format.
      */
     static func fromText(_ pbText: PbJSONElement.Text) -> CRDTText {
-        let rgaTreeSplit = RGATreeSplit<TextValue>()
+        let rgaTreeSplit = RGATreeSplit<CRDTTextValue>()
 
         var prev = rgaTreeSplit.head
         pbText.nodes.forEach { pbNode in
@@ -1012,7 +1012,7 @@ extension Converter {
     /**
      * `toTextNodes` converts the given model to Protobuf format.
      */
-    static func toTextNodes(_ rgaTreeSplit: RGATreeSplit<TextValue>) -> [PbTextNode] {
+    static func toTextNodes(_ rgaTreeSplit: RGATreeSplit<CRDTTextValue>) -> [PbTextNode] {
         var pbTextNodes = [PbTextNode]()
         for textNode in rgaTreeSplit {
             var pbTextNode = PbTextNode()
@@ -1036,8 +1036,8 @@ extension Converter {
     /**
      * `fromTextNode` converts the given Protobuf format to model format.
      */
-    static func fromTextNode(_ pbTextNode: PbTextNode) -> RGATreeSplitNode<TextValue> {
-        let textValue = TextValue(pbTextNode.value)
+    static func fromTextNode(_ pbTextNode: PbTextNode) -> RGATreeSplitNode<CRDTTextValue> {
+        let textValue = CRDTTextValue(pbTextNode.value)
         pbTextNode.attributes.forEach {
             textValue.setAttr(key: $0.key, value: $0.value.value, updatedAt: fromTimeTicket($0.value.updatedAt))
         }

--- a/Sources/Document/CRDT/CRDTElement.swift
+++ b/Sources/Document/CRDT/CRDTElement.swift
@@ -110,12 +110,3 @@ protocol CRDTContainer: CRDTElement {
 
     func getDescendants(callback: (_ element: CRDTElement, _ parent: CRDTContainer?) -> Bool)
 }
-
-/**
- * `CRDTGCElement` represents element which has garbage collecting method.
- */
-protocol CRDTGCElement: CRDTElement {
-    var removedNodesLength: Int { get }
-
-    func purgeRemovedNodesBefore(ticket: TimeTicket) -> Int
-}

--- a/Sources/Document/CRDT/GC.swift
+++ b/Sources/Document/CRDT/GC.swift
@@ -39,3 +39,7 @@ protocol GCChild: AnyObject {
     var toIDString: String { get }
     var removedAt: TimeTicket? { get }
 }
+
+protocol CRDTGCPairContainable: CRDTElement {
+    func getGCPairs() -> [GCPair]
+}

--- a/Sources/Document/CRDT/RHT.swift
+++ b/Sources/Document/CRDT/RHT.swift
@@ -224,6 +224,7 @@ class RHT {
     func purge(_ child: RHTNode) {
         let node = self.nodeMapByKey[child.key]
         if node == nil || node!.toIDString != child.toIDString {
+            // TODO(hackerwins): Should we return an error when the child is not found?
             return
         }
 

--- a/Sources/Document/Change/ChangeContext.swift
+++ b/Sources/Document/Change/ChangeContext.swift
@@ -68,14 +68,6 @@ class ChangeContext {
     }
 
     /**
-     * `registerElementHasRemovedNodes` register GC element has removed node for
-     * garbage collection.
-     */
-    func registerElementHasRemovedNodes(_ element: CRDTGCElement) {
-        self.root.registerElementHasRemovedNodes(element)
-    }
-
-    /**
      * `registerGCPair` registers the given pair to hash table.
      */
     func registerGCPair(_ pair: GCPair) {

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -433,7 +433,7 @@ public actor Document {
             """
             trying to apply \(changes.count) remote changes.
             elements:\(self.root.elementMapSize),
-            removeds:\(self.root.removedElementSetSize)
+            removeds:\(self.root.garbageElementSetSize)
             """)
 
         Logger.trace(changes.map { "\($0.id.toTestString)\t\($0.toTestString)" }.joined(separator: "\n"))
@@ -507,7 +507,7 @@ public actor Document {
             """
             after appling \(changes.count) remote changes.
             elements:\(self.root.elementMapSize),
-            removeds:\(self.root.removedElementSetSize)
+            removeds:\(self.root.garbageElementSetSize)
             """
         )
     }

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -86,9 +86,13 @@ public class JSONText {
             attrs = StringValueTypeDictionary.stringifyAttributes(attributes)
         }
 
-        guard let (maxCreatedAtMapByActor, _, rangeAfterEdit) = try? text.edit(range, content, ticket, attrs) else {
+        guard let (maxCreatedAtMapByActor, _, pairs, rangeAfterEdit) = try? text.edit(range, content, ticket, attrs) else {
             Logger.critical("can't edit Text")
             return nil
+        }
+
+        for pair in pairs {
+            self.context?.registerGCPair(pair)
         }
 
         context.push(
@@ -100,10 +104,6 @@ public class JSONText {
                                      attributes: attrs,
                                      executedAt: ticket)
         )
-
-        if range.0 != range.1 {
-            context.registerElementHasRemovedNodes(text)
-        }
 
         return try? self.text?.findIndexesFromRange(rangeAfterEdit)
     }
@@ -230,7 +230,7 @@ public class JSONText {
     /**
      * `values` returns values of this text.
      */
-    public var values: [TextValue]? {
+    public var values: [CRDTTextValue]? {
         guard self.context != nil, let text else {
             Logger.critical("it is not initialized yet")
             return nil

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -478,8 +478,12 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, maxCreatedAtMapByActor) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket) {
+        let (_, pairs, maxCreatedAtMapByActor) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket) {
             context.issueTimeTicket
+        }
+
+        for pair in pairs {
+            self.context?.registerGCPair(pair)
         }
 
         context.push(operation: TreeEditOperation(parentCreatedAt: tree.createdAt,
@@ -490,10 +494,6 @@ public class JSONTree {
                                                   executedAt: ticket,
                                                   maxCreatedAtMapByActor: maxCreatedAtMapByActor)
         )
-
-        if fromPos != toPos {
-            context.registerElementHasRemovedNodes(tree)
-        }
 
         return true
     }

--- a/Sources/Document/Operation/EditOperation.swift
+++ b/Sources/Document/Operation/EditOperation.swift
@@ -73,10 +73,10 @@ struct EditOperation: Operation {
             throw YorkieError.unexpected(message: log)
         }
 
-        let changes = try text.edit((self.fromPos, self.toPos), self.content, self.executedAt, self.attributes, self.maxCreatedAtMapByActor).1
+        let (_, changes, pairs, _) = try text.edit((self.fromPos, self.toPos), self.content, self.executedAt, self.attributes, self.maxCreatedAtMapByActor)
 
-        if self.fromPos != self.toPos {
-            root.registerElementHasRemovedNodes(text)
+        for pair in pairs {
+            root.registerGCPair(pair)
         }
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -71,7 +71,7 @@ struct TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, _) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, self.maxCreatedAtMapByActor) {
+        let (changes, pairs, _) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, self.maxCreatedAtMapByActor) {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -83,8 +83,8 @@ struct TreeEditOperation: Operation {
             return editedAt
         }
 
-        if self.fromPos != self.toPos {
-            root.registerElementHasRemovedNodes(tree)
+        for pair in pairs {
+            root.registerGCPair(pair)
         }
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {

--- a/Tests/Unit/Document/CRDT/CRDTRootTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTRootTests.swift
@@ -112,7 +112,7 @@ class CRDTRootTests: XCTestCase {
         target.registerRemovedElement(a2)
 
         // when
-        let result = target.removedElementSetSize
+        let result = target.garbageElementSetSize
 
         // then
         XCTAssertEqual(result, 2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- https://github.com/yorkie-team/yorkie-js-sdk/pull/819

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced garbage collection handling within CRDT elements.
  - Improved text and tree node editing operations with better garbage collection support.

- **Refactor**
  - Renamed `TextValue` to `CRDTTextValue`.
  - Renamed `removedElementSetByCreatedAt` to `gcElementSetByCreatedAt`.
  - Removed `CRDTGCElement` protocol and associated methods.

- **Bug Fixes**
  - Improved garbage collection logic to handle removed nodes more efficiently.

- **Tests**
  - Updated test cases to reflect changes in garbage collection and element editing.
  - Added new test scenarios for garbage collection in tree nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->