### PR TITLE
Modifying the slowdown caused by logging

### DIFF
--- a/Sources/Core/Logger.swift
+++ b/Sources/Core/Logger.swift
@@ -30,32 +30,34 @@ enum Logger {
 
     private static var yorkieLogger = Logging.Logger(label: "Yorkie")
 
-    static func trace(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .trace, message, error: error, filename: filename, function: function, line: line)
+    static func trace(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .trace, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func debug(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .debug, message, error: error, filename: filename, function: function, line: line)
+    static func debug(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .debug, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func info(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .info, message, error: error, filename: filename, function: function, line: line)
+    static func info(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .info, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func warning(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .warning, message, error: error, filename: filename, function: function, line: line)
+    static func warning(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .warning, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func error(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .error, message, error: error, filename: filename, function: function, line: line)
+    static func error(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .error, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func critical(_ message: String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
-        self.log(level: .critical, message, error: error, filename: filename, function: function, line: line)
+    static func critical(_ message: @autoclosure () -> String, error: Error? = nil, filename: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .critical, message(), error: error, filename: filename, function: function, line: line)
     }
 
-    static func log(level: Logging.Logger.Level, _ message: String, error: Error? = nil, filename: String = #file, function: String = #function, line: UInt = #line) {
-        var log = message
+    static func log(level: Logging.Logger.Level, _ message: @autoclosure () -> String, error: Error? = nil, filename: String = #file, function: String = #function, line: UInt = #line) {
+        guard Logger.logLevel <= level else { return }
+
+        var log = message()
 
         if let error {
             log += "(\(String(describing: error)))"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Some logging messages take many times to make a message. (eg. toJSON()) So I modified the log functions to prevent performing message generation functions when the log level is low.
- For Example, the toJSON() function won't performed If the logging level is higher than the trace.
```
  Logger.trace("trying to update a local change: \(self.toJSON())") 
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logging efficiency by allowing deferred evaluation of log messages, enhancing performance.
  
- **Bug Fixes**
	- Addressed unnecessary string interpolation in logging functions when the log level is lower than the message's severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->