### PR TITLE
Add subscribeStatus(callback) function to Document

### DIFF
--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -88,6 +88,7 @@ public class Document {
     private var subscribeCallbacks = [String: SubscribeCallback]()
     private var presenceSubscribeCallback = [String: SubscribeCallback]()
     private var connectionSubscribeCallback: SubscribeCallback?
+    private var statusSubscribeCallback: SubscribeCallback?
     private var syncSubscribeCallback: SubscribeCallback?
 
     /**
@@ -192,6 +193,14 @@ public class Document {
      */
     public func subscribeConnection(_ callback: @escaping SubscribeCallback) {
         self.connectionSubscribeCallback = callback
+    }
+
+    /**
+     * `subscribeStatus` registers a callback to subscribe to events on the document.
+     * The callback will be called when the document status changes.
+     */
+    public func subscribeStatus(_ callback: @escaping SubscribeCallback) {
+        self.statusSubscribeCallback = callback
     }
 
     /**
@@ -639,6 +648,8 @@ public class Document {
             }
         } else if event.type == .connectionChanged {
             self.connectionSubscribeCallback?(event, self)
+        } else if event.type == .statusChanged {
+            self.statusSubscribeCallback?(event, self)
         } else if event.type == .syncStatusChanged {
             self.syncSubscribeCallback?(event, self)
         } else if event.type == .snapshot {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- https://github.com/yorkie-team/yorkie-js-sdk/pull/828

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to subscribe to document status changes, allowing real-time notifications for status updates.
	- Enhanced document detachment process during client deactivation for improved performance.

- **Bug Fixes**
	- Improved handling of document status transitions, ensuring accuracy during detach and deactivate operations.

- **Tests**
	- Added integration tests to verify document status change events and transitions during client operations.
	- Introduced a new event collector class to enhance test coverage for document status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->