### PR TITLE
Apply updates from yorkie-js-sdk v0.4.31

### DIFF
--- a/Sources/Document/CRDT/CRDTArray.swift
+++ b/Sources/Document/CRDT/CRDTArray.swift
@@ -52,8 +52,7 @@ class CRDTArray: CRDTContainer {
     func get(createdAt: TimeTicket) throws -> CRDTElement {
         guard let node = try? self.elements.get(createdAt: createdAt), node.isRemoved == false else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         return node

--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -64,7 +64,7 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
         case .long(let int64Value):
             self.value &+= T(int64Value)
         default:
-            throw YorkieError.unimplemented(message: "unimplemented type: \(type(of: primitive.value))")
+            throw YorkieError(code: .errUnimplemented, message: "Unsupported type of value: \(type(of: primitive.value))")
         }
 
         return self

--- a/Sources/Document/CRDT/CRDTObject.swift
+++ b/Sources/Document/CRDT/CRDTObject.swift
@@ -129,8 +129,8 @@ extension CRDTObject {
     /**
      * `delete` physically deletes the given element.
      */
-    func purge(element: CRDTElement) {
-        self.memberNodes.purge(element: element)
+    func purge(element: CRDTElement) throws {
+        try self.memberNodes.purge(element: element)
     }
 
     /**

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -109,7 +109,7 @@ extension CRDTTreePos {
         let parentNode = tree.findFloorNode(parentID)
         let leftNode = tree.findFloorNode(leftSiblingID)
         guard let parentNode, var leftNode else {
-            throw YorkieError.unexpected(message: "cannot find node of CRDTTreePos(\(parentID.toTestString), \(leftSiblingID.toTestString))")
+            throw YorkieError(code: .errRefused, message: "cannot find node of CRDTTreePos(\(parentID.toTestString), \(leftSiblingID.toTestString))")
         }
 
         /**
@@ -379,7 +379,7 @@ final class CRDTTreeNode: IndexTreeNode {
     @discardableResult
     func split(_ tree: CRDTTree, _ offset: Int32, _ issueTimeTicket: TimeTicket? = nil) throws -> CRDTTreeNode? {
         if self.isText == false, issueTimeTicket == nil {
-            throw YorkieError.unexpected(message: "The issueTimeTicket for Text Node have to nil!")
+            throw YorkieError(code: .errInvalidArgument, message: "The issueTimeTicket for Text Node have to nil!")
         }
 
         let split = self.isText ? try self.splitText(offset, self.id.offset) : try self.splitElement(offset, issueTimeTicket!)
@@ -903,7 +903,7 @@ class CRDTTree: CRDTElement {
      */
     func move(_ target: (Int, Int), _ source: (Int, Int), _ ticket: TimeTicket) throws {
         // TODO(hackerwins, easylogic): Implement this with keeping references of the nodes.
-        throw YorkieError.unimplemented(message: "not implemented, \(target), \(source) \(ticket)")
+        throw YorkieError(code: .errInvalidArgument, message: "not implemented, \(target), \(source) \(ticket)")
     }
 
     /**
@@ -1204,7 +1204,7 @@ class CRDTTree: CRDTElement {
         let siblings = parent!.innerChildren
 
         guard let offset = siblings.firstIndex(where: { $0 === node }) else {
-            throw YorkieError.unexpected(message: "Can't find index of node \(node)")
+            throw YorkieError(code: .errUnexpected, message: "Can't find index of node \(node)")
         }
 
         if parent != nil, offset == siblings.count - 1 {
@@ -1234,7 +1234,7 @@ class CRDTTree: CRDTElement {
         let siblings = parent!.innerChildren
 
         guard let offset = siblings.firstIndex(where: { $0 === node }) else {
-            throw YorkieError.unexpected(message: "Can't find index of node \(node)")
+            throw YorkieError(code: .errUnexpected, message: "Can't find index of node \(node)")
         }
 
         if parent != nil, offset == 0 {

--- a/Sources/Document/CRDT/ElementRHT.swift
+++ b/Sources/Document/CRDT/ElementRHT.swift
@@ -85,7 +85,7 @@ class ElementRHT {
     @discardableResult
     func delete(createdAt: TimeTicket, executedAt: TimeTicket) throws -> CRDTElement {
         guard let node = nodeMapByCreatedAt[createdAt.toIDString] else {
-            throw YorkieError.noSuchElement(message: "Can't find node of given createdAt [\(createdAt)] or executedAt [\(executedAt)]")
+            throw YorkieError(code: .errInvalidArgument, message: "Can't find node of given createdAt [\(createdAt)] or executedAt [\(executedAt)]")
         }
 
         node.remove(removedAt: executedAt)
@@ -98,8 +98,8 @@ class ElementRHT {
     func subPath(createdAt: TimeTicket) throws -> String {
         guard let node = self.nodeMapByCreatedAt[createdAt.toIDString] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         return node.key
@@ -108,10 +108,9 @@ class ElementRHT {
     /**
      * purge physically purge child element.
      */
-    func purge(element: CRDTElement) {
+    func purge(element: CRDTElement) throws {
         guard let node = nodeMapByCreatedAt[element.createdAt.toIDString] else {
-            Logger.critical("fail to find: \(element.createdAt)")
-            return
+            throw YorkieError(code: .errInvalidArgument, message: "fail to find: \(element.createdAt)")
         }
 
         if node == self.nodeMapByKey[node.key] {
@@ -127,7 +126,7 @@ class ElementRHT {
     @discardableResult
     func deleteByKey(key: String, executedAt: TimeTicket) throws -> CRDTElement {
         guard let node = nodeMapByKey[key] else {
-            throw YorkieError.noSuchElement(message: "Can't find node of given key [\(key)] or executedAt [\(executedAt)]")
+            throw YorkieError(code: .errInvalidArgument, message: "Can't find node of given key [\(key)] or executedAt [\(executedAt)]")
         }
 
         node.remove(removedAt: executedAt)

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -136,8 +136,7 @@ class RGATreeList {
     private func findNode(fromCreatedAt createdAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode {
         guard var node = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         while true {
@@ -183,14 +182,12 @@ class RGATreeList {
     func move(createdAt: TimeTicket, afterCreatedAt: TimeTicket, executedAt: TimeTicket) throws {
         guard let previsousNode = self.nodeMapByCreatedAt[afterCreatedAt] else {
             let log = "can't find the given node: \(afterCreatedAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         guard let movingNode = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         guard previsousNode !== movingNode else {
@@ -226,8 +223,7 @@ class RGATreeList {
     func get(createdAt: TimeTicket) throws -> CRDTElement {
         guard let node = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         return node.value
@@ -239,8 +235,7 @@ class RGATreeList {
     func subPath(createdAt: TimeTicket) throws -> String {
         guard let node = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         return String(self.nodeMapByIndex.indexOf(node))
@@ -252,8 +247,7 @@ class RGATreeList {
     func purge(_ value: CRDTElement) throws {
         guard let node = self.nodeMapByCreatedAt[value.createdAt] else {
             let log = "failed to find the given createdAt: \(value.createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         self.release(node: node)
@@ -265,15 +259,13 @@ class RGATreeList {
     func getNode(index: Int) throws -> RGATreeListNode {
         guard index < self.length else {
             let log = "length is smaller than or equal to: \(index)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let (node, offset) = self.nodeMapByIndex.find(index)
         guard let rgaNode = node as? RGATreeListNode else {
             let log = "failed to find the given index: \(index)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         guard (index == 0 && rgaNode === self.dummyHead) || offset >= 1 else {
@@ -291,8 +283,7 @@ class RGATreeList {
 
         guard let nextRgaNode else {
             let log = "failed to find the given index: \(index)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errUnexpected, message: log)
         }
 
         return nextRgaNode
@@ -304,8 +295,7 @@ class RGATreeList {
     func getPreviousCreatedAt(ofCreatedAt createdAt: TimeTicket) throws -> TimeTicket {
         guard let node = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
         var previousNode: RGATreeListNode? = node
         repeat {
@@ -321,8 +311,7 @@ class RGATreeList {
     func delete(createdAt: TimeTicket, executedAt: TimeTicket) throws -> CRDTElement {
         guard let node = self.nodeMapByCreatedAt[createdAt] else {
             let log = "can't find the given node: \(createdAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let alreadyRemoved = node.isRemoved

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -262,7 +262,7 @@ class RGATreeList {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        let (node, offset) = self.nodeMapByIndex.find(index)
+        let (node, offset) = try self.nodeMapByIndex.find(index)
         guard let rgaNode = node as? RGATreeListNode else {
             let log = "failed to find the given index: \(index)"
             throw YorkieError(code: .errInvalidArgument, message: log)

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -488,7 +488,7 @@ class RGATreeSplit<T: RGATreeSplitValue> {
      * `findNodePos` finds RGATreeSplitNodePos of given offset.
      */
     public func indexToPos(_ idx: Int) throws -> RGATreeSplitPos {
-        let (node, offset) = self.treeByIndex.find(idx)
+        let (node, offset) = try self.treeByIndex.find(idx)
         guard let splitNode = node as? RGATreeSplitNode<T> else {
             throw YorkieError(code: .errInvalidArgument, message: "no element for index \(idx)")
         }
@@ -784,7 +784,7 @@ class RGATreeSplit<T: RGATreeSplitValue> {
      */
     private func findEdgesOfCandidates(_ candidates: [RGATreeSplitNode<T>]) throws -> (RGATreeSplitNode<T>, RGATreeSplitNode<T>?) {
         guard let prev = candidates[0].prev else {
-            throw YorkieError(code : .errInvalidArgument, message: "prev must not nil!")
+            throw YorkieError(code: .errInvalidArgument, message: "prev must not nil!")
         }
 
         return (prev, candidates[safe: candidates.count - 1]?.next)

--- a/Sources/Document/CRDT/RHT.swift
+++ b/Sources/Document/CRDT/RHT.swift
@@ -146,8 +146,7 @@ class RHT {
     func get(key: String) throws -> String {
         guard self.has(key: key), let node = self.nodeMapByKey[key] else {
             let log = "can't find the given node with: \(key)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         return node.value

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -115,11 +115,11 @@ public class Document {
      */
     public func update(_ updater: (_ root: JSONObject, _ presence: inout Presence) throws -> Void, _ message: String? = nil) throws {
         guard self.status != .removed else {
-            throw YorkieError.documentRemoved(message: "\(self) is removed.")
+            throw YorkieError(code: .errDocumentRemoved, message: "\(self) is removed.")
         }
 
         guard let actorID = self.actorID else {
-            throw YorkieError.unexpected(message: "actor ID is null.")
+            throw YorkieError(code: .errUnexpected, message: "actor ID is null.")
         }
 
         // 01. Update the clone object and create a change.
@@ -458,7 +458,7 @@ public class Document {
             var presenceEvent: DocEvent?
 
             guard let actorID = change.id.getActorID() else {
-                throw YorkieError.unexpected(message: "ActorID is null")
+                throw YorkieError(code: .errUnexpected, message: "ActorID is null")
             }
 
             if let presenceChange = change.presenceChange, self.onlineClients.contains(actorID) {
@@ -483,7 +483,7 @@ public class Document {
                     // Detached user is no longer participating in the document, we remove
                     // them from the online clients and trigger the 'unwatched' event.
                     guard let presence = self.getPresence(actorID) else {
-                        throw YorkieError.unexpected(message: "No presence!")
+                        throw YorkieError(code: .errUnexpected, message: "No presence!")
                     }
 
                     presenceEvent = UnwatchedEvent(value: (actorID, presence))
@@ -532,7 +532,7 @@ public class Document {
      */
     public func getValueByPath(_ path: String) throws -> Any? {
         guard path.starts(with: JSONObject.rootKey) else {
-            throw YorkieError.unexpected(message: "The path must start with \(JSONObject.rootKey)")
+            throw YorkieError(code: .errInvalidArgument, message: "The path must start with \(JSONObject.rootKey)")
         }
 
         let rootObject = self.getRoot()
@@ -547,7 +547,7 @@ public class Document {
         let keySeparator = JSONObject.keySeparator
 
         guard subPath.starts(with: keySeparator) else {
-            throw YorkieError.unexpected(message: "Invalid path.")
+            throw YorkieError(code: .errUnexpected, message: "Invalid path.")
         }
 
         subPath.removeFirst(keySeparator.count)

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -282,7 +282,7 @@ public class JSONArray: CustomDebugStringConvertible {
         } else if let array = value as? [Any] {
             let crdtArray = CRDTArray(createdAt: ticket)
             guard let clone = crdtArray.deepcopy() as? CRDTArray else {
-                throw YorkieError.unexpected(message: "Failed to cast array.deepcopy() to CRDTArray")
+                throw YorkieError(code: .errUnexpected, message: "Failed to cast array.deepcopy() to CRDTArray")
             }
 
             try self.target.insert(value: clone, afterCreatedAt: previousCreatedAt)
@@ -299,7 +299,7 @@ public class JSONArray: CustomDebugStringConvertible {
         } else if value is JSONArray {
             let crdtArray = CRDTArray(createdAt: ticket)
             guard let clone = crdtArray.deepcopy() as? CRDTArray else {
-                throw YorkieError.unexpected(message: "Failed to cast array.deepcopy() to CRDTArray")
+                throw YorkieError(code: .errUnexpected, message: "Failed to cast array.deepcopy() to CRDTArray")
             }
 
             try self.target.insert(value: clone, afterCreatedAt: previousCreatedAt)
@@ -359,7 +359,7 @@ public class JSONArray: CustomDebugStringConvertible {
             return text
         } else if let element = value as? JSONTree {
             guard let root = try? element.buildRoot(context) else {
-                throw YorkieError.unexpected(message: "Can't build root!")
+                throw YorkieError(code: .errUnexpected, message: "Can't build root!")
             }
             let tree = CRDTTree(root: root, createdAt: ticket)
             element.initialize(context: self.context, tree: tree)
@@ -375,7 +375,7 @@ public class JSONArray: CustomDebugStringConvertible {
             return tree
         }
 
-        throw YorkieError.unimplemented(message: "Unsupported type of value: \(type(of: value))")
+        throw YorkieError(code: .errUnimplemented, message: "Unsupported type of value: \(type(of: value))")
     }
 
     /**

--- a/Sources/Document/Json/JSONCounter.swift
+++ b/Sources/Document/Json/JSONCounter.swift
@@ -59,7 +59,17 @@ public class JSONCounter<T: YorkieCountable> {
      * `increase` increases numeric data.
      */
     @discardableResult
-    public func increase(value: any BinaryInteger) throws -> Self {
+    public func increase(value: any BinaryInteger) -> Self {
+        do {
+            return try self.increaseThrows(value: value)
+        } catch {
+            Logger.critical(String(describing: error))
+            return self
+        }
+    }
+
+    @discardableResult
+    private func increaseThrows(value: any BinaryInteger) throws -> Self {
         guard let context, let counter else {
             let log = "Counter is not initialized yet"
             throw YorkieError(code: .errNotInitialized, message: log)
@@ -86,8 +96,8 @@ public class JSONCounter<T: YorkieCountable> {
     }
 
     @discardableResult
-    public func increase(value: any BinaryFloatingPoint) throws -> Self {
-        try self.increase(value: T(value))
+    public func increase(value: any BinaryFloatingPoint) -> Self {
+        self.increase(value: T(value))
     }
 }
 

--- a/Sources/Document/Json/JSONCounter.swift
+++ b/Sources/Document/Json/JSONCounter.swift
@@ -59,19 +59,15 @@ public class JSONCounter<T: YorkieCountable> {
      * `increase` increases numeric data.
      */
     @discardableResult
-    public func increase(value: any BinaryInteger) -> Self {
+    public func increase(value: any BinaryInteger) throws -> Self {
         guard let context, let counter else {
-            let log = "it is not initialized yet"
-            Logger.critical(log)
-
-            return self
+            let log = "Counter is not initialized yet"
+            throw YorkieError(code: .errNotInitialized, message: log)
         }
 
         guard let primitiveValue = Primitive.type(of: value) else {
             let log = "Unsupported type of value: \(type(of: T.self))"
-            Logger.critical(log)
-
-            return self
+            throw YorkieError(code: .errInvalidType, message: log)
         }
 
         let ticket = context.issueTimeTicket
@@ -79,19 +75,10 @@ public class JSONCounter<T: YorkieCountable> {
 
         guard primitive.isNumericType else {
             let log = "Unsupported type of value: \(type(of: T.self))"
-            Logger.critical(log)
-
-            return self
+            throw YorkieError(code: .errInvalidType, message: log)
         }
 
-        do {
-            try counter.increase(primitive)
-        } catch {
-            let log = "catch error when increase counter: [\(error)]"
-            Logger.critical(log)
-
-            return self
-        }
+        try counter.increase(primitive)
 
         context.push(operation: IncreaseOperation(parentCreatedAt: counter.createdAt, value: primitive, executedAt: ticket))
 
@@ -99,8 +86,8 @@ public class JSONCounter<T: YorkieCountable> {
     }
 
     @discardableResult
-    public func increase(value: any BinaryFloatingPoint) -> Self {
-        self.increase(value: T(value))
+    public func increase(value: any BinaryFloatingPoint) throws -> Self {
+        try self.increase(value: T(value))
     }
 }
 

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -61,21 +61,16 @@ public class JSONText {
      * `edit` edits this text with the given content.
      */
     @discardableResult
-    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) -> (Int, Int)? {
+    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) throws -> (Int, Int)? {
         guard let context, let text else {
-            Logger.critical("it is not initialized yet")
-            return nil
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromIdx > toIdx {
-            Logger.critical("from should be less than or equal to to")
-            return nil
+            throw YorkieError(code: .errInvalidArgument, message: "from should be less than or equal to to")
         }
 
-        guard let range = try? text.indexRangeToPosRange(fromIdx, toIdx) else {
-            Logger.critical("can't create range")
-            return nil
-        }
+        let range = try text.indexRangeToPosRange(fromIdx, toIdx)
 
         Logger.debug("EDIT: f:\(fromIdx)->\(range.0.toTestString), t:\(toIdx)->\(range.1.toTestString) c:\(content)")
 
@@ -86,10 +81,7 @@ public class JSONText {
             attrs = StringValueTypeDictionary.stringifyAttributes(attributes)
         }
 
-        guard let (maxCreatedAtMapByActor, _, pairs, rangeAfterEdit) = try? text.edit(range, content, ticket, attrs) else {
-            Logger.critical("can't edit Text")
-            return nil
-        }
+        let (maxCreatedAtMapByActor, _, pairs, rangeAfterEdit) = try text.edit(range, content, ticket, attrs)
 
         for pair in pairs {
             self.context?.registerGCPair(pair)
@@ -112,37 +104,32 @@ public class JSONText {
      * `delete` deletes the text in the given range.
      */
     @discardableResult
-    public func delete(_ fromIdx: Int, _ toIdx: Int) -> (Int, Int)? {
-        self.edit(fromIdx, toIdx, "")
+    public func delete(_ fromIdx: Int, _ toIdx: Int) throws -> (Int, Int)? {
+        return try self.edit(fromIdx, toIdx, "")
     }
 
     /**
      * `empty` makes the text empty.
      */
     @discardableResult
-    public func empty() -> (Int, Int)? {
-        self.edit(0, self.length, "")
+    public func empty() throws -> (Int, Int)? {
+        return try self.edit(0, self.length, "")
     }
 
     /**
      * `setStyle` styles this text with the given attributes.
      */
     @discardableResult
-    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) -> Bool {
+    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) throws -> Bool {
         guard let context, let text else {
-            Logger.critical("it is not initialized yet")
-            return false
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromIdx > toIdx {
-            Logger.critical("from should be less than or equal to to")
-            return false
+            throw YorkieError(code: .errInvalidArgument, message: "from should be less than or equal to to")
         }
 
-        guard let range = try? text.indexRangeToPosRange(fromIdx, toIdx) else {
-            Logger.critical("can't create range")
-            return false
-        }
+        let range = try text.indexRangeToPosRange(fromIdx, toIdx)
 
         Logger.debug("STYL: f:\(fromIdx)->\(range.0.toTestString), t:\(toIdx)->\(range.1.toTestString) a:\(attributes)")
 
@@ -150,12 +137,8 @@ public class JSONText {
         let maxCreatedAtMapByActor: [String: TimeTicket]
         let pairs: [GCPair]
         let stringAttrs = StringValueTypeDictionary.stringifyAttributes(attributes)
-        do {
-            (maxCreatedAtMapByActor, pairs, _) = try text.setStyle(range, stringAttrs, ticket)
-        } catch {
-            Logger.critical("can't set Style")
-            return false
-        }
+        
+        (maxCreatedAtMapByActor, pairs, _) = try text.setStyle(range, stringAttrs, ticket)
 
         context.push(operation: StyleOperation(parentCreatedAt: text.createdAt,
                                                fromPos: range.0,
@@ -176,7 +159,7 @@ public class JSONText {
      */
     public func indexRangeToPosRange(_ range: (Int, Int)) throws -> TextPosStructRange {
         guard self.context != nil, let text else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let textRange = try text.indexRangeToPosRange(range.0, range.1)
@@ -188,7 +171,7 @@ public class JSONText {
      */
     public func posRangeToIndexRange(_ range: TextPosStructRange) throws -> (Int, Int) {
         guard self.context != nil, let text else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let textRange = try text.findIndexesFromRange((RGATreeSplitPos.fromStruct(range.0), RGATreeSplitPos.fromStruct(range.1)))
@@ -201,7 +184,7 @@ public class JSONText {
      */
     public var toTestString: String {
         guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
+            Logger.critical("\(type(of: self)) is not initialized yet")
             return ""
         }
 
@@ -220,7 +203,7 @@ public class JSONText {
      */
     public func toSortedJSON() -> String {
         guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
+            Logger.critical("\(type(of: self)) is not initialized yet")
             return ""
         }
 
@@ -232,7 +215,7 @@ public class JSONText {
      */
     public var values: [CRDTTextValue]? {
         guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
+            Logger.critical("\(type(of: self)) is not initialized yet")
             return nil
         }
 
@@ -266,7 +249,7 @@ public class JSONText {
      */
     func createRangeForTest(_ fromIdx: Int, _ toIdx: Int) -> RGATreeSplitPosRange? {
         guard self.context != nil, let text else {
-            Logger.critical("it is not initialized yet")
+            Logger.critical("\(type(of: self)) is not initialized yet")
             return nil
         }
 

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -61,7 +61,17 @@ public class JSONText {
      * `edit` edits this text with the given content.
      */
     @discardableResult
-    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) throws -> (Int, Int)? {
+    public func edit(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) -> (Int, Int)? {
+        do {
+            return try self.editThrows(fromIdx, toIdx, content, attributes)
+        } catch {
+            Logger.critical(String(describing: error))
+            return nil
+        }
+    }
+
+    @discardableResult
+    private func editThrows(_ fromIdx: Int, _ toIdx: Int, _ content: String, _ attributes: Codable? = nil) throws -> (Int, Int)? {
         guard let context, let text else {
             throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
@@ -104,23 +114,33 @@ public class JSONText {
      * `delete` deletes the text in the given range.
      */
     @discardableResult
-    public func delete(_ fromIdx: Int, _ toIdx: Int) throws -> (Int, Int)? {
-        return try self.edit(fromIdx, toIdx, "")
+    public func delete(_ fromIdx: Int, _ toIdx: Int) -> (Int, Int)? {
+        return self.edit(fromIdx, toIdx, "")
     }
 
     /**
      * `empty` makes the text empty.
      */
     @discardableResult
-    public func empty() throws -> (Int, Int)? {
-        return try self.edit(0, self.length, "")
+    public func empty() -> (Int, Int)? {
+        return self.edit(0, self.length, "")
     }
-
+    
     /**
      * `setStyle` styles this text with the given attributes.
      */
     @discardableResult
-    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) throws -> Bool {
+    public func setStyle(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) -> Bool {
+        do {
+            return try self.setStyleThrows(fromIdx, toIdx, attributes)
+        } catch {
+            Logger.critical(String(describing: error))
+            return false
+        }
+    }
+
+    @discardableResult
+    private func setStyleThrows(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) throws -> Bool {
         guard let context, let text else {
             throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -125,7 +125,7 @@ public class JSONText {
     public func empty() -> (Int, Int)? {
         return self.edit(0, self.length, "")
     }
-    
+
     /**
      * `setStyle` styles this text with the given attributes.
      */
@@ -157,7 +157,7 @@ public class JSONText {
         let maxCreatedAtMapByActor: [String: TimeTicket]
         let pairs: [GCPair]
         let stringAttrs = StringValueTypeDictionary.stringifyAttributes(attributes)
-        
+
         (maxCreatedAtMapByActor, pairs, _) = try text.setStyle(range, stringAttrs, ticket)
 
         context.push(operation: StyleOperation(parentCreatedAt: text.createdAt,

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -211,7 +211,7 @@ func createCRDTTreeNode(context: ChangeContext, content: any JSONTreeNode) throw
  */
 func validateTextNode(_ textNode: JSONTreeTextNode) throws {
     if textNode.value.length == 0 {
-        throw YorkieError.unexpected(message: "text node cannot have empty value")
+        throw YorkieError(code: .errInvalidArgument, message: "text node cannot have empty value")
     }
 }
 
@@ -228,12 +228,12 @@ func validateTreeNodes(_ treeNodes: [any JSONTreeNode]) throws {
             if let node = node as? JSONTreeTextNode {
                 try validateTextNode(node)
             } else {
-                throw YorkieError.unexpected(message: "element node and text node cannot be passed together")
+                throw YorkieError(code: .errInvalidArgument, message: "element node and text node cannot be passed together")
             }
         }
     } else {
         if treeNodes.first(where: { !($0 is JSONTreeElementNode) }) != nil {
-            throw YorkieError.unexpected(message: "element node and text node cannot be passed together")
+            throw YorkieError(code: .errInvalidArgument, message: "element node and text node cannot be passed together")
         }
     }
 }
@@ -298,7 +298,7 @@ public class JSONTree {
      */
     public func getSize() throws -> Int {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.size
@@ -309,7 +309,7 @@ public class JSONTree {
      */
     public func getNodeSize() throws -> Int {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.nodeSize
@@ -320,7 +320,7 @@ public class JSONTree {
      */
     func getIndexTree() throws -> IndexTree<CRDTTreeNode> {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.indexTree
@@ -339,11 +339,11 @@ public class JSONTree {
 
     public func styleByPathInternal(_ path: [Int], _ stringAttrs: [String: String]) throws {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if path.isEmpty {
-            throw YorkieError.unexpected(message: "path should not be empty")
+            throw YorkieError(code: .errInvalidArgument, message: "path should not be empty")
         }
 
         let (fromPos, toPos) = try tree.pathToPosRange(path)
@@ -364,11 +364,11 @@ public class JSONTree {
 
     func styleByIndexInternal(_ fromIdx: Int, _ toIdx: Int, _ stringAttrs: [String: String]) throws {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromIdx > toIdx {
-            throw YorkieError.unexpected(message: "from should be less than or equal to to")
+            throw YorkieError(code: .errInvalidArgument, message: "from should be less than or equal to to")
         }
 
         let fromPos = try tree.findPos(fromIdx)
@@ -379,7 +379,7 @@ public class JSONTree {
 
     func styleInternal(_ fromPos: CRDTTreePos, _ toPos: CRDTTreePos, _ stringAttrs: [String: String]) throws {
         guard let context, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let ticket = context.issueTimeTicket
@@ -405,11 +405,11 @@ public class JSONTree {
      */
     public func removeStyleByPath(_ path: [Int], _ attributesToRemove: [String]) throws {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if path.isEmpty {
-            throw YorkieError.unexpected(message: "path should not be empty")
+            throw YorkieError(code: .errInvalidArgument, message: "path should not be empty")
         }
 
         let (fromPos, toPos) = try tree.pathToPosRange(path)
@@ -422,11 +422,11 @@ public class JSONTree {
      */
     public func removeStyle(_ fromIdx: Int, _ toIdx: Int, _ attributesToRemove: [String]) throws {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromIdx > toIdx {
-            throw YorkieError.unexpected(message: "from should be less than or equal to to")
+            throw YorkieError(code: .errInvalidArgument, message: "from should be less than or equal to to")
         }
 
         let fromPos = try tree.findPos(fromIdx)
@@ -437,7 +437,7 @@ public class JSONTree {
 
     private func removeStyleInternal(_ fromPos: CRDTTreePos, _ toPos: CRDTTreePos, _ attributesToRemove: [String]) throws {
         guard let context, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let ticket = context.issueTimeTicket
@@ -460,7 +460,7 @@ public class JSONTree {
 
     private func editInternal(_ fromPos: CRDTTreePos, _ toPos: CRDTTreePos, _ contents: [any JSONTreeNode]?, _ splitLevel: Int32 = 0) throws -> Bool {
         guard let context, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if let contents, contents.isEmpty == false {
@@ -523,15 +523,15 @@ public class JSONTree {
     @discardableResult
     public func editBulkByPath(_ fromPath: [Int], _ toPath: [Int], _ contents: [any JSONTreeNode]? = nil, _ splitLevel: Int32 = 0) throws -> Bool {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromPath.count != toPath.count {
-            throw YorkieError.unexpected(message: "path length should be equal")
+            throw YorkieError(code: .errInvalidArgument, message: "path length should be equal")
         }
 
         if fromPath.isEmpty || toPath.isEmpty {
-            throw YorkieError.unexpected(message: "path should not be empty")
+            throw YorkieError(code: .errInvalidArgument, message: "path should not be empty")
         }
 
         let fromPos = try tree.pathToPos(fromPath)
@@ -554,11 +554,11 @@ public class JSONTree {
     @discardableResult
     public func editBulk(_ fromIdx: Int, _ toIdx: Int, _ contents: [any JSONTreeNode]? = nil, _ splitLevel: Int32 = 0) throws -> Bool {
         guard let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         if fromIdx > toIdx {
-            throw YorkieError.unexpected(message: "from should be less than or equal to to")
+            throw YorkieError(code: .errInvalidArgument, message: "from should be less than or equal to to")
         }
 
         let fromPos = try tree.findPos(fromIdx)
@@ -570,10 +570,9 @@ public class JSONTree {
     /**
      * `toXML` returns the XML string of this tree.
      */
-    public func toXML() -> String {
+    public func toXML() throws -> String {
         guard self.context != nil, let tree else {
-            Logger.critical("it is not initialized yet")
-            return ""
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.toXML()
@@ -582,10 +581,9 @@ public class JSONTree {
     /**
      * `toJSON` returns the JSON string of this tree.
      */
-    public func toJSON() -> String {
+    public func toJSON() throws -> String {
         guard self.context != nil, let tree else {
-            Logger.critical("it is not initialized yet")
-            return ""
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.toJSON()
@@ -596,7 +594,7 @@ public class JSONTree {
      */
     public func getRootTreeNode() throws -> (any JSONTreeNode)? {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return tree.root.toJSONTreeNode
@@ -607,7 +605,7 @@ public class JSONTree {
      */
     public func indexToPath(_ index: Int) throws -> [Int] {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return try tree.indexToPath(index)
@@ -618,7 +616,7 @@ public class JSONTree {
      */
     public func pathToIndex(_ path: [Int]) throws -> Int {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return try tree.pathToIndex(path)
@@ -629,7 +627,7 @@ public class JSONTree {
      */
     public func pathRangeToPosRange(_ range: ([Int], [Int])) throws -> TreePosStructRange {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let indexRange = try (tree.pathToIndex(range.0), tree.pathToIndex(range.1))
@@ -643,7 +641,7 @@ public class JSONTree {
      */
     public func indexRangeToPosRange(_ range: (Int, Int)) throws -> TreePosStructRange {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         return try tree.indexRangeToPosStructRange(range)
@@ -654,7 +652,7 @@ public class JSONTree {
      */
     public func posRangeToIndexRange(_ range: TreePosStructRange) throws -> (Int, Int) {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let posRange = try (CRDTTreePos.fromStruct(range.0), CRDTTreePos.fromStruct(range.1))
@@ -667,7 +665,7 @@ public class JSONTree {
      */
     public func posRangeToPathRange(_ range: TreePosStructRange) throws -> ([Int], [Int]) {
         guard self.context != nil, let tree else {
-            throw YorkieError.unexpected(message: "it is not initialized yet")
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }
 
         let posRange = try (CRDTTreePos.fromStruct(range.0), CRDTTreePos.fromStruct(range.1))
@@ -700,7 +698,7 @@ extension TimeTicket {
      */
     static func fromStruct(_ value: TimeTicketStruct) throws -> TimeTicket {
         guard let lamport = Int64(value.lamport) else {
-            throw YorkieError.unexpected(message: "Lamport is not a valid string representing Int64")
+            throw YorkieError(code: .errUnexpected, message: "Lamport is not a valid string representing Int64")
         }
 
         return TimeTicket(lamport: lamport, delimiter: value.delimiter, actorID: value.actorID)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -570,7 +570,16 @@ public class JSONTree {
     /**
      * `toXML` returns the XML string of this tree.
      */
-    public func toXML() throws -> String {
+    public func toXML() -> String {
+        do {
+            return try self.toXMLThrows()
+        } catch {
+            Logger.critical(String(describing: error))
+            return ""
+        }
+    }
+
+    private func toXMLThrows() throws -> String {
         guard self.context != nil, let tree else {
             throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -590,7 +590,16 @@ public class JSONTree {
     /**
      * `toJSON` returns the JSON string of this tree.
      */
-    public func toJSON() throws -> String {
+    public func toJSON() -> String {
+        do {
+            return try self.toJSONThrows()
+        } catch {
+            Logger.critical(String(describing: error))
+            return ""
+        }
+    }
+
+    private func toJSONThrows() throws -> String {
         guard self.context != nil, let tree else {
             throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
         }

--- a/Sources/Document/Json/ObjectDataHandler.swift
+++ b/Sources/Document/Json/ObjectDataHandler.swift
@@ -160,7 +160,7 @@ class ObjectDataHandler {
         } else {
             let log = "The value does not exist. - key: \(key)"
             Logger.error(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidObjectKey, message: log)
         }
     }
 

--- a/Sources/Document/Operation/AddOperation.swift
+++ b/Sources/Document/Operation/AddOperation.swift
@@ -52,7 +52,7 @@ struct AddOperation: Operation {
         try array.insert(value: value, afterCreatedAt: self.previousCreatedAt)
         root.registerElement(value, parent: array)
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         guard let index = try Int(array.subPath(createdAt: self.effectedCreatedAt)) else {
             throw YorkieError(code: .errUnexpected, message: "fail to get index")

--- a/Sources/Document/Operation/AddOperation.swift
+++ b/Sources/Document/Operation/AddOperation.swift
@@ -45,20 +45,17 @@ struct AddOperation: Operation {
             } else {
                 log = "fail to execute, only array can execute add"
             }
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let value = self.value.deepcopy()
         try array.insert(value: value, afterCreatedAt: self.previousCreatedAt)
         root.registerElement(value, parent: array)
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         guard let index = try Int(array.subPath(createdAt: self.effectedCreatedAt)) else {
-            throw YorkieError.unexpected(message: "fail to get index")
+            throw YorkieError(code: .errUnexpected, message: "fail to get index")
         }
 
         return [AddOpInfo(path: path, index: index)]

--- a/Sources/Document/Operation/EditOperation.swift
+++ b/Sources/Document/Operation/EditOperation.swift
@@ -68,9 +68,7 @@ struct EditOperation: Operation {
             } else {
                 log = "fail to find \(self.parentCreatedAt)"
             }
-
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let (_, changes, pairs, _) = try text.edit((self.fromPos, self.toPos), self.content, self.executedAt, self.attributes, self.maxCreatedAtMapByActor)
@@ -79,9 +77,7 @@ struct EditOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         return changes.compactMap {
             EditOpInfo(path: path, from: $0.from, to: $0.to, attributes: $0.attributes?.createdDictionary, content: $0.content)

--- a/Sources/Document/Operation/EditOperation.swift
+++ b/Sources/Document/Operation/EditOperation.swift
@@ -77,7 +77,7 @@ struct EditOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         return changes.compactMap {
             EditOpInfo(path: path, from: $0.from, to: $0.to, attributes: $0.attributes?.createdDictionary, content: $0.content)

--- a/Sources/Document/Operation/IncreaseOperation.swift
+++ b/Sources/Document/Operation/IncreaseOperation.swift
@@ -47,8 +47,7 @@ struct IncreaseOperation: Operation {
     func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         if let counter = parentObject as? CRDTCounter<Int32> {
@@ -61,16 +60,13 @@ struct IncreaseOperation: Operation {
             }
         } else {
             let log = "fail to execute, only Counter can execute increase"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
-
+        let path = try root.createPath(createdAt: parentCreatedAt)
+        
         guard let value = Int((value as? Primitive)?.toJSON() ?? "") else {
-            throw YorkieError.unexpected(message: "fail to get counter value")
+            throw YorkieError(code: .errUnexpected, message: "fail to get counter value")
         }
 
         return [IncreaseOpInfo(path: path, value: value)]

--- a/Sources/Document/Operation/IncreaseOperation.swift
+++ b/Sources/Document/Operation/IncreaseOperation.swift
@@ -63,8 +63,8 @@ struct IncreaseOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
-        
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
+
         guard let value = Int((value as? Primitive)?.toJSON() ?? "") else {
             throw YorkieError(code: .errUnexpected, message: "fail to get counter value")
         }

--- a/Sources/Document/Operation/MoveOperation.swift
+++ b/Sources/Document/Operation/MoveOperation.swift
@@ -46,23 +46,20 @@ struct MoveOperation: Operation {
             } else {
                 log = "fail to execute, only array can execute move"
             }
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        let previousIndex = try? Int(array.subPath(createdAt: self.createdAt))
+        guard let previousIndex = try Int(array.subPath(createdAt: self.createdAt)) else {
+            throw YorkieError(code: .errUnexpected, message: "fail to get previousIndex")
+        }
 
         try array.move(createdAt: self.createdAt, afterCreatedAt: self.previousCreatedAt, executedAt: self.executedAt)
 
-        let index = try? Int(array.subPath(createdAt: self.createdAt))
-
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
+        guard let index = try Int(array.subPath(createdAt: self.createdAt)) else {
+            throw YorkieError(code: .errUnexpected, message: "fail to get index")
         }
 
-        guard let previousIndex, let index else {
-            throw YorkieError.unexpected(message: "fail to get indexes")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         return [MoveOpInfo(path: path, previousIndex: previousIndex, index: index)]
     }

--- a/Sources/Document/Operation/MoveOperation.swift
+++ b/Sources/Document/Operation/MoveOperation.swift
@@ -59,7 +59,7 @@ struct MoveOperation: Operation {
             throw YorkieError(code: .errUnexpected, message: "fail to get index")
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         return [MoveOpInfo(path: path, previousIndex: previousIndex, index: index)]
     }

--- a/Sources/Document/Operation/RemoveOperation.swift
+++ b/Sources/Document/Operation/RemoveOperation.swift
@@ -54,9 +54,7 @@ struct RemoveOperation: Operation {
 
         let key = try object.subPath(createdAt: self.createdAt)
 
-        guard let index = Int(key) else {
-            throw YorkieError(code: .errUnexpected, message: "fail to convert \(key) to Int")
-        }
+        let index = Int(key)
 
         return [parent is CRDTArray ? RemoveOpInfo(path: path, key: nil, index: index) : RemoveOpInfo(path: path, key: key, index: nil)]
     }

--- a/Sources/Document/Operation/RemoveOperation.swift
+++ b/Sources/Document/Operation/RemoveOperation.swift
@@ -50,10 +50,10 @@ struct RemoveOperation: Operation {
         let element = try object.delete(createdAt: self.createdAt, executedAt: self.executedAt)
         root.registerRemovedElement(element)
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         let key = try object.subPath(createdAt: self.createdAt)
-        
+
         guard let index = Int(key) else {
             throw YorkieError(code: .errUnexpected, message: "fail to convert \(key) to Int")
         }

--- a/Sources/Document/Operation/RemoveOperation.swift
+++ b/Sources/Document/Operation/RemoveOperation.swift
@@ -44,21 +44,21 @@ struct RemoveOperation: Operation {
             } else {
                 log = "fail to find \(self.parentCreatedAt)"
             }
-
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let element = try object.delete(createdAt: self.createdAt, executedAt: self.executedAt)
         root.registerRemovedElement(element)
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
+        let path = try root.createPath(createdAt: parentCreatedAt)
+
+        let key = try object.subPath(createdAt: self.createdAt)
+        
+        guard let index = Int(key) else {
+            throw YorkieError(code: .errUnexpected, message: "fail to convert \(key) to Int")
         }
 
-        let key = try? object.subPath(createdAt: self.createdAt)
-
-        return [parent is CRDTArray ? RemoveOpInfo(path: path, key: nil, index: Int(key ?? "")) : RemoveOpInfo(path: path, key: key, index: nil)]
+        return [parent is CRDTArray ? RemoveOpInfo(path: path, key: nil, index: index) : RemoveOpInfo(path: path, key: key, index: nil)]
     }
 
     /**

--- a/Sources/Document/Operation/SetOperation.swift
+++ b/Sources/Document/Operation/SetOperation.swift
@@ -45,13 +45,10 @@ struct SetOperation: Operation {
             let log: String
             if parent == nil {
                 log = "failed to find \(self.parentCreatedAt)"
-
             } else {
                 log = "fail to execute, only object can execute set"
             }
-
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let value = self.value.deepcopy()
@@ -62,7 +59,7 @@ struct SetOperation: Operation {
         }
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
+            throw YorkieError(code: .errUnexpected, message: "fail to get path")
         }
 
         return [SetOpInfo(path: path, key: self.key)]

--- a/Sources/Document/Operation/StyleOperation.swift
+++ b/Sources/Document/Operation/StyleOperation.swift
@@ -71,7 +71,7 @@ struct StyleOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         return changes.compactMap {
             StyleOpInfo(path: path, from: $0.from, to: $0.to, attributes: $0.attributes?.createdDictionary)

--- a/Sources/Document/Operation/StyleOperation.swift
+++ b/Sources/Document/Operation/StyleOperation.swift
@@ -62,9 +62,7 @@ struct StyleOperation: Operation {
             } else {
                 log = "fail to find \(self.parentCreatedAt)"
             }
-
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         let (_, pairs, changes) = try text.setStyle((self.fromPos, self.toPos), self.attributes, self.executedAt, self.maxCreatedAtMapByActor)
@@ -73,9 +71,7 @@ struct StyleOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         return changes.compactMap {
             StyleOpInfo(path: path, from: $0.from, to: $0.to, attributes: $0.attributes?.createdDictionary)

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -86,7 +86,7 @@ struct TreeEditOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         return changes.compactMap { change in
             let value: [CRDTTreeNode] = {

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -55,6 +55,7 @@ struct TreeEditOperation: Operation {
     public func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
+            Logger.critical(log)
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -55,13 +55,12 @@ struct TreeEditOperation: Operation {
     public func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         var editedAt = self.executedAt
         guard let tree = parentObject as? CRDTTree else {
-            fatalError("fail to execute, only Tree can execute edit")
+            throw YorkieError(code: .errInvalidArgument, message: "fail to execute, only Tree can execute edit")
         }
 
         /**
@@ -87,9 +86,7 @@ struct TreeEditOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         return changes.compactMap { change in
             let value: [CRDTTreeNode] = {

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -56,12 +56,11 @@ class TreeStyleOperation: Operation {
     public func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
-            Logger.critical(log)
-            throw YorkieError.unexpected(message: log)
+            throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
         guard let tree = parentObject as? CRDTTree else {
-            fatalError("fail to execute, only Tree can execute edit")
+            throw YorkieError(code: .errInvalidArgument, message: "fail to execute, only Tree can execute edit")
         }
 
         let changes: [TreeChange]
@@ -73,9 +72,7 @@ class TreeStyleOperation: Operation {
             (_, pairs, changes) = try tree.removeStyle((self.fromPos, self.toPos), self.attributesToRemove, self.executedAt, self.maxCreatedAtMapByActor)
         }
 
-        guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
-            throw YorkieError.unexpected(message: "fail to get path")
-        }
+        let path = try root.createPath(createdAt: parentCreatedAt)
 
         for pair in pairs {
             root.registerGCPair(pair)

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -72,7 +72,7 @@ class TreeStyleOperation: Operation {
             (_, pairs, changes) = try tree.removeStyle((self.fromPos, self.toPos), self.attributesToRemove, self.executedAt, self.maxCreatedAtMapByActor)
         }
 
-        let path = try root.createPath(createdAt: parentCreatedAt)
+        let path = try root.createPath(createdAt: self.parentCreatedAt)
 
         for pair in pairs {
             root.registerGCPair(pair)

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -56,6 +56,7 @@ class TreeStyleOperation: Operation {
     public func execute(root: CRDTRoot) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
+            Logger.critical(log)
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -40,10 +40,10 @@ struct YorkieError: Error, CustomStringConvertible {
 
         // ErrInvalidType is returned when the type is invalid.
         case errInvalidType = "ErrInvalidType"
-        
+
         // ErrDummy is used to verify errors for testing purposes.
         case errDummy = "ErrDummy"
-        
+
         // ErrDocumentNotAttached is returned when the document is not attached.
         case errDocumentNotAttached = "ErrDocumentNotAttached"
 
@@ -58,16 +58,16 @@ struct YorkieError: Error, CustomStringConvertible {
 
         // ErrInvalidArgument is returned when the argument is invalid.
         case errInvalidArgument = "ErrInvalidArgument"
-        
+
         // ErrNotInitialized is returned when required initialization has not been completed.
         case errNotInitialized = "ErrNotInitialized"
-        
+
         // ErrNotReady is returned when execution of following actions is not ready.
         case errNotReady = "ErrNotReady"
-        
+
         // ErrRefused is returned when the execution is rejected.
         case errRefused = "ErrRefused"
-           
+
         // ErrUnexpected is returned when an unexpected error occurred (iOS only)
         case errUnexpected = "ErrUnexpected"
 

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -17,25 +17,13 @@
 import Connect
 import Foundation
 
-struct YorkieError: Error {
+struct YorkieError: Error, CustomStringConvertible {
     let code: Code
     let message: String
-//    case unexpected(message: String)
-//    case clientNotActivated(message: String)
-//    case clientNotFound(message: String)
-//    case unimplemented(message: String)
-//    case unsupported(message: String)
-//
-//    case documentNotAttached(message: String)
-//    case documentNotDetached(message: String)
-//    case documentRemoved(message: String)
-//
-//    case invalidObjectKey(message: String)
-//    case invalidArgument(message: String)
-//
-//    case noSuchElement(message: String)
-//    case timeout(message: String)
-//    case rpcError(message: String)
+
+    var description: String {
+        return "[code=\(code.rawValue)]: \(message)"
+    }
 
     enum Code: String {
         // Ok is returned when the operation completed successfully.

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -22,7 +22,7 @@ struct YorkieError: Error, CustomStringConvertible {
     let message: String
 
     var description: String {
-        return "[code=\(code.rawValue)]: \(message)"
+        return "[code=\(self.code.rawValue)]: \(self.message)"
     }
 
     enum Code: String {
@@ -70,8 +70,10 @@ struct YorkieError: Error, CustomStringConvertible {
            
         // ErrUnexpected is returned when an unexpected error occurred (iOS only)
         case errUnexpected = "ErrUnexpected"
-    }
 
+        // ErrRPC is returned when an error occurred in the RPC Request
+        case errRPC = "ErrRPC"
+    }
 }
 
 /**

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -17,6 +17,9 @@
 import Connect
 import Foundation
 
+/**
+ * `YorkieError` is an error returned by a Yorkie operation.
+ */
 struct YorkieError: Error, CustomStringConvertible {
     let code: Code
     let message: String
@@ -26,52 +29,52 @@ struct YorkieError: Error, CustomStringConvertible {
     }
 
     enum Code: String {
-        // Ok is returned when the operation completed successfully.
+        /// Ok is returned when the operation completed successfully.
         case ok
 
-        // ErrClientNotActivated is returned when the client is not active.
+        /// ErrClientNotActivated is returned when the client is not active.
         case errClientNotActivated = "ErrClientNotActivated"
 
-        // ErrClientNotFound is returned when the client is not found.
+        /// ErrClientNotFound is returned when the client is not found.
         case errClientNotFound = "ErrClientNotFound"
 
-        // ErrUnimplemented is returned when the operation is not implemented.
+        /// ErrUnimplemented is returned when the operation is not implemented.
         case errUnimplemented = "ErrUnimplemented"
 
-        // ErrInvalidType is returned when the type is invalid.
+        /// ErrInvalidType is returned when the type is invalid.
         case errInvalidType = "ErrInvalidType"
 
-        // ErrDummy is used to verify errors for testing purposes.
+        /// ErrDummy is used to verify errors for testing purposes.
         case errDummy = "ErrDummy"
 
-        // ErrDocumentNotAttached is returned when the document is not attached.
+        /// ErrDocumentNotAttached is returned when the document is not attached.
         case errDocumentNotAttached = "ErrDocumentNotAttached"
 
-        // ErrDocumentNotDetached is returned when the document is not detached.
+        /// ErrDocumentNotDetached is returned when the document is not detached.
         case errDocumentNotDetached = "ErrDocumentNotDetached"
 
-        // ErrDocumentRemoved is returned when the document is removed.
+        /// ErrDocumentRemoved is returned when the document is removed.
         case errDocumentRemoved = "ErrDocumentRemoved"
 
-        // InvalidObjectKey is returned when the object key is invalid.
+        /// InvalidObjectKey is returned when the object key is invalid.
         case errInvalidObjectKey = "ErrInvalidObjectKey"
 
-        // ErrInvalidArgument is returned when the argument is invalid.
+        /// ErrInvalidArgument is returned when the argument is invalid.
         case errInvalidArgument = "ErrInvalidArgument"
 
-        // ErrNotInitialized is returned when required initialization has not been completed.
+        /// ErrNotInitialized is returned when required initialization has not been completed.
         case errNotInitialized = "ErrNotInitialized"
 
-        // ErrNotReady is returned when execution of following actions is not ready.
+        /// ErrNotReady is returned when execution of following actions is not ready.
         case errNotReady = "ErrNotReady"
 
-        // ErrRefused is returned when the execution is rejected.
+        /// ErrRefused is returned when the execution is rejected.
         case errRefused = "ErrRefused"
 
-        // ErrUnexpected is returned when an unexpected error occurred (iOS only)
+        /// ErrUnexpected is returned when an unexpected error occurred (iOS only)
         case errUnexpected = "ErrUnexpected"
 
-        // ErrRPC is returned when an error occurred in the RPC Request
+        /// ErrRPC is returned when an error occurred in the RPC Request
         case errRPC = "ErrRPC"
     }
 }

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -17,23 +17,25 @@
 import Connect
 import Foundation
 
-enum YorkieError: Error {
-    case unexpected(message: String)
-    case clientNotActivated(message: String)
-    case clientNotFound(message: String)
-    case unimplemented(message: String)
-    case unsupported(message: String)
-
-    case documentNotAttached(message: String)
-    case documentNotDetached(message: String)
-    case documentRemoved(message: String)
-
-    case invalidObjectKey(message: String)
-    case invalidArgument(message: String)
-
-    case noSuchElement(message: String)
-    case timeout(message: String)
-    case rpcError(message: String)
+struct YorkieError: Error {
+    let code: Code
+    let message: String
+//    case unexpected(message: String)
+//    case clientNotActivated(message: String)
+//    case clientNotFound(message: String)
+//    case unimplemented(message: String)
+//    case unsupported(message: String)
+//
+//    case documentNotAttached(message: String)
+//    case documentNotDetached(message: String)
+//    case documentRemoved(message: String)
+//
+//    case invalidObjectKey(message: String)
+//    case invalidArgument(message: String)
+//
+//    case noSuchElement(message: String)
+//    case timeout(message: String)
+//    case rpcError(message: String)
 
     enum Code: String {
         // Ok is returned when the operation completed successfully.
@@ -48,9 +50,12 @@ enum YorkieError: Error {
         // ErrUnimplemented is returned when the operation is not implemented.
         case errUnimplemented = "ErrUnimplemented"
 
-        // Unsupported is returned when the operation is not supported.
-        case unsupported
-
+        // ErrInvalidType is returned when the type is invalid.
+        case errInvalidType = "ErrInvalidType"
+        
+        // ErrDummy is used to verify errors for testing purposes.
+        case errDummy = "ErrDummy"
+        
         // ErrDocumentNotAttached is returned when the document is not attached.
         case errDocumentNotAttached = "ErrDocumentNotAttached"
 
@@ -65,23 +70,20 @@ enum YorkieError: Error {
 
         // ErrInvalidArgument is returned when the argument is invalid.
         case errInvalidArgument = "ErrInvalidArgument"
+        
+        // ErrNotInitialized is returned when required initialization has not been completed.
+        case errNotInitialized = "ErrNotInitialized"
+        
+        // ErrNotReady is returned when execution of following actions is not ready.
+        case errNotReady = "ErrNotReady"
+        
+        // ErrRefused is returned when the execution is rejected.
+        case errRefused = "ErrRefused"
+           
+        // ErrUnexpected is returned when an unexpected error occurred (iOS only)
+        case errUnexpected = "ErrUnexpected"
     }
 
-    var code: YorkieError.Code? {
-        switch self {
-        case .clientNotActivated: return .errClientNotActivated
-        case .clientNotFound: return .errClientNotFound
-        case .unimplemented: return .errUnimplemented
-        case .unsupported: return .unsupported
-        case .documentNotAttached: return .errDocumentNotAttached
-        case .documentNotDetached: return .errDocumentNotDetached
-        case .documentRemoved: return .errDocumentRemoved
-        case .invalidObjectKey: return .errInvalidObjectKey
-        case .invalidArgument: return .errInvalidArgument
-        default:
-            return nil
-        }
-    }
 }
 
 /**
@@ -98,10 +100,10 @@ func errorCodeOf(error: ConnectError) -> String {
 }
 
 func toYorkieErrorCode(from error: Error) -> YorkieError.Code? {
-    guard let yorkieError = error as? YorkieError, let code = yorkieError.code else {
+    guard let yorkieError = error as? YorkieError else {
         return nil
     }
-    return code
+    return yorkieError.code
 }
 
 func connectError(from code: Code) -> ConnectError {

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -271,7 +271,7 @@ extension IndexTreeNode {
      */
     func append(contentsOf newNode: [Self]) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         self.innerChildren.append(contentsOf: newNode)
@@ -288,7 +288,7 @@ extension IndexTreeNode {
      */
     func prepend(contentsOf newNode: [Self]) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         self.innerChildren.insert(contentsOf: newNode, at: 0)
@@ -303,11 +303,11 @@ extension IndexTreeNode {
      */
     func insertBefore(_ newNode: Self, _ referenceNode: Self) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         guard let offset = self.innerChildren.firstIndex(where: { $0 === referenceNode }) else {
-            throw YorkieError.unexpected(message: "child not found")
+            throw YorkieError(code: .errInvalidArgument, message: "child not found")
         }
 
         try self.insertAtInternal(newNode: newNode, offset: offset)
@@ -319,11 +319,11 @@ extension IndexTreeNode {
      */
     func insertAfter(_ newNode: Self, _ referenceNode: Self) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         guard let offset = self.innerChildren.firstIndex(where: { $0 === referenceNode }) else {
-            throw YorkieError.unexpected(message: "child not found")
+            throw YorkieError(code: .errInvalidArgument, message: "child not found")
         }
 
         try self.insertAtInternal(newNode: newNode, offset: offset + 1)
@@ -335,7 +335,7 @@ extension IndexTreeNode {
      */
     func insertAt(_ newNode: Self, _ offset: Int) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         try self.insertAtInternal(newNode: newNode, offset: offset)
@@ -347,11 +347,11 @@ extension IndexTreeNode {
      */
     func removeChild(child: Self) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         guard let offset = self.innerChildren.firstIndex(where: { $0 === child }) else {
-            throw YorkieError.unexpected(message: "child not found")
+            throw YorkieError(code: .errInvalidArgument, message: "child not found")
         }
 
         self.innerChildren.splice(offset, 1, with: [])
@@ -398,11 +398,11 @@ extension IndexTreeNode {
      */
     func insertAfterInternal(newNode: Self, referenceNode: Self) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         guard let offset = self.innerChildren.firstIndex(where: { $0 === referenceNode }) else {
-            throw YorkieError.unexpected(message: "child not found")
+            throw YorkieError(code: .errInvalidArgument, message: "child not found")
         }
 
         try self.insertAtInternal(newNode: newNode, offset: offset + 1)
@@ -414,7 +414,7 @@ extension IndexTreeNode {
      */
     func insertAtInternal(newNode: Self, offset: Int) throws {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         self.innerChildren.splice(offset, 0, with: [newNode])
@@ -427,7 +427,7 @@ extension IndexTreeNode {
      */
     func findOffset(node: Self) throws -> Int {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         if node.isRemoved {
@@ -450,7 +450,7 @@ extension IndexTreeNode {
      */
     func findBranchOffset(node: Self) throws -> Int {
         guard self.isText == false else {
-            throw YorkieError.unexpected(message: "Text node cannot have children")
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
         }
 
         var current: Self? = node
@@ -565,15 +565,15 @@ func tokensBetween<T: IndexTreeNode>(root: T,
                                      callback: @escaping (TreeToken<T>, Bool) throws -> Void) throws
 {
     if from > to {
-        throw YorkieError.unexpected(message: "from is greater than to: \(from) > \(to)")
+        throw YorkieError(code: .errInvalidArgument, message: "from is greater than to: \(from) > \(to)")
     }
 
     if from > root.size {
-        throw YorkieError.unexpected(message: "from is out of range: \(from) > \(root.size)")
+        throw YorkieError(code: .errInvalidArgument, message: "from is out of range: \(from) > \(root.size)")
     }
 
     if to > root.size {
-        throw YorkieError.unexpected(message: "to is out of range: \(to) > \(root.size)")
+        throw YorkieError(code: .errInvalidArgument, message: "to is out of range: \(to) > \(root.size)")
     }
 
     if from == to {
@@ -644,7 +644,7 @@ func findTreePos<T: IndexTreeNode>(node: T,
                                    preferText: Bool = true) throws -> TreePos<T>
 {
     if index > node.size {
-        throw YorkieError.unexpected(message: "index is out of range: \(index) > \(node.size)")
+        throw YorkieError(code: .errInvalidArgument, message: "index is out of range: \(index) > \(node.size)")
     }
 
     if node.isText {
@@ -745,7 +745,7 @@ func findTextPos<T: IndexTreeNode>(node: T, pathElement: Int) throws -> TreePos<
     var pathElement = pathElement
 
     if node.size < pathElement {
-        throw YorkieError.unexpected(message: "unacceptable path")
+        throw YorkieError(code: .errInvalidArgument, message: "unacceptable path")
     }
 
     for child in node.children {
@@ -809,7 +809,7 @@ class IndexTree<T: IndexTreeNode> {
         if node.isText {
             let offset = try node.parent!.findOffset(node: node)
             if offset == -1 {
-                throw YorkieError.unexpected(message: "invalid treePos")
+                throw YorkieError(code: .errInvalidArgument, message: "invalid treePos")
             }
 
             let sizeOfLeftSiblings = addSizeOfLeftSiblings(parent: node.parent!, offset: offset)
@@ -827,7 +827,7 @@ class IndexTree<T: IndexTreeNode> {
         while node.parent != nil {
             let offset = try node.parent!.findOffset(node: node)
             if offset == -1 {
-                throw YorkieError.unexpected(message: "invalid treePos")
+                throw YorkieError(code: .errInvalidArgument, message: "invalid treePos")
             }
 
             path.append(offset)
@@ -851,13 +851,13 @@ class IndexTree<T: IndexTreeNode> {
      */
     public func pathToTreePos(_ path: [Int]) throws -> TreePos<T> {
         guard path.isEmpty != true else {
-            throw YorkieError.unexpected(message: "unacceptable path")
+            throw YorkieError(code: .errInvalidArgument, message: "unacceptable path")
         }
 
         var node = self.root
         for pathElement in path.dropLast() {
             guard let child = node.children[safe: pathElement] else {
-                throw YorkieError.unexpected(message: "unacceptable path")
+                throw YorkieError(code: .errInvalidArgument, message: "unacceptable path")
             }
             node = child
         }
@@ -867,7 +867,7 @@ class IndexTree<T: IndexTreeNode> {
         }
 
         if node.children.count < path[path.count - 1] {
-            throw YorkieError.unexpected(message: "unacceptable path")
+            throw YorkieError(code: .errInvalidArgument, message: "unacceptable path")
         }
 
         return TreePos(node: node, offset: Int32(path[path.count - 1]))
@@ -922,7 +922,7 @@ class IndexTree<T: IndexTreeNode> {
             let parent = node.parent!
             let offsetOfNode = try parent.findOffset(node: node)
             if offsetOfNode == -1 {
-                throw YorkieError.unexpected(message: "invalid pos")
+                throw YorkieError(code: .errInvalidArgument, message: "invalid pos")
             }
 
             size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode)
@@ -936,7 +936,7 @@ class IndexTree<T: IndexTreeNode> {
             let parent = node.parent!
             let offsetOfNode = try parent.findOffset(node: node)
             if offsetOfNode == -1 {
-                throw YorkieError.unexpected(message: "invalid pos")
+                throw YorkieError(code: .errInvalidArgument, message: "invalid pos")
             }
 
             size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode)

--- a/Sources/Util/SplayTree.swift
+++ b/Sources/Util/SplayTree.swift
@@ -140,7 +140,7 @@ class SplayTree<V> {
     /**
      * `find` returns the Node and offset of the given index.
      */
-    func find(_ position: Int) -> (node: SplayNode<V>?, offset: Int) {
+    func find(_ position: Int) throws -> (node: SplayNode<V>?, offset: Int) {
         guard let root = self.root, position >= 0 else {
             return (nil, 0)
         }
@@ -159,7 +159,8 @@ class SplayTree<V> {
             }
         }
         if offset > node.length {
-            Logger.error("out of index range: pos: \(offset) > node.length: \(node.length)")
+            let message = "out of index range: pos: \(offset) > node.length: \(node.length)"
+            throw YorkieError(code: .errInvalidArgument, message: message)
         }
         return (node, offset)
     }

--- a/Tests/Integration/DocumentIntegrationTests.swift
+++ b/Tests/Integration/DocumentIntegrationTests.swift
@@ -40,8 +40,8 @@ final class DocumentIntegrationTests: XCTestCase {
         // 01. client is not activated.
         do {
             try await self.c1.remove(self.d1)
-        } catch {
-            if case YorkieError.clientNotActivated(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errClientNotActivated = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -51,8 +51,8 @@ final class DocumentIntegrationTests: XCTestCase {
         do {
             try await self.c1.activate()
             try await self.c1.remove(self.d1)
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -75,8 +75,8 @@ final class DocumentIntegrationTests: XCTestCase {
             try await self.d1.update { root, _ in
                 root.k1 = String("v1")
             }
-        } catch {
-            if case YorkieError.documentRemoved = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentRemoved = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -85,8 +85,8 @@ final class DocumentIntegrationTests: XCTestCase {
         // 05. try to attach a removed document.
         do {
             try await self.c1.attach(self.d1)
-        } catch {
-            if case YorkieError.documentNotDetached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotDetached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -291,8 +291,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.detach(self.d1)
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -300,8 +300,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.sync()
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -309,8 +309,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.remove(self.d1)
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -321,8 +321,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.attach(self.d1)
-        } catch {
-            if case YorkieError.documentNotDetached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotDetached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -333,8 +333,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.remove(self.d1)
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -342,8 +342,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.sync()
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }
@@ -351,8 +351,8 @@ final class DocumentIntegrationTests: XCTestCase {
 
         do {
             try await self.c1.detach(self.d1)
-        } catch {
-            if case YorkieError.documentNotAttached(message:) = error {
+        } catch let error as YorkieError {
+            if case YorkieError.Code.errDocumentNotAttached = error.code {
             } else {
                 XCTAssert(false)
             }

--- a/Tests/Unit/Document/CRDT/CRDTObjectTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTObjectTests.swift
@@ -72,7 +72,7 @@ class CRDTObjectTests: XCTestCase {
         let a3 = Primitive(value: .string("A3"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
         target.set(key: "K3", value: a3)
 
-        target.purge(element: a2)
+        try target.purge(element: a2)
 
         XCTAssertFalse(target.has(key: targetKey))
     }

--- a/Tests/Unit/Document/CRDT/ElementRHTTests.swift
+++ b/Tests/Unit/Document/CRDT/ElementRHTTests.swift
@@ -108,7 +108,7 @@ class ElementRHTTests: XCTestCase {
         let a2 = Primitive(value: .string("A2"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
         target.set(key: "a2", value: a2)
 
-        target.purge(element: a2)
+        try target.purge(element: a2)
 
         let result = target.get(key: "a2")
         XCTAssertNil(result)
@@ -123,7 +123,7 @@ class ElementRHTTests: XCTestCase {
         let a2 = Primitive(value: .string("A2"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
         target.set(key: "a2", value: a2)
 
-        target.purge(element: a2)
+        try target.purge(element: a2)
 
         XCTAssertTrue(target.has(key: "a1"))
         XCTAssertFalse(target.has(key: "a2"))

--- a/Tests/Unit/Util/SplayTreeTests.swift
+++ b/Tests/Unit/Util/SplayTreeTests.swift
@@ -36,7 +36,7 @@ private class StringNode: SplayNode<String> {
 }
 
 class SplayTreeTests: XCTestCase {
-    func test_can_insert_values_and_splay_them() {
+    func test_can_insert_values_and_splay_them() throws {
         let tree = SplayTree<String>()
 
         let nodeA = tree.insert(StringNode.create("A2"))
@@ -57,35 +57,35 @@ class SplayTreeTests: XCTestCase {
         XCTAssertEqual(tree.indexOf(nodeC), 5)
         XCTAssertEqual(tree.indexOf(nodeD), 9)
 
-        var result = tree.find(-1)
+        var result = try tree.find(-1)
         XCTAssertNil(result.node)
         XCTAssertEqual(result.offset, 0)
 
-        result = tree.find(0)
+        result = try tree.find(0)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 0)
 
-        result = tree.find(1)
+        result = try tree.find(1)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 1)
 
-        result = tree.find(2)
+        result = try tree.find(2)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 2)
 
-        result = tree.find(3)
+        result = try tree.find(3)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 1)
 
-        result = tree.find(4)
+        result = try tree.find(4)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 2)
 
-        result = tree.find(5)
+        result = try tree.find(5)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 3)
 
-        result = tree.find(6)
+        result = try tree.find(6)
         XCTAssertEqual(result.node?.value, "C234")
         XCTAssertEqual(result.offset, 1)
     }
@@ -176,7 +176,7 @@ class SplayTreeTests: XCTestCase {
         XCTAssertEqual(self.sumOfWeight(testTree.nodes, from: 3, to: 7), 0)
     }
 
-    func test_splay() {
+    func test_splay() throws {
         let tree = SplayTree<String>()
 
         tree.insert(StringNode.create("A2"))
@@ -195,7 +195,7 @@ class SplayTreeTests: XCTestCase {
         tree.splayNode(nodeB)
         XCTAssertEqual(tree.toTestString, "[2,2]A2[14,3]B23[9,4]C234[5,5]D2345")
 
-        let (node, _) = tree.find(6)
+        let (node, _) = try tree.find(6)
         XCTAssertEqual(node?.value, "C234")
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Applied changes from https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.4.31

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Applied**
- [ ] https://github.com/yorkie-team/yorkie-js-sdk/pull/877 : N/A
- [x] https://github.com/yorkie-team/yorkie-js-sdk/pull/878
- [ ] https://github.com/yorkie-team/yorkie-js-sdk/pull/879 : N/A
- [ ] https://github.com/yorkie-team/yorkie-js-sdk/pull/880 : N/A

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling across the application by replacing generic error messages with specific error codes. This change streamlines exception propagation and removes redundant logging, resulting in clearer diagnostics and improved system robustness.
  - Introduced throwing functions for several methods, allowing for more robust error management.

- **Tests**
  - Updated test cases to align with the refined error reporting. Tests now assert specific error conditions, ensuring more reliable validations and easier troubleshooting during failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->