### PR TITLE
Add ServerSeq into ChangeInfo

### DIFF
--- a/Sources/Document/Change/Change.swift
+++ b/Sources/Document/Change/Change.swift
@@ -50,7 +50,7 @@ public struct Change {
         }
 
         self.operations = operations
-        self.id.setActor(actorID)
+        self.id = self.id.setActor(actorID)
     }
 
     /**

--- a/Sources/Document/Change/ChangeID.swift
+++ b/Sources/Document/Change/ChangeID.swift
@@ -33,10 +33,11 @@ struct ChangeID {
     private var lamport: Int64
     private var actor: ActorID
 
-    init(clientSeq: UInt32, lamport: Int64, actor: ActorID) {
+    init(clientSeq: UInt32, lamport: Int64, actor: ActorID, serverSeq: Int64? = nil) {
         self.clientSeq = clientSeq
         self.lamport = lamport
         self.actor = actor
+        self.serverSeq = serverSeq
     }
 
     /**
@@ -69,8 +70,8 @@ struct ChangeID {
     /**
      * `setActor` sets the given actor.
      */
-    mutating func setActor(_ actorID: ActorID) {
-        self.actor = actorID
+    func setActor(_ actorID: ActorID) -> ChangeID {
+        ChangeID(clientSeq: self.clientSeq, lamport: self.lamport, actor: actorID, serverSeq: self.serverSeq)
     }
 
     /**
@@ -78,6 +79,17 @@ struct ChangeID {
      */
     func getClientSeq() -> UInt32 {
         return self.clientSeq
+    }
+
+    /**
+     * `getServerSeq` returns the server sequence of this ID.
+     */
+    func getServerSeq() -> String {
+        if let serverSeq {
+            return String(serverSeq)
+        } else {
+            return ""
+        }
     }
 
     /**

--- a/Sources/Document/DocEvent.swift
+++ b/Sources/Document/DocEvent.swift
@@ -175,6 +175,8 @@ public struct ChangeInfo {
     public let message: String
     public let operations: [any OperationInfo]
     public let actorID: ActorID?
+    public let clientSeq: UInt32
+    public let serverSeq: String
 }
 
 /**

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -159,7 +159,9 @@ public actor Document {
             if !opInfos.isEmpty {
                 let changeInfo = ChangeInfo(message: change.message ?? "",
                                             operations: opInfos,
-                                            actorID: actorID)
+                                            actorID: actorID,
+                                            clientSeq: change.id.getClientSeq(),
+                                            serverSeq: change.id.getServerSeq())
                 let changeEvent = LocalChangeEvent(value: changeInfo)
                 self.publish(changeEvent)
             }
@@ -322,7 +324,7 @@ public actor Document {
 
         self.localChanges = changes
 
-        self.changeID.setActor(actorID)
+        self.changeID = self.changeID.setActor(actorID)
 
         // TODOs also apply into root.
     }
@@ -484,7 +486,11 @@ public actor Document {
             let opInfos = try change.execute(root: self.root, presences: &self.presences)
 
             if change.hasOperations {
-                changeInfo = ChangeInfo(message: change.message ?? "", operations: opInfos, actorID: actorID)
+                changeInfo = ChangeInfo(message: change.message ?? "",
+                                        operations: opInfos,
+                                        actorID: actorID,
+                                        clientSeq: change.id.getClientSeq(),
+                                        serverSeq: change.id.getServerSeq())
             }
 
             // DocEvent should be emitted synchronously with applying changes.
@@ -650,7 +656,11 @@ public actor Document {
             }
 
             for (key, value) in operations {
-                let info = ChangeInfo(message: event.value.message, operations: value, actorID: event.value.actorID)
+                let info = ChangeInfo(message: event.value.message,
+                                      operations: value,
+                                      actorID: event.value.actorID,
+                                      clientSeq: event.value.clientSeq,
+                                      serverSeq: event.value.serverSeq)
 
                 if let callback = self.subscribeCallbacks[key] {
                     callback(event.type == .localChange ? LocalChangeEvent(value: info) : RemoteChangeEvent(value: info), self)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- https://github.com/yorkie-team/yorkie-js-sdk/pull/833

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `ChangeInfo` struct with new `clientSeq` and `serverSeq` properties for more detailed change tracking.
  
- **Bug Fixes**
  - Improved handling of `TreeStyleOperation` instances to ensure accurate creation based on conditions.
  
- **Refactor**
  - Updated `Change` struct to use a method call for setting the actor, improving code clarity.
  - Modified `ChangeID` struct to include a new `serverSeq` parameter and adjusted methods for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->