### PR TITLE
Fix incorrect indexes in TreeChange

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -14,9 +14,11 @@ jobs:
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v4
+    - name: Update Brew
+      run: brew update
     - name: Setup yorkie server
       run: brew reinstall yorkie
     - name: Run yorkie server
-      run: yorkie server & 
+      run: brew services start yorkie 
     - name: Run tests
       run: swift test --enable-code-coverage -v --filter YorkieIntegrationTests

--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Setup yorkie server
       run: brew reinstall yorkie
     - name: Run yorkie server
-      run: brew services start yorkie 
+      run: yorkie server & 
     - name: Run tests
       run: swift test --enable-code-coverage -v --filter YorkieIntegrationTests

--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -15,7 +15,7 @@ jobs:
         xcode-version: latest-stable
     - uses: actions/checkout@v4
     - name: Setup yorkie server
-      run: brew install yorkie
+      run: brew reinstall yorkie
     - name: Run yorkie server
       run: yorkie server & 
     - name: Run tests

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -1005,10 +1005,10 @@ extension Converter {
     static func fromTreeNode(_ pbTreeNode: PbTreeNode) -> CRDTTreeNode {
         let id = fromTreeNodeID(pbTreeNode.id)
         let node = CRDTTreeNode(id: id, type: pbTreeNode.type)
-
+        
         if node.isText {
             node.value = pbTreeNode.value as NSString
-        } else {
+        } else if !pbTreeNode.attributes.isEmpty {
             node.attrs = RHT()
             
             pbTreeNode.attributes.forEach { key, value in

--- a/Sources/Document/CRDT/RHT.swift
+++ b/Sources/Document/CRDT/RHT.swift
@@ -132,7 +132,7 @@ class RHT {
      * `get` returns the value of the given key.
      */
     func get(key: String) throws -> String {
-        guard let node = self.nodeMapByKey[key] else {
+        guard self.has(key: key), let node = self.nodeMapByKey[key] else {
             let log = "can't find the given node with: \(key)"
             Logger.critical(log)
             throw YorkieError.unexpected(message: log)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -384,7 +384,7 @@ public class JSONTree {
 
         let ticket = context.issueTimeTicket
 
-        let (maxCreationMapByActor, pairs, _) = try tree.style((fromPos, toPos), stringAttrs, ticket, nil)
+        let (maxCreationMapByActor, pairs, _) = try tree.style((fromPos, toPos), stringAttrs, ticket)
 
         context.push(operation: TreeStyleOperation(parentCreatedAt: tree.createdAt,
                                                    fromPos: fromPos,
@@ -442,7 +442,7 @@ public class JSONTree {
 
         let ticket = context.issueTimeTicket
 
-        let (pairs, _) = try tree.removeStyle((fromPos, toPos), attributesToRemove, ticket)
+        let (maxCreationMapByActor, pairs, _) = try tree.removeStyle((fromPos, toPos), attributesToRemove, ticket)
 
         for pair in pairs {
             self.context?.registerGCPair(pair)
@@ -451,7 +451,7 @@ public class JSONTree {
         context.push(operation: TreeStyleOperation(parentCreatedAt: tree.createdAt,
                                                    fromPos: fromPos,
                                                    toPos: toPos,
-                                                   maxCreatedAtMapByActor: [:],
+                                                   maxCreatedAtMapByActor: maxCreationMapByActor,
                                                    attributes: [:],
                                                    attributesToRemove: attributesToRemove,
                                                    executedAt: ticket)

--- a/Sources/Document/Operation/Operation.swift
+++ b/Sources/Document/Operation/Operation.swift
@@ -194,13 +194,31 @@ public struct TreeEditOpInfo: OperationInfo {
     }
 }
 
+public enum TreeStyleOpValue: Equatable {
+    case attributes([String: Any])
+    case attributesToRemove([String])
+
+    public static func == (lhs: TreeStyleOpValue, rhs: TreeStyleOpValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.attributes(let lhsAttributes), .attributes(let rhsAttributes)):
+            // Assuming [String: Any] comparison based on keys and string descriptions of values
+            return NSDictionary(dictionary: lhsAttributes).isEqual(to: rhsAttributes)
+        case (.attributesToRemove(let lhsAttributesToRemove), .attributesToRemove(let rhsAttributesToRemove)):
+            return lhsAttributesToRemove == rhsAttributesToRemove
+        default:
+            return false
+        }
+    }
+}
+
 public struct TreeStyleOpInfo: OperationInfo {
     public let type: OperationInfoType = .treeStyle
     public let path: String
     public let from: Int
     public let to: Int
     public let fromPath: [Int]
-    public let value: [String: Any]
+    public let toPath: [Int]
+    public let value: TreeStyleOpValue
 
     public static func == (lhs: TreeStyleOpInfo, rhs: TreeStyleOpInfo) -> Bool {
         if lhs.type != rhs.type {
@@ -216,6 +234,9 @@ public struct TreeStyleOpInfo: OperationInfo {
             return false
         }
         if lhs.fromPath != rhs.fromPath {
+            return false
+        }
+        if lhs.toPath != rhs.toPath {
             return false
         }
 

--- a/Sources/Document/Operation/Operation.swift
+++ b/Sources/Document/Operation/Operation.swift
@@ -218,7 +218,7 @@ public struct TreeStyleOpInfo: OperationInfo {
     public let to: Int
     public let fromPath: [Int]
     public let toPath: [Int]
-    public let value: TreeStyleOpValue
+    public let value: TreeStyleOpValue?
 
     public static func == (lhs: TreeStyleOpInfo, rhs: TreeStyleOpInfo) -> Bool {
         if lhs.type != rhs.type {

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -71,7 +71,7 @@ struct TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, _) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, self.maxCreatedAtMapByActor) {
+        let (changes, pairs, _) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -81,7 +81,7 @@ struct TreeEditOperation: Operation {
             editedAt = TimeTicket(lamport: editedAt.lamport, delimiter: delimiter, actorID: editedAt.actorID)
 
             return editedAt
-        }
+        }, self.maxCreatedAtMapByActor)
 
         for pair in pairs {
             root.registerGCPair(pair)

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -99,7 +99,7 @@ class TreeStyleOperation: Operation {
                 to: change.to,
                 fromPath: change.fromPath,
                 toPath: change.toPath,
-                value: values!
+                value: values
             )
         }
     }

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -70,7 +70,7 @@ class TreeStyleOperation: Operation {
         if self.attributes.isEmpty == false {
             (_, pairs, changes) = try tree.style((self.fromPos, self.toPos), self.attributes, self.executedAt, self.maxCreatedAtMapByActor)
         } else {
-            (pairs, changes) = try tree.removeStyle((self.fromPos, self.toPos), self.attributesToRemove, self.executedAt)
+            (_, pairs, changes) = try tree.removeStyle((self.fromPos, self.toPos), self.attributesToRemove, self.executedAt, self.maxCreatedAtMapByActor)
         }
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
@@ -82,11 +82,14 @@ class TreeStyleOperation: Operation {
         }
 
         return changes.compactMap { change in
-            let attributes: [String: Any] = {
-                if case .attributes(let attributes) = change.value {
-                    return attributes.toJSONObejct
-                } else {
-                    return [:]
+            let values: TreeStyleOpValue? = {
+                switch change.value {
+                case .attributes(let attributes):
+                    return .attributes(attributes.toJSONObejct)
+                case .attributesToRemove(let keys):
+                    return .attributesToRemove(keys)
+                default:
+                    return nil
                 }
             }()
 
@@ -95,7 +98,8 @@ class TreeStyleOperation: Operation {
                 from: change.from,
                 to: change.to,
                 fromPath: change.fromPath,
-                value: attributes
+                toPath: change.toPath,
+                value: values!
             )
         }
     }

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -209,6 +209,21 @@ extension IndexTreeNode {
     }
 
     /**
+     * `prevSibling` returns the previous sibling of the node.
+     */
+    var prevSibling: Self? {
+        guard let parent else {
+            return nil
+        }
+
+        guard let offset = try? parent.findOffset(node: self) else {
+            return nil
+        }
+
+        return parent.children[safe: offset - 1]
+    }
+
+    /**
      * `splitText` splits the given node at the given offset.
      */
     func splitText(_ offset: Int32, _ absOffset: Int32) throws -> Self? {

--- a/Tests/Integration/IntegrationHelper.swift
+++ b/Tests/Integration/IntegrationHelper.swift
@@ -85,8 +85,9 @@ struct TreeEditOpInfoForDebug: OperationInfoForDebug {
 struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
     let from: Int?
     let to: Int?
-    let value: [String: Codable]?
+    let value: TreeStyleOpValue?
     let fromPath: [Int]?
+    let toPath: [Int]?
 
     func compare(_ operation: TreeStyleOpInfo) {
         if let value = from {
@@ -96,15 +97,13 @@ struct TreeStyleOpInfoForDebug: OperationInfoForDebug {
             XCTAssertEqual(value, operation.to)
         }
         if let value = value {
-            XCTAssertEqual(value.count, operation.value.count)
-            if operation.value.count - 1 >= 0 {
-                for key in operation.value.keys {
-                    XCTAssertEqual(value[key]?.toJSONString, convertToJSONString(operation.value[key] ?? NSNull()))
-                }
-            }
+            XCTAssertEqual(value, operation.value)
         }
         if let value = fromPath {
             XCTAssertEqual(value, operation.fromPath)
+        }
+        if let value = toPath {
+            XCTAssertEqual(value, operation.toPath)
         }
     }
 }

--- a/Tests/Integration/TreeConcurrencyTests.swift
+++ b/Tests/Integration/TreeConcurrencyTests.swift
@@ -301,12 +301,11 @@ final class TreeConcurrencyTests: XCTestCase {
                     DispatchQueue.global().async {
                         Task {
                             let result = try await self.runTest(initialState: initialState.deepcopy(), initialXML: initialXML, ranges: ranges, op1: op1, op2: op2, desc: desc)
-
                             print("====== before d1: \(result.before.0)")
                             print("====== before d2: \(result.before.1)")
                             print("====== after d1: \(result.after.0)")
                             print("====== after d2: \(result.after.1)")
-                            XCTAssertEqual(result.after.0, result.after.1)
+                            XCTAssertEqual(result.after.0, result.after.1, desc)
 
                             exp.fulfill()
                         }
@@ -609,7 +608,7 @@ final class TreeConcurrencyTests: XCTestCase {
         )
         let initialXML = "<r><p color=\"red\">a</p><p color=\"red\">b</p><p color=\"red\">c</p></r>"
 
-        let content = JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "d")], attributes: ["italic": true])
+        let content = JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "d")], attributes: ["italic": true, "color": "blue"])
 
         let rangesArr = [
             // equal: <p>b</p> - <p>b</p>
@@ -679,7 +678,7 @@ final class TreeConcurrencyTests: XCTestCase {
                 .styleRemove,
                 "color",
                 "",
-                "remove-bold"
+                "remove-color"
             ),
             StyleOperationType(
                 .rangeAll,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- https://github.com/yorkie-team/yorkie-js-sdk/pull/837

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new concurrent operations tests: `test_concurrent_insert_and_style` and `test_concurrent_insert_and_removeStyle`.
  - Added `prevSibling` property to nodes in the index tree for enhanced navigation.

- **Bug Fixes**
  - Improved error handling in various methods to ensure operations are executed only if conditions are met.

- **Refactor**
  - Renamed methods and adjusted return types for better clarity and consistency.
  - Introduced new enums and type aliases to streamline code and improve readability.

- **Chores**
  - Updated GitHub workflow to ensure the latest version of Brew is used before reinstalling the `yorkie` server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->