### PR TITLE
Apply updates from yorkie-js-sdk 0.6.37

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.36
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b4df70c658482d4e91f7b601dcc56b7de69d23dd/Formula/y/yorkie.rb"
+      # yorkie server v0.6.37
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b60bc244e5c730fead732d6d446d0dcb2ba76db3/Formula/y/yorkie.rb"
       HOMEBREW_DEVELOPER: "1"
         
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.36
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b4df70c658482d4e91f7b601dcc56b7de69d23dd/Formula/y/yorkie.rb"
+      # yorkie server v0.6.37
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b60bc244e5c730fead732d6d446d0dcb2ba76db3/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -545,7 +545,7 @@ public class Client {
         attachRequest.channelKey = channel.getKey()
 
         do {
-            let attachResponse = await self.yorkieService.attachChannel(request: attachRequest, headers: self.authHeader.makeHeader(channel.getKey()))
+            let attachResponse = await self.yorkieService.attachChannel(request: attachRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
 
             guard attachResponse.error == nil, let message = attachResponse.message else {
                 throw self.handleErrorResponse(attachResponse.error, defaultMessage: "Unknown attach channel error")
@@ -619,7 +619,7 @@ public class Client {
         detachRequest.sessionID = attachment.resourceID
 
         do {
-            let detachResponse = await self.yorkieService.detachChannel(request: detachRequest, headers: self.authHeader.makeHeader(channel.getKey()))
+            let detachResponse = await self.yorkieService.detachChannel(request: detachRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
 
             guard detachResponse.error == nil else {
                 throw self.handleErrorResponse(detachResponse.error, defaultMessage: "Unknown detach channel error")
@@ -655,7 +655,7 @@ public class Client {
         refreshRequest.channelKey = channel.getKey()
         refreshRequest.sessionID = attachment.resourceID
 
-        let refreshResponse = await self.yorkieService.refreshChannel(request: refreshRequest, headers: self.authHeader.makeHeader(channel.getKey()))
+        let refreshResponse = await self.yorkieService.refreshChannel(request: refreshRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
 
         guard refreshResponse.error == nil, let message = refreshResponse.message else {
             throw self.handleErrorResponse(refreshResponse.error, defaultMessage: "Unknown refresh channel error")
@@ -1014,7 +1014,7 @@ public class Client {
         // dispatches presence-count updates + remote broadcast events to the
         // Channel's event system.
         if let channelAttachment = attachment as? Attachment<Channel> {
-            let stream = self.yorkieService.watchChannel(headers: self.authHeader.makeHeader(key), onResult: { result in
+            let stream = self.yorkieService.watchChannel(headers: self.authHeader.makeHeader(channelAttachment.resource.getFirstKeyPath()), onResult: { result in
                 Task {
                     switch result {
                     case .headers:
@@ -1409,7 +1409,7 @@ public extension Client {
         while retryCount <= maxRetries {
             let message = await self.yorkieService.broadcast(
                 request: request,
-                headers: self.authHeader.makeHeader(channelKey)
+                headers: self.authHeader.makeHeader(channelAttachment?.resource.getFirstKeyPath() ?? channelKey)
             )
 
             switch message.result {

--- a/Sources/Util/LLRBTree.swift
+++ b/Sources/Util/LLRBTree.swift
@@ -35,7 +35,6 @@ class LLRBTree<K: Comparable, V> {
     class Node: CustomDebugStringConvertible {
         var key: K
         var value: V
-        weak var parent: Node?
         var left: Node?
         var right: Node?
         var isRed: Bool
@@ -121,34 +120,20 @@ class LLRBTree<K: Comparable, V> {
      */
     func floorEntry(_ key: K) -> Entry? {
         var node = self.root
+        var result: Node?
 
-        while node != nil {
-            if key > node!.key {
-                if node!.right != nil {
-                    node?.right?.parent = node
-                    node = node?.right
-                } else {
-                    return node?.entry
-                }
-            } else if key < node!.key {
-                if node!.left != nil {
-                    node?.left?.parent = node
-                    node = node?.left
-                } else {
-                    var parent = node?.parent
-                    var childNode = node
-                    while parent != nil, childNode === parent?.left {
-                        childNode = parent
-                        parent = parent!.parent
-                    }
-
-                    return parent?.entry
-                }
+        while let current = node {
+            if key == current.key {
+                return current.entry
+            } else if key < current.key {
+                node = current.left
             } else {
-                return node?.entry
+                result = current
+                node = current.right
             }
         }
-        return nil
+
+        return result?.entry
     }
 
     /**

--- a/Tests/Unit/Util/LLRBTreeTests.swift
+++ b/Tests/Unit/Util/LLRBTreeTests.swift
@@ -85,6 +85,38 @@ class LLRBTreeTests: XCTestCase {
         }
     }
 
+    private func checkFloor(_ tree: LLRBTree<Int, Int>, _ arr: [Int], _ loop: Int) {
+        for floorKey in 0 ..< loop {
+            var expectedKey: Int?
+            for value in arr where value <= floorKey {
+                if expectedKey == nil || expectedKey! <= value {
+                    expectedKey = value
+                }
+            }
+
+            let resultEntry = tree.floorEntry(floorKey)
+
+            if let expectedKey {
+                XCTAssertEqual(expectedKey, resultEntry?.key)
+            } else {
+                XCTAssertNil(resultEntry)
+            }
+        }
+    }
+
+    func test_can_floor_entry_at_each_insertion_step() {
+        for array in self.sources {
+            var testArr = [Int]()
+            let target = LLRBTree<Int, Int>()
+            for value in array {
+                self.checkFloor(target, testArr, 10)
+                target.put(value, value)
+                testArr.append(value)
+                self.checkFloor(target, testArr, 10)
+            }
+        }
+    }
+
     func test_insert() {
         for array in self.sources {
             let target = LLRBTree<Int, Int>()


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs the iOS SDK with [yorkie-js-sdk v0.6.37](https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.6.37).

- Fix nil pointer dereference in `LLRBTree.floorEntry` by rewriting it iteratively with best-candidate tracking and dropping the `parent` back-pointer that caused the crash (yorkie-js-sdk#1107). Adds `test_can_floor_entry_at_each_insertion_step` mirroring the upstream unit test.
- Refine the channel shard key: the `x-shard-key` header now uses the channel's first key-path segment (`getFirstKeyPath()`) instead of the full key on attach / detach / refresh / watch / broadcast (yorkie-js-sdk#1109).
- Bump the CI `yorkie server` pin to v0.6.37.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- `channel.ts` key validation and `getFirstKeyPath()` were already present in the iOS `Channel`, so no port was needed there.
- Remaining v0.6.37 changes are JS/React examples, server integration tests, and lockfiles — not applicable to the iOS SDK.

**Does this PR introduce a user-facing change?**:
```release-note
Fix a crash (nil pointer dereference) in LLRBTree.floorEntry, and shard channel requests by the first key-path segment.
```

**Additional documentation**:
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Yorkie server dependency from v0.6.36 to v0.6.37 in Swift CI workflows.

* **Tests**
  * Added comprehensive test coverage for floor entry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->