### PR TITLE
Apply updates from yorkie-js-sdk 0.6.39

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.37
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b60bc244e5c730fead732d6d446d0dcb2ba76db3/Formula/y/yorkie.rb"
+      # yorkie server v0.6.39
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f9bdafae3e7666423330cd7383f7917b21e7f646/Formula/y/yorkie.rb"
       HOMEBREW_DEVELOPER: "1"
         
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.37
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b60bc244e5c730fead732d6d446d0dcb2ba76db3/Formula/y/yorkie.rb"
+      # yorkie server v0.6.39
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f9bdafae3e7666423330cd7383f7917b21e7f646/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,359 @@
+# Changelog
+
+All notable changes to Yorkie iOS SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and Yorkie iOS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
+
+## [v0.6.37] - 2026-06-02
+
+- Apply updates from yorkie-js-sdk 0.6.37 by @longhoang-lewy in https://github.com/yorkie-team/yorkie-ios-sdk/pull/241
+
+## [v0.6.36] - 2026-06-01
+
+- Apply updates from yorkie-js-sdk 0.6.36 by @longhoang-lewy in https://github.com/yorkie-team/yorkie-ios-sdk/pull/240
+- @longhoang-lewy made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/240
+
+## [v0.6.35] - 2026-01-12
+
+- Add Sample Todo MVC by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/226
+- Lack of conversion from JS to CRDTArray and CRDTObject in Converter by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/227
+- Add Example Simutaneous cursors by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/228
+- Add Example Scheduler by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/229
+- Add Example Rich Text Editor by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/230
+- Sync code for QA Process by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/231
+- Fix typo of SimultaneousCursors Example by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/232
+- Update swift connect to 1.2.0 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/233
+- Remove api key by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/234
+- Apply updates from yorkie-js-sdk 0.6.26 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/235
+- Apply updates from yorkie-js-sdk 0.6.28 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/236
+- Apply updates from yorkie-js-sdk 0.6.29 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/237
+- Apply updates from yorkie-js-sdk 0.6.34 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/238
+- Apply updates from yorkie-js-sdk 0.6.35 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/239
+
+## [v0.6.25] - 2025-09-30
+
+- Apply updates from yorkie-js-sdk 0.6.25 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/225
+
+## [v0.6.24] - 2025-09-29
+
+- Apply updates from yorkie-js-sdk 0.6.24 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/224
+
+## [v0.6.23] - 2025-09-25
+
+- Apply updates from yorkie-js-sdk 0.6.23 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/223
+
+## [v0.6.22] - 2025-09-25
+
+- Apply updates from yorkie-js-sdk 0.6.22 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/222
+
+## [v0.6.21] - 2025-09-25
+
+- _No release notes provided._ ([release](https://github.com/yorkie-team/yorkie-ios-sdk/releases/tag/0.6.21))
+
+## [v0.6.20] - 2025-09-25
+
+- _No release notes provided._ ([release](https://github.com/yorkie-team/yorkie-ios-sdk/releases/tag/0.6.20))
+
+## [v0.6.18] - 2025-09-16
+
+- Apply updates from yorkie-js-sdk 0.6.18 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/219
+
+## [v0.6.15] - 2025-09-11
+
+- Configure Code coverage for iOS CI/CD by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/217
+- Apply updates from yorkie-js-sdk 0.6.15 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/218
+
+## [v0.6.14] - 2025-08-29
+
+- Apply updates from yorkie-js-sdk 0.6.14 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/216
+
+## [v0.6.13] - 2025-08-29
+
+- Apply updates from yorkie-js-sdk 0.6.13 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/215
+
+## [v0.6.12] - 2025-08-15
+
+- Apply updates from yorkie-js-sdk 0.6.12 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/214
+
+## [v0.6.10] - 2025-08-11
+
+- Apply updates from yorkie-js-sdk 0.6.10 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/213
+
+## [v0.6.9] - 2025-08-04
+
+- Apply updates from yorkie-js-sdk 0.6.9 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/212
+
+## [v0.6.8] - 2025-07-30
+
+- Apply updates from yorkie-js-sdk 0.6.8 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/211
+
+## [v0.6.3] - 2025-07-23
+
+- Apply updates from yorkie-js-sdk 0.6.3 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/210
+
+## [v0.6.2] - 2025-07-18
+
+- Apply updates from yorkie-js-sdk 0.6.2 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/208
+
+## [v0.6.1] - 2025-07-18
+
+- Convert TransactionEvent to DocEvent by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/209
+
+## [v0.6.0] - 2025-07-16
+
+- Apply updates from yorkie-js-sdk 0.6.0 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/206
+
+## [v0.5.7] - 2025-07-11
+
+- Apply updates from yorkie-js-sdk 0.5.7 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/205
+
+## [v0.5.6] - 2025-07-09
+
+- Apply updates from yorkie-js-sdk 0.5.6 by @donhatkha in https://github.com/yorkie-team/yorkie-ios-sdk/pull/204
+- @donhatkha made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/204
+
+## [v0.5.5] - 2025-06-02
+
+- Handle retry for syncLoop and watchLoop by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/192
+- Improve performance for creating crdt.TreeNode by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/193
+- Unify error throwing methods by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/194
+- Introduce broadcast API for event sharing by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/195
+- Add configurable retry mechanism to broadcast interface by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/196
+- Add support for a new operation type ArraySet in the protocol by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/197
+- Introducing version vector to solve GC problem by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/199
+- Implement InitialRoot option for Document attachment by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/201
+- Add dynamic token refresh and authentication error handling by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/202
+- Fix build error in TextEditorApp example on Xcode 16.3 by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/203
+
+## [v0.4.26] - 2024-11-04
+
+- Add subscribeStatus(callback) function to Document by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/190
+- Remove node from indexes during GC by @hiddenviewer in https://github.com/yorkie-team/yorkie-ios-sdk/pull/191
+- @hiddenviewer made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/190
+
+## [v0.4.24] - 2024-08-28
+
+- Remove warnings and set public event values. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/189
+
+## [v0.4.23] - 2024-08-12
+
+- Fix invalid error message in CRDTTreePos by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/178
+- Add ServerSeq into ChangeInfo by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/179
+- Fix incorrect tree snapshot encoding/decoding by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/180
+- Fix incorrect indexes in TreeChange by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/181
+- Add RHTNode removal to converter for consistency by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/182
+- Fix miscalculation of tree size in concurrent editing by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/183
+- Lock local changes to assert transactions by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/184
+- Add lock by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/185
+- Handle local changes correctly when receiving snapshot by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/186
+- Change Client, Document actor to class by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/187
+- Modifying the slowdown caused by logging by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/188
+
+## [v0.4.20] - 2024-06-10
+
+- Implement RHT.GC by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/172
+- Avoid unnecessary syncs in push-only syncmode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/173
+- Apply GCPair to TreeNode, TextNode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/174
+- Migrate RPC to ConnectRPC by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/175
+- Prevent remote-change events in RealtimeSyncOff mode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/176
+- Remove skip from style-style-test by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/177
+
+## [v0.4.19] - 2024-05-27
+
+- Fix presence issues. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/163
+- Remove Client eventStream by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/164
+- Reset online clients when stream is disconnected by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/165
+- Handle concurrent editing and styling in Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/166
+- Fix invalid tree style changes by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/167
+- Fix inconsistent garbage collection for multiple nodes in text and tree type by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/168
+- Add Tree concurrency tests by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/169
+- Fix process of tree style change by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/170
+- Increase GRPC max Receive message length by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/171
+
+## [v0.4.17] - 2024-04-19
+
+- Add RealtimeSyncOff and refactor interface of SyncMode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/160
+- Reverse TreeChanges when Deleting in Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/161
+- Add Client constructor support URL address by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/162
+
+## [v0.4.16] - 2024-04-16
+
+- Provide CODECOV_TOKEN to codecov-action by @hackerwins in https://github.com/yorkie-team/yorkie-ios-sdk/pull/159
+- Implement Tree.RemoveStyle by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/158
+
+## [v0.4.15] - 2024-04-12
+
+- Fix incorrect index returned when using posRangeToIndexRange by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/149
+- Fix incorrect calculation in indexTree.treePosToPath operation by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/150
+- Change actorID to be non-optional by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/151
+- Fix errors when editing Tree due to missing insPrevID in CRDTTree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/153
+- Prevent remote-change events from occurring in push-only mode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/154
+- Fix string style value error of Tree Node attributes  by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/152
+- Modified to enable async closure in Subscription callback. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/155
+- remove async call of subscribe callbacks by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/156
+- Fix Tree to support emoji chracters. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/157
+
+## [v0.4.14] - 2024-02-15
+
+- Fix invalid TreeChanges in concurrent Tree.Style by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/146
+- Fix llrb tree error by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/147
+- Restore interface changes due to server DB sharding by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/148
+
+## [v0.4.13] - 2024-01-25
+
+- Reflect interface changes of server DB sharding by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/145
+
+## [v0.4.12] - 2024-01-22
+
+- Fix missing collection of removed elements from the root by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/125
+- Add toJSONString to JSONTreeNode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/126
+- Escape the string during toJSON. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/128
+- Prevent escaping slash of URL by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/127
+- Remove unused @MainActor by @wi-seong-cheol in https://github.com/yorkie-team/yorkie-ios-sdk/pull/129
+- Fix the Incorrectly generated attributes for toJsonString  of Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/131
+- remove envoy docker settings by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/132
+- Open clear function of Presence by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/133
+- Fix CI error script by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/135
+- Add missing removedAt during Primitive deepcopy by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/136
+- Add forced sync when switching to realtime mode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/134
+- Add more GC tests to reflect current server modifications by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/130
+- Fix getGarbageLen to retrun correct size  by @myupage in https://github.com/yorkie-team/yorkie-ios-sdk/pull/143
+- Refactor Tree codes by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/137
+- Implement splitLevel of Tree.Edit by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/139
+- Address duplicate node IDs in Tree.Split by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/138
+- Support concurrent insertion and splitting in Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/140
+- Generate correct TreeChange in concurrent edits by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/141
+- Bump to 0.4.12 by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/144
+- @wi-seong-cheol made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/129
+
+## [v0.4.7] - 2023-10-19
+
+- Remove SelectOpInfo by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/112
+- Add Tree.Edit benchmark and improve performance by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/113
+- Fix converter to get tree from snapshot by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/114
+- Add toJS to return TreeNode of Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/115
+- Remove strong reference cycle by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/118
+- Modify the JSON tree to allow Any dictionaries for the attributes by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/119
+- Add DisableGC option to document by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/117
+- Remove unused trie by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/120
+- Support concurrent formatting of Text by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/116
+- Remove TreeNode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/121
+- Fix generic warning at Xcode 15 by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/122
+- Fix the conversion for attribute of Tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/123
+
+## [v0.4.6] - 2023-08-31
+
+- Implement yorkie.Tree for text editors using tree model by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/90
+- memory leak fixed for TextEditorViewController in TextEditorSample by @myupage in https://github.com/yorkie-team/yorkie-ios-sdk/pull/89
+- Expose pathToIndex API by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/91
+- Fix gc to remove all removed nodes by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/92
+- Allow multi tree nodes when edit by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/93
+- Move Presence from Client to Document by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/94
+- Update Tree.edit to allow insertion of multiple contents at once by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/95
+- Replace selection with presence by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/96
+- Rename TextRangeStruct to TextPosStructRange by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/97
+- Clean up methods related to presence by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/98
+- Add presence.get() to get presence value in doc.update() by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/99
+- Change 'Documents' from plural to singular in DocEvent by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/100
+- Cleanup proto by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/101
+- Concurrent case handling for Yorkie.tree by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/102
+- Change TreeNode to have IDs instead of insPrev, insNext by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/103
+- Remove select operation from text by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/104
+- Adds more TCs for Tree test by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/105
+- Support multi-level and parital element selection by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/106
+- Fix presence to support JSONObject by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/107
+- Apply SDK 0.4.6 to Examples by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/110
+- Prepare 0.4.6 by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/111
+- @myupage made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/89
+
+## [v0.3.6] - 2023-07-13
+
+- Add getValueByPath() to the document  by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/86
+
+## [v0.3.5] - 2023-07-11
+
+- Apply Integration of SDK and Admin RPC Server by @krapie in https://github.com/yorkie-team/yorkie-ios-sdk/pull/69
+- Add x-shard-key to APIs by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/72
+- Add Client sync mode by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/65
+- Fix when searching for presence of non-existent peer by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/77
+- Allow specifying a topic when subscribing to a document by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/78
+- Replace Text event Stream with Document.subscribe by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/83
+- Change the value of XXXChange to Change in Document.subscribe by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/84
+- @krapie made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/69
+
+## [v0.3.3] - 2023-03-30
+
+- Update toJson() of Text to match results with JS by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/57
+- Remove delays for sync by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/58
+- Add toDocKey to convert to a valid key in tests by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/60
+- Implement the select feature in the Text Editor by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/61
+- Implement the pause/resume by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/62
+- Add RemoveDocument API by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/64
+- Add x-yorkie-user-agent by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/67
+
+## [v0.3.0] - 2023-02-21
+
+- Implement Text Element by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/50
+- Remove duplicated key from TextNodeAttr by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/52
+- Change Counter increase() to accept any numeric value by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/51
+- Let Client.attach wait until stream initialization is finished by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/53
+- Implement authentication of the client by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/55
+- feat: remove priority queue from RHTPQMap and entire project by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/56
+- Implement Text editor sample by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/54
+
+## [v0.2.20] - 2022-12-29
+
+- Prepare Multi examples. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/45
+- Apply swift-log package. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/46
+- Implements the TLS connection. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/47
+- Change the client relate code in the Example. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/48
+
+## [v0.2.19] - 2022-12-09
+
+- Initial project setup by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/2
+- Create swift.yml by @hackerwins in https://github.com/yorkie-team/yorkie-ios-sdk/pull/3
+- Add PR and issue templates by @hackerwins in https://github.com/yorkie-team/yorkie-ios-sdk/pull/4
+- Update swift.yml to use SwiftLint by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/5
+- Create folders based on yorkie-js-sdk by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/6
+- Add client activate/deactivate by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/7
+- Add heap, RedBlack Tree by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/8
+- Add Splay Tree by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/9
+- Add TimeTicket, ActorId, CRDTElement, Primitive, GRPCTypeAlias, YorkieError and related Tests by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/10
+- Add RGATreeList by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/11
+- Add CRDTArray by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/12
+- Add RHTPQMap and Change CRDTElement type from class to protocol by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/13
+- Report the code coverage to codecov by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/14
+- Add CRDTObject by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/15
+- Support Network byte order for Primitive values by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/16
+- Add RHT by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/17
+- Hyeongsik won fix/remove docker by @hackerwins in https://github.com/yorkie-team/yorkie-ios-sdk/pull/20
+- Add CRDTRoot, Operation, SetOperation and RemoveOepration by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/19
+- Add AddOperation and MoveOperation by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/21
+- Modify escaping string by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/22
+- Add ChangeID, Change, ChangeContext, CheckPoint and ChangePack by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/23
+- Add Trie, JsonObject, and Document by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/25
+- Initial implementation of the Converter between SDK structures and Protobuf Structures. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/24
+- Remove features for dynamicMemberLookup from JSONObject by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/26
+- Add JSONArrays and unit tests for Document by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/27
+- Create ExampleApp and fix some bugs by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/28
+- Change Document from class to actor for concurrent access to it by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/29
+- Add Kanban board to ExampleApp & Improve the interfaces of JSONObject and JSONArray by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/30
+- Implement Client functions. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/31
+- Sync Kanban app with a local server and fix some bugs by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/32
+- Change some types from class to struct to avoid data racing by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/33
+- Apply styles for Swift by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/35
+- Convert Client from class to actor for concurrency. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/34
+- Change endian of Primitive values to little endian by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/36
+- Improve Document sync Test. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/37
+- Add get(keyPath:) to JSONObject by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/38
+- Setup for integration tests by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/39
+- Implement the Counter. by @humdrum in https://github.com/yorkie-team/yorkie-ios-sdk/pull/40
+- Add a github action to publish API reference docs by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/41
+- Apply changed comments of JS-SDK by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/42
+- Change eventStream of Client from Error to Never by @hyeongsik-won in https://github.com/yorkie-team/yorkie-ios-sdk/pull/43
+- Create MAINTAINING.md for v0.2.19 by @hackerwins in https://github.com/yorkie-team/yorkie-ios-sdk/pull/44
+- @hyeongsik-won made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/2
+- @hackerwins made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/3
+- @humdrum made their first contribution in https://github.com/yorkie-team/yorkie-ios-sdk/pull/16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.6.39] - 2026-06-02
+
+- Apply updates from yorkie-js-sdk 0.6.39 in https://github.com/yorkie-team/yorkie-ios-sdk/pull/242
+
 ## [v0.6.37] - 2026-06-02
 
 - Apply updates from yorkie-js-sdk 0.6.37 by @longhoang-lewy in https://github.com/yorkie-team/yorkie-ios-sdk/pull/241

--- a/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
+++ b/Examples/TextEditorApp/TextEditorApp/TextEditor/TextViewModel.swift
@@ -30,7 +30,7 @@ class TextViewModel {
 
     private weak var operationSubject: PassthroughSubject<[TextOperation], Never>?
 
-    init(_ operationSubject: PassthroughSubject<[TextOperation], Never>) {
+    @MainActor init(_ operationSubject: PassthroughSubject<[TextOperation], Never>) {
         self.operationSubject = operationSubject
 
         // create client with RPCAddress.
@@ -46,7 +46,7 @@ class TextViewModel {
             // attach the document into the client.
             try! await self.client.attach(self.document)
 
-            try await self.document.update { root, _ in
+            try self.document.update { root, _ in
                 var text = root.content as? JSONText
                 if text == nil {
                     root.content = JSONText()
@@ -55,7 +55,7 @@ class TextViewModel {
             }
 
             // subscribe document event.
-            await self.document.subscribe { [weak self] event, _ in
+            self.document.subscribe { [weak self] event, _ in
                 switch event.type {
                 case .snapshot, .remoteChange:
                     Task { [weak self] in
@@ -66,7 +66,7 @@ class TextViewModel {
                 }
             }
 
-            await self.document.subscribePresence(.others) { [weak self] event, document in
+            self.document.subscribePresence(.others) { [weak self] event, document in
                 if let event = event as? PresenceChangedEvent {
                     if let fromPos: TextPosStruct = self?.decodePresence(event.value.presence["from"]),
                        let toPos: TextPosStruct = self?.decodePresence(event.value.presence["to"])

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -2171,6 +2171,20 @@ public struct Yorkie_V1_Presence: Sendable {
   public init() {}
 }
 
+public struct Yorkie_V1_ChannelSummary: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var key: String = String()
+
+  public var presenceCount: Int32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Yorkie_V1_Checkpoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -2413,6 +2427,37 @@ public struct Yorkie_V1_Rule: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+}
+
+public struct Yorkie_V1_RevisionSummary: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var id: String = String()
+
+  public var seq: Int64 = 0
+
+  public var label: String = String()
+
+  public var description_p: String = String()
+
+  public var snapshot: String = String()
+
+  public var createdAt: SwiftProtobuf.Google_Protobuf_Timestamp {
+    get {_createdAt ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_createdAt = newValue}
+  }
+  /// Returns true if `createdAt` has been explicitly set.
+  public var hasCreatedAt: Bool {self._createdAt != nil}
+  /// Clears the value of `createdAt`. Subsequent reads from it will return its default value.
+  public mutating func clearCreatedAt() {self._createdAt = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _createdAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -5511,6 +5556,41 @@ extension Yorkie_V1_Presence: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
+extension Yorkie_V1_ChannelSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ChannelSummary"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{3}presence_count\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.presenceCount) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.key.isEmpty {
+      try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
+    }
+    if self.presenceCount != 0 {
+      try visitor.visitSingularInt32Field(value: self.presenceCount, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_ChannelSummary, rhs: Yorkie_V1_ChannelSummary) -> Bool {
+    if lhs.key != rhs.key {return false}
+    if lhs.presenceCount != rhs.presenceCount {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Yorkie_V1_Checkpoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Checkpoint"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}server_seq\0\u{3}client_seq\0")
@@ -5931,6 +6011,65 @@ extension Yorkie_V1_Rule: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
   public static func ==(lhs: Yorkie_V1_Rule, rhs: Yorkie_V1_Rule) -> Bool {
     if lhs.path != rhs.path {return false}
     if lhs.type != rhs.type {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_RevisionSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".RevisionSummary"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}seq\0\u{1}label\0\u{1}description\0\u{1}snapshot\0\u{3}created_at\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.id) }()
+      case 2: try { try decoder.decodeSingularInt64Field(value: &self.seq) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.label) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.description_p) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.snapshot) }()
+      case 6: try { try decoder.decodeSingularMessageField(value: &self._createdAt) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.id.isEmpty {
+      try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
+    }
+    if self.seq != 0 {
+      try visitor.visitSingularInt64Field(value: self.seq, fieldNumber: 2)
+    }
+    if !self.label.isEmpty {
+      try visitor.visitSingularStringField(value: self.label, fieldNumber: 3)
+    }
+    if !self.description_p.isEmpty {
+      try visitor.visitSingularStringField(value: self.description_p, fieldNumber: 4)
+    }
+    if !self.snapshot.isEmpty {
+      try visitor.visitSingularStringField(value: self.snapshot, fieldNumber: 5)
+    }
+    try { if let v = self._createdAt {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_RevisionSummary, rhs: Yorkie_V1_RevisionSummary) -> Bool {
+    if lhs.id != rhs.id {return false}
+    if lhs.seq != rhs.seq {return false}
+    if lhs.label != rhs.label {return false}
+    if lhs.description_p != rhs.description_p {return false}
+    if lhs.snapshot != rhs.snapshot {return false}
+    if lhs._createdAt != rhs._createdAt {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/Generated/yorkie/v1/yorkie.connect.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/yorkie.connect.swift
@@ -54,6 +54,24 @@ public protocol Yorkie_V1_YorkieServiceClientInterface: Sendable {
     func `watchDocument`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Yorkie_V1_WatchDocumentRequest, Yorkie_V1_WatchDocumentResponse>
 
     @discardableResult
+    func `createRevision`(request: Yorkie_V1_CreateRevisionRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_CreateRevisionResponse>) -> Void) -> Connect.Cancelable
+
+    @available(iOS 13, *)
+    func `createRevision`(request: Yorkie_V1_CreateRevisionRequest, headers: Connect.Headers) async -> ResponseMessage<Yorkie_V1_CreateRevisionResponse>
+
+    @discardableResult
+    func `listRevisions`(request: Yorkie_V1_ListRevisionsRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_ListRevisionsResponse>) -> Void) -> Connect.Cancelable
+
+    @available(iOS 13, *)
+    func `listRevisions`(request: Yorkie_V1_ListRevisionsRequest, headers: Connect.Headers) async -> ResponseMessage<Yorkie_V1_ListRevisionsResponse>
+
+    @discardableResult
+    func `restoreRevision`(request: Yorkie_V1_RestoreRevisionRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_RestoreRevisionResponse>) -> Void) -> Connect.Cancelable
+
+    @available(iOS 13, *)
+    func `restoreRevision`(request: Yorkie_V1_RestoreRevisionRequest, headers: Connect.Headers) async -> ResponseMessage<Yorkie_V1_RestoreRevisionResponse>
+
+    @discardableResult
     func `attachChannel`(request: Yorkie_V1_AttachChannelRequest, headers: Connect.Headers, completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_AttachChannelResponse>) -> Void) -> Connect.Cancelable
 
     @available(iOS 13, *)
@@ -161,6 +179,36 @@ public final class Yorkie_V1_YorkieServiceClient: Yorkie_V1_YorkieServiceClientI
     }
 
     @discardableResult
+    public func `createRevision`(request: Yorkie_V1_CreateRevisionRequest, headers: Connect.Headers = [:], completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_CreateRevisionResponse>) -> Void) -> Connect.Cancelable {
+        return self.client.unary(path: "/yorkie.v1.YorkieService/CreateRevision", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
+    }
+
+    @available(iOS 13, *)
+    public func `createRevision`(request: Yorkie_V1_CreateRevisionRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Yorkie_V1_CreateRevisionResponse> {
+        return await self.client.unary(path: "/yorkie.v1.YorkieService/CreateRevision", idempotencyLevel: .unknown, request: request, headers: headers)
+    }
+
+    @discardableResult
+    public func `listRevisions`(request: Yorkie_V1_ListRevisionsRequest, headers: Connect.Headers = [:], completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_ListRevisionsResponse>) -> Void) -> Connect.Cancelable {
+        return self.client.unary(path: "/yorkie.v1.YorkieService/ListRevisions", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
+    }
+
+    @available(iOS 13, *)
+    public func `listRevisions`(request: Yorkie_V1_ListRevisionsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Yorkie_V1_ListRevisionsResponse> {
+        return await self.client.unary(path: "/yorkie.v1.YorkieService/ListRevisions", idempotencyLevel: .unknown, request: request, headers: headers)
+    }
+
+    @discardableResult
+    public func `restoreRevision`(request: Yorkie_V1_RestoreRevisionRequest, headers: Connect.Headers = [:], completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_RestoreRevisionResponse>) -> Void) -> Connect.Cancelable {
+        return self.client.unary(path: "/yorkie.v1.YorkieService/RestoreRevision", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
+    }
+
+    @available(iOS 13, *)
+    public func `restoreRevision`(request: Yorkie_V1_RestoreRevisionRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Yorkie_V1_RestoreRevisionResponse> {
+        return await self.client.unary(path: "/yorkie.v1.YorkieService/RestoreRevision", idempotencyLevel: .unknown, request: request, headers: headers)
+    }
+
+    @discardableResult
     public func `attachChannel`(request: Yorkie_V1_AttachChannelRequest, headers: Connect.Headers = [:], completion: @escaping @Sendable (ResponseMessage<Yorkie_V1_AttachChannelResponse>) -> Void) -> Connect.Cancelable {
         return self.client.unary(path: "/yorkie.v1.YorkieService/AttachChannel", idempotencyLevel: .unknown, request: request, headers: headers, completion: completion)
     }
@@ -218,6 +266,9 @@ public final class Yorkie_V1_YorkieServiceClient: Yorkie_V1_YorkieServiceClientI
             public static let removeDocument = Connect.MethodSpec(name: "RemoveDocument", service: "yorkie.v1.YorkieService", type: .unary)
             public static let pushPullChanges = Connect.MethodSpec(name: "PushPullChanges", service: "yorkie.v1.YorkieService", type: .unary)
             public static let watchDocument = Connect.MethodSpec(name: "WatchDocument", service: "yorkie.v1.YorkieService", type: .serverStream)
+            public static let createRevision = Connect.MethodSpec(name: "CreateRevision", service: "yorkie.v1.YorkieService", type: .unary)
+            public static let listRevisions = Connect.MethodSpec(name: "ListRevisions", service: "yorkie.v1.YorkieService", type: .unary)
+            public static let restoreRevision = Connect.MethodSpec(name: "RestoreRevision", service: "yorkie.v1.YorkieService", type: .unary)
             public static let attachChannel = Connect.MethodSpec(name: "AttachChannel", service: "yorkie.v1.YorkieService", type: .unary)
             public static let detachChannel = Connect.MethodSpec(name: "DetachChannel", service: "yorkie.v1.YorkieService", type: .unary)
             public static let refreshChannel = Connect.MethodSpec(name: "RefreshChannel", service: "yorkie.v1.YorkieService", type: .unary)

--- a/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
@@ -344,6 +344,101 @@ public struct Yorkie_V1_PushPullChangesResponse: Sendable {
   fileprivate var _changePack: Yorkie_V1_ChangePack? = nil
 }
 
+public struct Yorkie_V1_CreateRevisionRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var clientID: String = String()
+
+  public var documentID: String = String()
+
+  public var label: String = String()
+
+  public var description_p: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Yorkie_V1_CreateRevisionResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var revision: Yorkie_V1_RevisionSummary {
+    get {_revision ?? Yorkie_V1_RevisionSummary()}
+    set {_revision = newValue}
+  }
+  /// Returns true if `revision` has been explicitly set.
+  public var hasRevision: Bool {self._revision != nil}
+  /// Clears the value of `revision`. Subsequent reads from it will return its default value.
+  public mutating func clearRevision() {self._revision = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _revision: Yorkie_V1_RevisionSummary? = nil
+}
+
+public struct Yorkie_V1_ListRevisionsRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var projectID: String = String()
+
+  public var documentID: String = String()
+
+  public var pageSize: Int32 = 0
+
+  public var offset: Int32 = 0
+
+  public var isForward: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Yorkie_V1_ListRevisionsResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var revisions: [Yorkie_V1_RevisionSummary] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Yorkie_V1_RestoreRevisionRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var clientID: String = String()
+
+  public var revisionID: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Yorkie_V1_RestoreRevisionResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Yorkie_V1_AttachChannelRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1105,6 +1200,219 @@ extension Yorkie_V1_PushPullChangesResponse: SwiftProtobuf.Message, SwiftProtobu
 
   public static func ==(lhs: Yorkie_V1_PushPullChangesResponse, rhs: Yorkie_V1_PushPullChangesResponse) -> Bool {
     if lhs._changePack != rhs._changePack {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_CreateRevisionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateRevisionRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}document_id\0\u{1}label\0\u{1}description\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.clientID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.documentID) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.label) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.description_p) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.clientID.isEmpty {
+      try visitor.visitSingularStringField(value: self.clientID, fieldNumber: 1)
+    }
+    if !self.documentID.isEmpty {
+      try visitor.visitSingularStringField(value: self.documentID, fieldNumber: 2)
+    }
+    if !self.label.isEmpty {
+      try visitor.visitSingularStringField(value: self.label, fieldNumber: 3)
+    }
+    if !self.description_p.isEmpty {
+      try visitor.visitSingularStringField(value: self.description_p, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_CreateRevisionRequest, rhs: Yorkie_V1_CreateRevisionRequest) -> Bool {
+    if lhs.clientID != rhs.clientID {return false}
+    if lhs.documentID != rhs.documentID {return false}
+    if lhs.label != rhs.label {return false}
+    if lhs.description_p != rhs.description_p {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_CreateRevisionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateRevisionResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}revision\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._revision) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._revision {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_CreateRevisionResponse, rhs: Yorkie_V1_CreateRevisionResponse) -> Bool {
+    if lhs._revision != rhs._revision {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_ListRevisionsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ListRevisionsRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}project_id\0\u{3}document_id\0\u{3}page_size\0\u{1}offset\0\u{3}is_forward\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.projectID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.documentID) }()
+      case 3: try { try decoder.decodeSingularInt32Field(value: &self.pageSize) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self.offset) }()
+      case 5: try { try decoder.decodeSingularBoolField(value: &self.isForward) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.projectID.isEmpty {
+      try visitor.visitSingularStringField(value: self.projectID, fieldNumber: 1)
+    }
+    if !self.documentID.isEmpty {
+      try visitor.visitSingularStringField(value: self.documentID, fieldNumber: 2)
+    }
+    if self.pageSize != 0 {
+      try visitor.visitSingularInt32Field(value: self.pageSize, fieldNumber: 3)
+    }
+    if self.offset != 0 {
+      try visitor.visitSingularInt32Field(value: self.offset, fieldNumber: 4)
+    }
+    if self.isForward != false {
+      try visitor.visitSingularBoolField(value: self.isForward, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_ListRevisionsRequest, rhs: Yorkie_V1_ListRevisionsRequest) -> Bool {
+    if lhs.projectID != rhs.projectID {return false}
+    if lhs.documentID != rhs.documentID {return false}
+    if lhs.pageSize != rhs.pageSize {return false}
+    if lhs.offset != rhs.offset {return false}
+    if lhs.isForward != rhs.isForward {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_ListRevisionsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ListRevisionsResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}revisions\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.revisions) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.revisions.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.revisions, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_ListRevisionsResponse, rhs: Yorkie_V1_ListRevisionsResponse) -> Bool {
+    if lhs.revisions != rhs.revisions {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_RestoreRevisionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".RestoreRevisionRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}revision_id\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.clientID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.revisionID) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.clientID.isEmpty {
+      try visitor.visitSingularStringField(value: self.clientID, fieldNumber: 1)
+    }
+    if !self.revisionID.isEmpty {
+      try visitor.visitSingularStringField(value: self.revisionID, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_RestoreRevisionRequest, rhs: Yorkie_V1_RestoreRevisionRequest) -> Bool {
+    if lhs.clientID != rhs.clientID {return false}
+    if lhs.revisionID != rhs.revisionID {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_RestoreRevisionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".RestoreRevisionResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_RestoreRevisionResponse, rhs: Yorkie_V1_RestoreRevisionResponse) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/buf.gen.yaml
+++ b/Sources/API/V1/buf.gen.yaml
@@ -1,12 +1,12 @@
 version: v1
 plugins:
-  - plugin: buf.build/connectrpc/swift
+  - plugin: buf.build/connectrpc/swift:v1.0.3
     opt:
       - GenerateAsyncMethods=true
       - GenerateCallbackMethods=true
       - Visibility=Public
     out: Generated
-  - plugin: buf.build/apple/swift
+  - plugin: buf.build/apple/swift:v1.37.0
     opt:
       - Visibility=Public
     out: Generated

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -378,6 +378,11 @@ message Presence {
   map<string, string> data = 1;
 }
 
+message ChannelSummary {
+  string key = 1;
+  int32 presence_count = 2;
+}
+
 message Checkpoint {
   int64 server_seq = 1; 
   uint32 client_seq = 2;
@@ -467,4 +472,17 @@ message Schema {
 message Rule {
   string path = 1;
   string type = 2;
+}
+
+/////////////////////////////////////////
+// Messages for Revision               //
+/////////////////////////////////////////
+
+message RevisionSummary {
+  string id = 1;
+  int64 seq = 2;
+  string label = 3;
+  string description = 4;
+  string snapshot = 5;
+  google.protobuf.Timestamp created_at = 6;
 }

--- a/Sources/API/V1/yorkie/v1/yorkie.proto
+++ b/Sources/API/V1/yorkie/v1/yorkie.proto
@@ -35,6 +35,10 @@ service YorkieService {
   rpc PushPullChanges (PushPullChangesRequest) returns (PushPullChangesResponse) {}
   rpc WatchDocument (WatchDocumentRequest) returns (stream WatchDocumentResponse) {}
 
+  rpc CreateRevision (CreateRevisionRequest) returns (CreateRevisionResponse) {}
+  rpc ListRevisions (ListRevisionsRequest) returns (ListRevisionsResponse) {}
+  rpc RestoreRevision (RestoreRevisionRequest) returns (RestoreRevisionResponse) {}
+
   rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
   rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
   rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
@@ -118,6 +122,37 @@ message PushPullChangesRequest {
 
 message PushPullChangesResponse {
   ChangePack change_pack = 1;
+}
+
+message CreateRevisionRequest {
+  string client_id = 1;
+  string document_id = 2;
+  string label = 3;
+  string description = 4;
+}
+
+message CreateRevisionResponse {
+  RevisionSummary revision = 1;
+}
+
+message ListRevisionsRequest {
+  string project_id = 1;
+  string document_id = 2;
+  int32 page_size = 3;
+  int32 offset = 4;
+  bool is_forward = 5;
+}
+
+message ListRevisionsResponse {
+  repeated RevisionSummary revisions = 1;
+}
+
+message RestoreRevisionRequest {
+  string client_id = 1;
+  string revision_id = 2;
+}
+
+message RestoreRevisionResponse {
 }
 
 message AttachChannelRequest {

--- a/Sources/Document/CRDT/CRDTArray.swift
+++ b/Sources/Document/CRDT/CRDTArray.swift
@@ -163,7 +163,7 @@ extension CRDTArray {
     func deepcopy() -> CRDTElement {
         let result = CRDTArray(createdAt: self.createdAt)
         for node in self.elements {
-            try? result.elements.insert(
+            _ = try? result.elements.insert(
                 node.value.deepcopy(),
                 prevCreatedAt: result.getLastCreatedAt()
             )

--- a/Sources/Document/Change/ChangeID.swift
+++ b/Sources/Document/Change/ChangeID.swift
@@ -108,9 +108,6 @@ struct ChangeID {
     func setClocks(with otherLamport: Int64, vector: VersionVector) -> ChangeID {
         let lamport = otherLamport > self.lamport ? otherLamport + 1 : self.lamport + 1
 
-        // clone another vector before mutating
-        var vector = vector
-
         var maxVersionVector = self.versionVector.max(other: vector)
         maxVersionVector.set(actorID: self.actor, lamport: lamport)
 

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -130,7 +130,6 @@ public class JSONArray: CustomDebugStringConvertible {
     /**
      * `moveAfterByIndex` moves the element after the given index.
      */
-    @discardableResult
     func moveAfterByIndex(
         prevIndex: Int,
         targetIndex: Int

--- a/Tests/Integration/ClientIntegrationTests.swift
+++ b/Tests/Integration/ClientIntegrationTests.swift
@@ -37,28 +37,28 @@ final class ClientIntegrationTests: XCTestCase {
 
         let clientWithKey = Client(self.rpcAddress, options)
 
-        var boolResult = await clientWithKey.isActive
+        var boolResult = clientWithKey.isActive
         XCTAssertFalse(boolResult)
         try await clientWithKey.activate()
-        boolResult = await clientWithKey.isActive
+        boolResult = clientWithKey.isActive
         XCTAssertTrue(boolResult)
         var key = clientWithKey.key
         XCTAssertEqual(key, clientKey)
         try await clientWithKey.deactivate()
-        boolResult = await clientWithKey.isActive
+        boolResult = clientWithKey.isActive
         XCTAssertFalse(boolResult)
 
         let clientWithoutKey = Client(self.rpcAddress)
 
-        boolResult = await clientWithoutKey.isActive
+        boolResult = clientWithoutKey.isActive
         XCTAssertFalse(boolResult)
         try await clientWithoutKey.activate()
-        boolResult = await clientWithoutKey.isActive
+        boolResult = clientWithoutKey.isActive
         XCTAssertTrue(boolResult)
         key = clientWithoutKey.key
         XCTAssertEqual(key.count, 36)
         try await clientWithoutKey.deactivate()
-        boolResult = await clientWithoutKey.isActive
+        boolResult = clientWithoutKey.isActive
         XCTAssertFalse(boolResult)
     }
 
@@ -98,39 +98,39 @@ final class ClientIntegrationTests: XCTestCase {
     @MainActor
     func test_can_handle_sync() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = "v1"
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k2 = "v2"
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k3 = "v3"
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -203,44 +203,44 @@ final class ClientIntegrationTests: XCTestCase {
         try await c1.attach(d1, [:], .manual)
         try await c2.attach(d2, [:], .manual)
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.version = "v1"
         }
 
-        var d1JSON = await d1.toSortedJSON()
-        var d2JSON = await d2.toSortedJSON()
+        var d1JSON = d1.toSortedJSON()
+        var d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v1\"}")
         XCTAssertEqual(d2JSON, "{}")
 
         try await c1.sync()
         try await c2.sync()
 
-        d2JSON = await d2.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d2JSON, "{\"version\":\"v1\"}")
 
         // 02. c2 changes the sync mode to realtime sync mode.
         let c2Exp1 = expectation(description: "C2 Exp")
 
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 c2Exp1.fulfill()
             }
         }
 
-        try await c2.changeSyncMode(d2, .realtime)
+        try c2.changeSyncMode(d2, .realtime)
         await fulfillment(of: [c2Exp1], timeout: 5) // sync occurs when resuming
 
-        await d2.unsubscribeSync()
+        d2.unsubscribeSync()
 
         let c2Exp2 = expectation(description: "C2 Exp 2")
 
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 c2Exp2.fulfill()
             }
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.version = "v2"
         }
 
@@ -248,26 +248,26 @@ final class ClientIntegrationTests: XCTestCase {
 
         await fulfillment(of: [c2Exp2], timeout: 5)
 
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v2\"}")
         XCTAssertEqual(d2JSON, "{\"version\":\"v2\"}")
 
-        await d2.unsubscribeSync()
+        d2.unsubscribeSync()
 
         // 03. c2 changes the sync mode to manual sync mode again.
-        try await c2.changeSyncMode(d2, .manual)
-        try await d1.update { root, _ in
+        try c2.changeSyncMode(d2, .manual)
+        try d1.update { root, _ in
             root.version = "v3"
         }
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v3\"}")
         XCTAssertEqual(d2JSON, "{\"version\":\"v2\"}")
 
         try await c1.sync()
         try await c2.sync()
-        d2JSON = await d2.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d2JSON, "{\"version\":\"v3\"}")
 
         try await c1.deactivate()
@@ -319,7 +319,7 @@ final class ClientIntegrationTests: XCTestCase {
         var d2EventCount = 0
         var d3EventCount = 0
 
-        await d1.subscribe { event, _ in
+        d1.subscribe { event, _ in
             guard event is ChangeEvent else {
                 return
             }
@@ -340,7 +340,7 @@ final class ClientIntegrationTests: XCTestCase {
             }
         }
 
-        await d2.subscribe { event, _ in
+        d2.subscribe { event, _ in
             guard event is ChangeEvent else {
                 return
             }
@@ -362,7 +362,7 @@ final class ClientIntegrationTests: XCTestCase {
             }
         }
 
-        await d3.subscribe { event, _ in
+        d3.subscribe { event, _ in
             guard event is ChangeEvent else {
                 return
             }
@@ -385,79 +385,79 @@ final class ClientIntegrationTests: XCTestCase {
         }
 
         // 02. [Step1] c1, c2, c3 sync in realtime.
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.c1 = Int64(0)
         }
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             root.c2 = Int64(0)
         }
-        try await d3.update { root, _ in
+        try d3.update { root, _ in
             root.c3 = Int64(0)
         }
 
         await fulfillment(of: [d1Exp1, d2Exp1, d3Exp1], timeout: 5)
 
-        var d1JSON = await d1.toSortedJSON()
-        var d2JSON = await d2.toSortedJSON()
-        var d3JSON = await d3.toSortedJSON()
+        var d1JSON = d1.toSortedJSON()
+        var d2JSON = d2.toSortedJSON()
+        var d3JSON = d3.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"c1\":0,\"c2\":0,\"c3\":0}")
         XCTAssertEqual(d2JSON, "{\"c1\":0,\"c2\":0,\"c3\":0}")
         XCTAssertEqual(d3JSON, "{\"c1\":0,\"c2\":0,\"c3\":0}")
 
         // 03. [Step2] c1 sync with push-only mode, c2 sync with sync-off mode.
         // c3 can get the changes of c1 and c2, because c3 sync with push-pull mode.
-        try await c1.changeSyncMode(d1, .realtimePushOnly)
-        try await c2.changeSyncMode(d2, .realtimeSyncOff)
-        try await d1.update { root, _ in
+        try c1.changeSyncMode(d1, .realtimePushOnly)
+        try c2.changeSyncMode(d2, .realtimeSyncOff)
+        try d1.update { root, _ in
             root.c1 = Int64(1)
         }
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             root.c2 = Int64(1)
         }
-        try await d3.update { root, _ in
+        try d3.update { root, _ in
             root.c3 = Int64(1)
         }
 
         await fulfillment(of: [d1Exp2, d2Exp2, d3Exp2], timeout: 5)
 
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
-        d3JSON = await d3.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
+        d3JSON = d3.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"c1\":1,\"c2\":0,\"c3\":0}")
         XCTAssertEqual(d2JSON, "{\"c1\":0,\"c2\":1,\"c3\":0}")
         XCTAssertEqual(d3JSON, "{\"c1\":1,\"c2\":0,\"c3\":1}")
 
         // 04. [Step3] c1 sync with sync-off mode, c2 sync with push-only mode.
-        try await c1.changeSyncMode(d1, .realtimeSyncOff)
-        try await c2.changeSyncMode(d2, .realtimePushOnly)
-        try await d1.update { root, _ in
+        try c1.changeSyncMode(d1, .realtimeSyncOff)
+        try c2.changeSyncMode(d2, .realtimePushOnly)
+        try d1.update { root, _ in
             root.c1 = Int64(2)
         }
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             root.c2 = Int64(2)
         }
-        try await d3.update { root, _ in
+        try d3.update { root, _ in
             root.c3 = Int64(2)
         }
 
         await fulfillment(of: [d1Exp3, d2Exp3, d3Exp3], timeout: 5)
 
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
-        d3JSON = await d3.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
+        d3JSON = d3.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"c1\":2,\"c2\":0,\"c3\":0}")
         XCTAssertEqual(d2JSON, "{\"c1\":0,\"c2\":2,\"c3\":0}")
         XCTAssertEqual(d3JSON, "{\"c1\":1,\"c2\":2,\"c3\":2}")
 
         // 05. [Step4] c1 and c2 sync with push-pull mode.
-        try await c1.changeSyncMode(d1, .realtime)
-        try await c2.changeSyncMode(d2, .realtime)
+        try c1.changeSyncMode(d1, .realtime)
+        try c2.changeSyncMode(d2, .realtime)
 
         await fulfillment(of: [d1Exp4, d2Exp4, d3Exp4], timeout: 5)
 
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
-        d3JSON = await d3.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
+        d3JSON = d3.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"c1\":2,\"c2\":2,\"c3\":2}")
         XCTAssertEqual(d2JSON, "{\"c1\":2,\"c2\":2,\"c3\":2}")
         XCTAssertEqual(d3JSON, "{\"c1\":2,\"c2\":2,\"c3\":2}")
@@ -481,7 +481,7 @@ final class ClientIntegrationTests: XCTestCase {
         let d2 = Document(key: docKey)
 
         let exp1 = expectation(description: "exp 1")
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 exp1.fulfill()
             }
@@ -491,74 +491,74 @@ final class ClientIntegrationTests: XCTestCase {
         try await c1.attach(d1, [:], .manual)
         try await c2.attach(d2)
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.version = "v1"
         }
 
         try await c1.sync()
 
-        var d1JSON = await d1.toSortedJSON()
+        var d1JSON = d1.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v1\"}")
 
         await fulfillment(of: [exp1], timeout: 5)
 
-        var d2JSON = await d2.toSortedJSON()
+        var d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d2JSON, "{\"version\":\"v1\"}")
 
         // 02. c2 is changed to manual sync. So, c2 doesn't get the changes of c1.
-        try await c2.changeSyncMode(d2, .manual)
-        try await d1.update { root, _ in
+        try c2.changeSyncMode(d2, .manual)
+        try d1.update { root, _ in
             root.version = "v2"
         }
         try await c1.sync()
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v2\"}")
         XCTAssertEqual(d2JSON, "{\"version\":\"v1\"}")
 
         // 03. c2 is changed to realtime sync.
         // c2 should be able to apply changes made to the document while c2 is not in realtime sync.
-        await d2.unsubscribeSync()
+        d2.unsubscribeSync()
 
         let exp2 = expectation(description: "exp 2")
 
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 exp2.fulfill()
             }
         }
 
-        try await c2.changeSyncMode(d2, .realtime)
+        try c2.changeSyncMode(d2, .realtime)
 
         await fulfillment(of: [exp2], timeout: 5)
 
-        d2JSON = await d2.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d2JSON, "{\"version\":\"v2\"}")
 
         // 04. c2 should automatically synchronize changes.
-        await d2.unsubscribeSync()
+        d2.unsubscribeSync()
 
         let exp3 = expectation(description: "exp 3")
 
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 exp3.fulfill()
             }
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.version = "v3"
         }
         try await c1.sync()
 
         await fulfillment(of: [exp3], timeout: 5)
 
-        d1JSON = await d1.toSortedJSON()
-        d2JSON = await d2.toSortedJSON()
+        d1JSON = d1.toSortedJSON()
+        d2JSON = d2.toSortedJSON()
         XCTAssertEqual(d1JSON, "{\"version\":\"v3\"}")
         XCTAssertEqual(d2JSON, "{\"version\":\"v3\"}")
 
-        await d2.unsubscribeSync()
+        d2.unsubscribeSync()
 
         try await c1.deactivate()
         try await c2.deactivate()
@@ -576,63 +576,63 @@ final class ClientIntegrationTests: XCTestCase {
 
         // 02. cli update the document with creating a counter
         //     and sync with push-pull mode: CP(1, 1) -> CP(2, 2)
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.counter = JSONCounter(value: Int64(0))
         }
 
-        var checkpoint = await d1.checkpoint
+        var checkpoint = d1.checkpoint
         XCTAssertEqual(checkpoint.getClientSeq(), 1)
         XCTAssertEqual(checkpoint.getServerSeq(), 1)
 
         try await c1.sync()
-        checkpoint = await d1.checkpoint
+        checkpoint = d1.checkpoint
         XCTAssertEqual(checkpoint.getClientSeq(), 2)
         XCTAssertEqual(checkpoint.getServerSeq(), 2)
 
         // 03. cli update the document with increasing the counter(0 -> 1)
         //     and sync with push-only mode: CP(2, 2) -> CP(3, 2)
         let exp1 = expectation(description: "exp 1")
-        await d1.subscribeSync { event, _ in
+        d1.subscribeSync { event, _ in
             if let event = event as? SyncStatusChangedEvent, event.value == .synced {
                 exp1.fulfill()
             }
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
         }
 
-        var changePack = await d1.createChangePack()
+        var changePack = d1.createChangePack()
         XCTAssertEqual(changePack.getChangeSize(), 1)
 
-        try await c1.changeSyncMode(d1, .realtimePushOnly)
+        try c1.changeSyncMode(d1, .realtimePushOnly)
         await fulfillment(of: [exp1], timeout: 5)
 
-        await d1.unsubscribeSync()
+        d1.unsubscribeSync()
 
-        checkpoint = await d1.checkpoint
+        checkpoint = d1.checkpoint
         XCTAssertEqual(checkpoint.getClientSeq(), 3)
         XCTAssertEqual(checkpoint.getServerSeq(), 2)
 
-        try await c1.changeSyncMode(d1, .manual)
+        try c1.changeSyncMode(d1, .manual)
 
         // 04. cli update the document with increasing the counter(1 -> 2)
         //     and sync with push-pull mode. CP(3, 2) -> CP(4, 4)
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
         }
 
         // The previous increase(0 -> 1) is already pushed to the server,
         // so the ChangePack of the request only has the increase(1 -> 2).
-        changePack = await d1.createChangePack()
+        changePack = d1.createChangePack()
         XCTAssertEqual(changePack.getChangeSize(), 1)
 
         try await c1.sync()
-        checkpoint = await d1.checkpoint
+        checkpoint = d1.checkpoint
         XCTAssertEqual(checkpoint.getClientSeq(), 4)
         XCTAssertEqual(checkpoint.getServerSeq(), 4)
 
-        let value = await(d1.getRoot().counter as? JSONCounter<Int64>)?.value
+        let value = (d1.getRoot().counter as? JSONCounter<Int64>)?.value
         XCTAssertEqual(value, 2)
 
         try await c1.deactivate()
@@ -656,15 +656,15 @@ final class ClientIntegrationTests: XCTestCase {
         let eventCollectorD2 = EventCollector<DocEventType>(doc: d2)
 
         // subscribe document change event
-        await d1.subscribe("$") { event, _ in
+        d1.subscribe("$") { event, _ in
             eventCollectorD1.add(event: event.type)
         }
 
-        await d2.subscribe("$") { event, _ in
+        d2.subscribe("$") { event, _ in
             eventCollectorD2.add(event: event.type)
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "doc", children: [
                 JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "12")]),
                 JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "34")])
@@ -675,12 +675,12 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD2.verifyNthValue(at: 1, isEqualTo: .remoteChange)
         }
 
-        var d1JSON = await(d1.getRoot().tree as? JSONTree)?.toXML()
-        var d2JSON = await(d2.getRoot().tree as? JSONTree)?.toXML()
+        var d1JSON = (d1.getRoot().tree as? JSONTree)?.toXML()
+        var d2JSON = (d2.getRoot().tree as? JSONTree)?.toXML()
         XCTAssertEqual(d1JSON, "<doc><p>12</p><p>34</p></doc>")
         XCTAssertEqual(d2JSON, "<doc><p>12</p><p>34</p></doc>")
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             try (root.tree as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "a"))
         }
         try await c1.sync()
@@ -690,11 +690,11 @@ final class ClientIntegrationTests: XCTestCase {
         try await c2.sync()
 
         // In push-only mode, remote-change events should not occur.
-        try await c2.changeSyncMode(d2, .realtimePushOnly)
+        try c2.changeSyncMode(d2, .realtimePushOnly)
         var remoteChangeOccured = false
 
-        await d2.unsubscribe()
-        await d2.subscribe { event, _ in
+        d2.unsubscribe()
+        d2.subscribe { event, _ in
             if event.type == .remoteChange {
                 remoteChangeOccured = true
             }
@@ -703,9 +703,9 @@ final class ClientIntegrationTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertFalse(remoteChangeOccured)
 
-        try await c2.changeSyncMode(d2, .realtime)
+        try c2.changeSyncMode(d2, .realtime)
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             try (root.tree as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "b"))
         }
 
@@ -713,13 +713,13 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD1.verifyNthValue(at: 3, isEqualTo: .remoteChange)
         }
 
-        d1JSON = await(d1.getRoot().tree as? JSONTree)?.toXML()
-        d2JSON = await(d2.getRoot().tree as? JSONTree)?.toXML()
+        d1JSON = (d1.getRoot().tree as? JSONTree)?.toXML()
+        d2JSON = (d2.getRoot().tree as? JSONTree)?.toXML()
         XCTAssertEqual(d1JSON, "<doc><p>1ba2</p><p>34</p></doc>")
         XCTAssertEqual(d2JSON, "<doc><p>1ba2</p><p>34</p></doc>")
 
-        await d1.unsubscribe()
-        await d2.unsubscribe()
+        d1.unsubscribe()
+        d2.unsubscribe()
 
         try await c1.deactivate()
         try await c2.deactivate()
@@ -743,14 +743,14 @@ final class ClientIntegrationTests: XCTestCase {
         let eventCollectorD2 = EventCollector<DocEventType>(doc: d2)
 
         // subscribe document change events
-        await d1.subscribe("$") { event, _ in
+        d1.subscribe("$") { event, _ in
             eventCollectorD1.add(event: event.type)
         }
-        await d2.subscribe("$") { event, _ in
+        d2.subscribe("$") { event, _ in
             eventCollectorD2.add(event: event.type)
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "doc", children: [
                 JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "12")]),
                 JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "34")])
@@ -761,12 +761,12 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD2.verifyNthValue(at: 1, isEqualTo: .remoteChange)
         }
 
-        var d1XML = await(d1.getRoot().tree as? JSONTree)?.toXML()
-        var d2XML = await(d2.getRoot().tree as? JSONTree)?.toXML()
+        var d1XML = (d1.getRoot().tree as? JSONTree)?.toXML()
+        var d2XML = (d2.getRoot().tree as? JSONTree)?.toXML()
         XCTAssertEqual(d1XML, "<doc><p>12</p><p>34</p></doc>")
         XCTAssertEqual(d2XML, "<doc><p>12</p><p>34</p></doc>")
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             try (root.tree as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "a"))
         }
         try await c1.sync()
@@ -776,11 +776,11 @@ final class ClientIntegrationTests: XCTestCase {
         try await c2.sync()
 
         // In sync-off mode, remote-change events should not occur.
-        try await c2.changeSyncMode(d2, .realtimeSyncOff)
+        try c2.changeSyncMode(d2, .realtimeSyncOff)
 
         var remoteChangeOccurred = false
-        await d2.unsubscribe()
-        await d2.subscribe("$") { event, _ in
+        d2.unsubscribe()
+        d2.subscribe("$") { event, _ in
             if event.type == .remoteChange {
                 remoteChangeOccurred = true
             }
@@ -789,9 +789,9 @@ final class ClientIntegrationTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertFalse(remoteChangeOccurred)
 
-        try await c2.changeSyncMode(d2, .realtime)
+        try c2.changeSyncMode(d2, .realtime)
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             try (root.tree as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "b"))
         }
 
@@ -799,13 +799,13 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD1.verifyNthValue(at: 3, isEqualTo: .remoteChange)
         }
 
-        d1XML = await(d1.getRoot().tree as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().tree as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().tree as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().tree as? JSONTree)?.toXML()
         XCTAssertEqual(d1XML, "<doc><p>1ba2</p><p>34</p></doc>")
         XCTAssertEqual(d2XML, "<doc><p>1ba2</p><p>34</p></doc>")
 
-        await d1.unsubscribe()
-        await d2.unsubscribe()
+        d1.unsubscribe()
+        d2.unsubscribe()
         try await c1.deactivate()
         try await c2.deactivate()
     }
@@ -824,13 +824,13 @@ final class ClientIntegrationTests: XCTestCase {
         let eventCollectorD1 = EventCollector<DocSyncStatus>(doc: d1)
         let eventCollectorD2 = EventCollector<DocSyncStatus>(doc: d2)
 
-        await d1.subscribeSync { event, _ in
+        d1.subscribeSync { event, _ in
             if let syncStatusEvent = event as? SyncStatusChangedEvent {
                 eventCollectorD1.add(event: syncStatusEvent.value)
             }
         }
 
-        await d2.subscribeSync { event, _ in
+        d2.subscribeSync { event, _ in
             if let syncStatusEvent = event as? SyncStatusChangedEvent {
                 eventCollectorD2.add(event: syncStatusEvent.value)
             }
@@ -843,7 +843,7 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD1.verifyNthValue(at: 1, isEqualTo: .synced)
         }
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
         }
@@ -852,15 +852,15 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD2.verifyNthValue(at: 1, isEqualTo: .synced)
         }
 
-        var d1JSON = await(d1.getRoot().t as? JSONText)?.toString
-        var d2JSON = await(d2.getRoot().t as? JSONText)?.toString
+        var d1JSON = (d1.getRoot().t as? JSONText)?.toString
+        var d2JSON = (d2.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(d1JSON, "a")
         XCTAssertEqual(d2JSON, "a")
 
         eventCollectorD1.reset()
-        try await c1.changeSyncMode(d1, .realtimePushOnly)
+        try c1.changeSyncMode(d1, .realtimePushOnly)
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             (root.t as? JSONText)?.edit(1, 1, "b")
         }
 
@@ -868,7 +868,7 @@ final class ClientIntegrationTests: XCTestCase {
             await eventCollectorD2.verifyNthValue(at: 2, isEqualTo: .synced)
         }
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }
 
@@ -877,19 +877,19 @@ final class ClientIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(eventCollectorD1.count, 0)
-        try await c1.changeSyncMode(d1, .realtime)
+        try c1.changeSyncMode(d1, .realtime)
 
         for await _ in eventCollectorD1.waitStream(until: .synced) {
             await eventCollectorD1.verifyNthValue(at: 1, isEqualTo: .synced)
         }
 
-        d1JSON = await(d1.getRoot().t as? JSONText)?.toString
-        d2JSON = await(d2.getRoot().t as? JSONText)?.toString
+        d1JSON = (d1.getRoot().t as? JSONText)?.toString
+        d2JSON = (d2.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(d1JSON, "abc")
         XCTAssertEqual(d2JSON, "abc")
 
-        await d1.unsubscribeSync()
-        await d2.unsubscribeSync()
+        d1.unsubscribeSync()
+        d2.unsubscribeSync()
 
         try await c1.deactivate()
         try await c2.deactivate()
@@ -917,7 +917,7 @@ final class ClientIntegrationTests: XCTestCase {
     @MainActor
     func test_duplicated_local_changes_not_sent_to_server() async throws {
         try await withTwoClientsAndDocuments(self.description, detachDocuments: false) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -936,8 +936,8 @@ final class ClientIntegrationTests: XCTestCase {
 
             try await c2.sync()
 
-            let d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            let d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>12</p><p>34</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>12</p><p>34</p></doc>")
 
@@ -951,7 +951,7 @@ final class ClientIntegrationTests: XCTestCase {
     @MainActor
     func test_should_handle_local_changes_correctly_when_receiving_snapshot() async throws {
         try await withTwoClientsAndDocuments(self.description, detachDocuments: false) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.counter = JSONCounter(value: Int64(0))
             }
 
@@ -960,7 +960,7 @@ final class ClientIntegrationTests: XCTestCase {
 
             // 01. c1 increases the counter for creating snapshot.
             for _ in 0 ..< defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
                 }
             }
@@ -971,15 +971,15 @@ final class ClientIntegrationTests: XCTestCase {
             Task {
                 try await c2.sync()
             }
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
             }
 
             try await c2.sync()
             try await c1.sync()
 
-            let d1JSON = await d1.toSortedJSON()
-            let d2JSON = await d2.toSortedJSON()
+            let d1JSON = d1.toSortedJSON()
+            let d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }

--- a/Tests/Integration/CounterIntegrationTests.swift
+++ b/Tests/Integration/CounterIntegrationTests.swift
@@ -30,32 +30,32 @@ final class CounterIntegrationTests: XCTestCase {
     func test_can_be_increased_by_Counter_type() async throws {
         let doc = Document(key: "test-doc")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.age = JSONCounter(value: Int32(1))
             root.length = JSONCounter(value: Int64(10))
             (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
             (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
         }
 
-        let age = await doc.getRoot().age as? JSONCounter<Int32>
+        let age = doc.getRoot().age as? JSONCounter<Int32>
 
         XCTAssert(age!.value == 6)
 
-        var result = await doc.toSortedJSON()
+        var result = doc.toSortedJSON()
         XCTAssert(result == "{\"age\":6,\"length\":13}")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             (root.age as! JSONCounter<Int32>).increase(value: Int32(1)).increase(value: Int32(1))
             (root.length as! JSONCounter<Int64>).increase(value: Int64(3)).increase(value: Int64(1))
         }
 
-        result = await doc.toSortedJSON()
+        result = doc.toSortedJSON()
         XCTAssert(result == "{\"age\":8,\"length\":17}")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             (root.age as! JSONCounter<Int32>).increase(value: Int64(1))
         }
-        result = await doc.toSortedJSON()
+        result = doc.toSortedJSON()
         XCTAssertEqual(result, "{\"age\":9,\"length\":17}")
     }
 
@@ -75,11 +75,11 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, [:], .manual)
         try await self.c2.attach(self.d2, [:], .manual)
 
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.age = JSONCounter(value: Int32(1))
         }
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             root.length = JSONCounter(value: Int64(10))
         }
 
@@ -87,12 +87,12 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c2.sync()
         try await self.c1.sync()
 
-        var result1 = await self.d1.toSortedJSON()
-        var result2 = await self.d2.toSortedJSON()
+        var result1 = self.d1.toSortedJSON()
+        var result2 = self.d2.toSortedJSON()
 
         XCTAssert(result1 == result2)
 
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             (root.age as! JSONCounter<Int32>).increase(value: Int32(5))
             (root.length as! JSONCounter<Int64>).increase(value: Int64(3))
         }
@@ -100,8 +100,8 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        result1 = await self.d1.toSortedJSON()
-        result2 = await self.d2.toSortedJSON()
+        result1 = self.d1.toSortedJSON()
+        result2 = self.d2.toSortedJSON()
 
         XCTAssertEqual(result1, result2)
 
@@ -128,24 +128,24 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.attach(self.d1, [:], .manual)
         try await self.c2.attach(self.d2, [:], .manual)
 
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.counts = [JSONCounter(value: Int32(1))]
         }
 
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             (root.counts as! JSONArray).append(JSONCounter(value: Int32(10)))
         }
 
         try await self.c1.sync()
         try await self.c2.sync()
 
-        var result1 = await self.d1.toSortedJSON()
-        var result2 = await self.d2.toSortedJSON()
+        var result1 = self.d1.toSortedJSON()
+        var result2 = self.d2.toSortedJSON()
 
         XCTAssert(result1 == result2)
         XCTAssert(result1 == "{\"counts\":[1,10]}")
 
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             ((root.counts as! JSONArray)[0] as! JSONCounter<Int32>).increase(value: Int32(5))
             ((root.counts as! JSONArray)[1] as! JSONCounter<Int32>).increase(value: Int32(3))
         }
@@ -153,8 +153,8 @@ final class CounterIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        result1 = await self.d1.toSortedJSON()
-        result2 = await self.d2.toSortedJSON()
+        result1 = self.d1.toSortedJSON()
+        result2 = self.d2.toSortedJSON()
 
         XCTAssert(result1 == result2)
         XCTAssert(result1 == "{\"counts\":[6,13]}")

--- a/Tests/Integration/DocumentIntegrationTests.swift
+++ b/Tests/Integration/DocumentIntegrationTests.swift
@@ -128,8 +128,8 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d3 = Document(key: docKey)
         try await self.c1.attach(self.d3)
 
-        let doc2Content = d2.toSortedJSON()
-        let doc3Content = d3.toSortedJSON()
+        let doc2Content = self.d2.toSortedJSON()
+        let doc3Content = self.d3.toSortedJSON()
 
         XCTAssertEqual(doc2Content, doc3Content)
 
@@ -166,8 +166,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = d1.toSortedJSON()
-        let doc2Content = d2.toSortedJSON()
+        let doc1Content = self.d1.toSortedJSON()
+        let doc2Content = self.d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
@@ -181,8 +181,8 @@ final class DocumentIntegrationTests: XCTestCase {
         // 03. c2 syncs and checks that d2 is removed.
         try await self.c2.sync()
 
-        let doc1Status = d1.status
-        let doc2Status = d2.status
+        let doc1Status = self.d1.status
+        let doc2Status = self.d2.status
 
         XCTAssertEqual(doc1Status, doc2Status)
 
@@ -216,8 +216,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = d1.toSortedJSON()
-        let doc2Content = d2.toSortedJSON()
+        let doc1Content = self.d1.toSortedJSON()
+        let doc2Content = self.d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
@@ -225,8 +225,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.remove(self.d1)
         try await self.c2.detach(self.d2)
 
-        let doc1Status = d1.status
-        let doc2Status = d2.status
+        let doc1Status = self.d1.status
+        let doc2Status = self.d2.status
 
         XCTAssertEqual(doc1Status, .removed)
         XCTAssertEqual(doc2Status, .removed)
@@ -261,8 +261,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = d1.toSortedJSON()
-        let doc2Content = d2.toSortedJSON()
+        let doc1Content = self.d1.toSortedJSON()
+        let doc2Content = self.d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
@@ -270,8 +270,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.remove(self.d1)
         try await self.c2.remove(self.d2)
 
-        let doc1Status = d1.status
-        let doc2Status = d2.status
+        let doc1Status = self.d1.status
+        let doc2Status = self.d2.status
 
         XCTAssertEqual(doc1Status, .removed)
         XCTAssertEqual(doc2Status, .removed)

--- a/Tests/Integration/DocumentIntegrationTests.swift
+++ b/Tests/Integration/DocumentIntegrationTests.swift
@@ -70,13 +70,13 @@ final class DocumentIntegrationTests: XCTestCase {
             XCTAssert(false)
         }
 
-        let docStatus = await self.d1.status
+        let docStatus = self.d1.status
 
         XCTAssertEqual(docStatus, .removed)
 
         // 04. try to update a removed document.
         do {
-            try await self.d1.update { root, _ in
+            try self.d1.update { root, _ in
                 root.k1 = String("v1")
             }
         } catch let error as YorkieError {
@@ -112,7 +112,7 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d1 = Document(key: docKey)
 
         // 01. c1 create d1 and remove it.
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.k1 = "v1"
         }
 
@@ -128,8 +128,8 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d3 = Document(key: docKey)
         try await self.c1.attach(self.d3)
 
-        let doc2Content = await d2.toSortedJSON()
-        let doc3Content = await d3.toSortedJSON()
+        let doc2Content = d2.toSortedJSON()
+        let doc3Content = d3.toSortedJSON()
 
         XCTAssertEqual(doc2Content, doc3Content)
 
@@ -153,7 +153,7 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d1 = Document(key: docKey)
 
         // 01. c1 creates d1 and c2 syncs.
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.k1 = "v1"
         }
 
@@ -166,13 +166,13 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = await d1.toSortedJSON()
-        let doc2Content = await d2.toSortedJSON()
+        let doc1Content = d1.toSortedJSON()
+        let doc2Content = d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
         // 02. c1 updates d1 and removes it.
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.k1 = "v2"
         }
 
@@ -181,8 +181,8 @@ final class DocumentIntegrationTests: XCTestCase {
         // 03. c2 syncs and checks that d2 is removed.
         try await self.c2.sync()
 
-        let doc1Status = await d1.status
-        let doc2Status = await d2.status
+        let doc1Status = d1.status
+        let doc2Status = d2.status
 
         XCTAssertEqual(doc1Status, doc2Status)
 
@@ -203,7 +203,7 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d1 = Document(key: docKey)
 
         // 01. c1 creates d1 and c2 syncs.
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.k1 = "v1"
         }
 
@@ -216,8 +216,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = await d1.toSortedJSON()
-        let doc2Content = await d2.toSortedJSON()
+        let doc1Content = d1.toSortedJSON()
+        let doc2Content = d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
@@ -225,8 +225,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.remove(self.d1)
         try await self.c2.detach(self.d2)
 
-        let doc1Status = await d1.status
-        let doc2Status = await d2.status
+        let doc1Status = d1.status
+        let doc2Status = d2.status
 
         XCTAssertEqual(doc1Status, .removed)
         XCTAssertEqual(doc2Status, .removed)
@@ -248,7 +248,7 @@ final class DocumentIntegrationTests: XCTestCase {
         self.d1 = Document(key: docKey)
 
         // 01. c1 creates d1 and c2 syncs.
-        try await self.d1.update { root, _ in
+        try self.d1.update { root, _ in
             root.k1 = "v1"
         }
 
@@ -261,8 +261,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.sync()
         try await self.c2.sync()
 
-        let doc1Content = await d1.toSortedJSON()
-        let doc2Content = await d2.toSortedJSON()
+        let doc1Content = d1.toSortedJSON()
+        let doc2Content = d2.toSortedJSON()
 
         XCTAssertEqual(doc1Content, doc2Content)
 
@@ -270,8 +270,8 @@ final class DocumentIntegrationTests: XCTestCase {
         try await self.c1.remove(self.d1)
         try await self.c2.remove(self.d2)
 
-        let doc1Status = await d1.status
-        let doc2Status = await d2.status
+        let doc1Status = d1.status
+        let doc2Status = d2.status
 
         XCTAssertEqual(doc1Status, .removed)
         XCTAssertEqual(doc2Status, .removed)
@@ -390,19 +390,19 @@ final class DocumentIntegrationTests: XCTestCase {
         var d2Events = [any OperationInfo]()
         var d3Events = [any OperationInfo]()
 
-        await self.d1.subscribe { event, _ in
+        self.d1.subscribe { event, _ in
             d1Events.append(contentsOf: (event as? ChangeEvent)?.value.operations ?? [])
         }
 
-        await self.d1.subscribe("$.todos") { event, _ in
+        self.d1.subscribe("$.todos") { event, _ in
             d2Events.append(contentsOf: (event as? ChangeEvent)?.value.operations ?? [])
         }
 
-        await self.d1.subscribe("$.counter") { event, _ in
+        self.d1.subscribe("$.counter") { event, _ in
             d3Events.append(contentsOf: (event as? ChangeEvent)?.value.operations ?? [])
         }
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             root.counter = JSONCounter(value: Int32(0))
             root.todos = ["todo1", "todo2"]
         }
@@ -420,7 +420,7 @@ final class DocumentIntegrationTests: XCTestCase {
         d1Events = []
         d2Events = []
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             (root.counter as? JSONCounter<Int32>)?.increase(value: 10)
         }
 
@@ -433,7 +433,7 @@ final class DocumentIntegrationTests: XCTestCase {
         d1Events = []
         d3Events = []
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             (root.todos as? JSONArray)?.append("todo3")
         }
 
@@ -446,9 +446,9 @@ final class DocumentIntegrationTests: XCTestCase {
         d1Events = []
         d2Events = []
 
-        await self.d1.unsubscribe("$.todos")
+        self.d1.unsubscribe("$.todos")
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             (root.todos as? JSONArray)?.append("todo4")
         }
 
@@ -460,9 +460,9 @@ final class DocumentIntegrationTests: XCTestCase {
 
         d1Events = []
 
-        await self.d1.unsubscribe("$.counter")
+        self.d1.unsubscribe("$.counter")
 
-        try await self.d2.update { root, _ in
+        try self.d2.update { root, _ in
             (root.counter as? JSONCounter<Int32>)?.increase(value: 10)
         }
 
@@ -472,7 +472,7 @@ final class DocumentIntegrationTests: XCTestCase {
         XCTAssertEqual(d1Events[0] as? IncreaseOpInfo, IncreaseOpInfo(path: "$.counter", value: 10))
         XCTAssertTrue(d3Events.isEmpty)
 
-        await self.d1.unsubscribe()
+        self.d1.unsubscribe()
 
         try await self.c1.detach(self.d1)
         try await self.c2.detach(self.d2)
@@ -605,7 +605,7 @@ final class DocumentIntegrationTests: XCTestCase {
             ]
         ])
 
-        let doc1JSON = await doc1.toSortedJSON()
+        let doc1JSON = doc1.toSortedJSON()
         XCTAssertEqual(doc1JSON, "{\"content\":{\"x\":1,\"y\":1},\"counter\":0}")
 
         try await c1.sync()
@@ -621,7 +621,7 @@ final class DocumentIntegrationTests: XCTestCase {
             "new": ["k": "v"]
         ])
 
-        let doc2JSON = await doc2.toSortedJSON()
+        let doc2JSON = doc2.toSortedJSON()
         XCTAssertEqual(doc2JSON, "{\"content\":{\"x\":1,\"y\":1},\"counter\":0,\"new\":{\"k\":\"v\"}}")
 
         try await c1.deactivate()
@@ -641,7 +641,7 @@ final class DocumentIntegrationTests: XCTestCase {
         try await c1.attach(doc1, initialRoot: [
             "writer": "user1"
         ])
-        var doc1JSON = await doc1.toSortedJSON()
+        var doc1JSON = doc1.toSortedJSON()
         XCTAssertEqual(doc1JSON, "{\"writer\":\"user1\"}")
 
         // 02. user2 attach with initialRoot and client doesn't sync
@@ -649,7 +649,7 @@ final class DocumentIntegrationTests: XCTestCase {
         try await c2.attach(doc2, initialRoot: [
             "writer": "user2"
         ])
-        var doc2JSON = await doc2.toSortedJSON()
+        var doc2JSON = doc2.toSortedJSON()
         XCTAssertEqual(doc2JSON, "{\"writer\":\"user2\"}")
 
         // 03. user1 sync first and user2 seconds
@@ -657,14 +657,14 @@ final class DocumentIntegrationTests: XCTestCase {
         try await c2.sync()
 
         // 04. user1's local document's writer was user1
-        doc1JSON = await doc1.toSortedJSON()
+        doc1JSON = doc1.toSortedJSON()
         XCTAssertEqual(doc1JSON, "{\"writer\":\"user1\"}")
-        doc2JSON = await doc2.toSortedJSON()
+        doc2JSON = doc2.toSortedJSON()
         XCTAssertEqual(doc2JSON, "{\"writer\":\"user2\"}")
 
         // 05. user1's local document's writer is overwritten by user2
         try await c1.sync()
-        doc1JSON = await doc2.toSortedJSON()
+        doc1JSON = doc2.toSortedJSON()
         XCTAssertEqual(doc1JSON, "{\"writer\":\"user2\"}")
 
         try await c1.deactivate()
@@ -732,7 +732,7 @@ final class DocumentIntegrationTests: XCTestCase {
                 testCase.name: testCase.input
             ])
 
-            let docJSON = await doc.toSortedJSON()
+            let docJSON = doc.toSortedJSON()
             XCTAssertEqual(docJSON, testCase.expectedJSON)
 
             try await c1.deactivate()
@@ -745,7 +745,7 @@ final class DocumentIntegrationTests: XCTestCase {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             let eventCollector = EventCollector<Int32>(doc: d2)
 
-            await d2.subscribe("$") { event, doc in
+            d2.subscribe("$") { event, doc in
                 if event.type == .snapshot {
                     if let value = (doc.getRoot().counter as? JSONCounter<Int32>)?.value as? Int32 {
                         eventCollector.add(event: value)
@@ -753,7 +753,7 @@ final class DocumentIntegrationTests: XCTestCase {
                 }
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.counter = JSONCounter(value: Int32(0))
             }
             try await c1.sync()
@@ -761,14 +761,14 @@ final class DocumentIntegrationTests: XCTestCase {
 
             // 01. c1 increases the counter for creating snapshot.
             for _ in 1 ... defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     (root.counter as? JSONCounter<Int32>)?.increase(value: 1)
                 }
             }
             try await c1.sync()
 
             // 02. c2 receives the snapshot and increases the counter simultaneously.
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.counter as? JSONCounter<Int32>)?.increase(value: 1)
             }
             // should have a local change after receiving a snapshot event

--- a/Tests/Integration/DocumentLimitTests.swift
+++ b/Tests/Integration/DocumentLimitTests.swift
@@ -158,7 +158,7 @@ extension DocumentSizeLimitTest {
     func test_should_successfully_assign_size_limit_to_document() async throws {
         // update the max size of document
         let (_, document) = try await activateClientAndDocument()
-        let docMaxSize = await document.getMaxSizePerDocument()
+        let docMaxSize = document.getMaxSizePerDocument()
 
         XCTAssertEqual(docMaxSize, self.sizeLimit)
     }
@@ -168,25 +168,25 @@ extension DocumentSizeLimitTest {
     func test_should_reject_local_update_that_exceeds_document_size_limit() async throws {
         let expectation = XCTestExpectation(description: "Must throws when update due to size limitation risk!")
         let (client, document) = try await activateClientAndDocument(size: 100)
-        try await document.update { root, _ in
+        try document.update { root, _ in
             root.t = JSONText()
         }
 
-        let size = await document.getDocSize()
+        let size = document.getDocSize()
         XCTAssertEqual(size.live, .init(data: 0, meta: 72))
-        let rootSize = await document.getClone()?.root.getDocSize()
+        let rootSize = document.getClone()?.root.getDocSize()
         XCTAssertEqual(size, rootSize)
 
         // document size exceeded
         do {
-            try await document.update { root, _ in
+            try document.update { root, _ in
                 (root.t as? JSONText)?.edit(0, 0, "helloworld")
             }
         } catch {
             expectation.fulfill()
         }
 
-        let totalSize = await document.getDocSize().totalDocSize
+        let totalSize = document.getDocSize().totalDocSize
         XCTAssertEqual(totalSize, 72)
 
         try await client.detach(document)
@@ -200,53 +200,53 @@ extension DocumentSizeLimitTest {
     func test_should_allow_remote_updates_even_if_they_exceed_document_size_limit() async throws {
         let (client1, doc1) = try await activateClientAndDocument(size: 100)
 
-        let client2 = await Client(rpcAddress, ClientOptions(apiKey: apiKey, authTokenInjector: TestAuthTokenInjector()))
+        let client2 = Client(rpcAddress, ClientOptions(apiKey: apiKey, authTokenInjector: TestAuthTokenInjector()))
 
         try await client2.activate()
         let doc2 = Document(key: docKey)
 
         try await client2.attach(doc2)
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.t = JSONText()
         }
 
-        var size = await doc1.getDocSize()
+        var size = doc1.getDocSize()
         XCTAssertEqual(size.live, .init(data: 0, meta: 72))
 
         try await client1.sync()
         try await client2.sync()
 
-        size = await doc1.getDocSize()
+        size = doc1.getDocSize()
         XCTAssertEqual(size.live, .init(data: 0, meta: 72))
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "aa")
         }
-        var live = await doc1.getDocSize().live
+        var live = doc1.getDocSize().live
         XCTAssertEqual(live, .init(data: 4, meta: 96))
 
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "a")
         }
 
-        live = await doc2.getDocSize().live
+        live = doc2.getDocSize().live
         XCTAssertEqual(live, .init(data: 2, meta: 96))
 
         try await client2.sync()
         // Pulls changes - should succeed despite exceeding limit
 
-        live = await doc2.getDocSize().live
+        live = doc2.getDocSize().live
         XCTAssertEqual(live, .init(data: 2, meta: 96))
 
         try await client1.sync()
 
-        live = await doc1.getDocSize().live
+        live = doc1.getDocSize().live
         XCTAssertEqual(live, .init(data: 6, meta: 120))
 
         let expectation = XCTestExpectation(description: "Must return error!")
         do {
-            try await doc1.update { root, _ in
+            try doc1.update { root, _ in
                 (root.t as? JSONText)?.edit(0, 0, "a")
             }
         } catch {

--- a/Tests/Integration/GCIntegrationTests.swift
+++ b/Tests/Integration/GCIntegrationTests.swift
@@ -41,7 +41,7 @@ class GCIntegrationTests: XCTestCase {
         // 1. initial state
         try await client1.attach(doc1, [:], .manual)
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.point = ["x": Int64(0), "y": Int64(0)]
         }
 
@@ -49,19 +49,19 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
 
         // 2. client1 updates doc
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.remove(key: "point")
         }
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         // 3. client2 updates doc
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.point as? JSONObject)?.remove(key: "x")
         }
 
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 1) // x
 
         try await client1.sync()
@@ -69,14 +69,14 @@ class GCIntegrationTests: XCTestCase {
         try await client1.sync()
 
         let gcNodeLen = 3 // point x, y
-        var doc1Len = await doc1.getGarbageLength()
-        var doc2Len = await doc2.getGarbageLength()
+        var doc1Len = doc1.getGarbageLength()
+        var doc2Len = doc2.getGarbageLength()
         XCTAssertEqual(doc1Len, gcNodeLen)
         XCTAssertEqual(doc2Len, gcNodeLen)
 
         // Actual garbage-collected nodes
-        doc1Len = await doc1.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [client1.id, client2.id]))
-        doc2Len = await doc2.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [client1.id, client2.id]))
+        doc1Len = doc1.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [client1.id, client2.id]))
+        doc2Len = doc2.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [client1.id, client2.id]))
 
         XCTAssertEqual(doc1Len, gcNodeLen)
         XCTAssertEqual(doc2Len, gcNodeLen)
@@ -107,7 +107,7 @@ class GCIntegrationTests: XCTestCase {
         await assertTrue(versionVector: d2.getVersionVector(),
                          actorDatas: [])
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [
@@ -131,9 +131,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c1.id!, lamport: 1)
         ])
 
-        var len = await d1.getGarbageLength()
+        var len = d1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await c1.sync()
@@ -147,7 +147,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 2)
         ])
 
-        try await d2.update({ root, _ in
+        try d2.update({ root, _ in
             do {
                 try (root.t as? JSONTree)?.editByPath([0, 0, 0], [0, 0, 2], JSONTreeTextNode(value: "gh"))
             } catch {
@@ -160,9 +160,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await c2.sync()
@@ -171,9 +171,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await c1.sync()
@@ -182,9 +182,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await c2.sync()
@@ -193,9 +193,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await c1.sync()
@@ -204,9 +204,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await c2.sync()
@@ -215,9 +215,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: c2.id!, lamport: 3)
         ])
 
-        len = await d1.getGarbageLength()
+        len = d1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await d2.getGarbageLength()
+        len = d2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await c1.detach(d1)
@@ -246,7 +246,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root["1"] = Int64(1)
             root["2"] = [Int64(1), Int64(2), Int64(3)]
             root["3"] = Int64(3)
@@ -255,9 +255,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -271,7 +271,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             root.remove(key: "2")
         }, "removes 2")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -279,9 +279,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client2.sync()
@@ -290,9 +290,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client1.sync()
@@ -301,9 +301,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 4)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client2.sync()
@@ -312,9 +312,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 4)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client1.sync()
@@ -324,9 +324,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client2.sync()
@@ -335,9 +335,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.detach(doc1)
@@ -366,7 +366,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.text = JSONText()
             (root.text as? JSONText)?.edit(0, 0, "Hello World")
             root.textWithAttr = JSONText()
@@ -376,9 +376,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -392,7 +392,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.text as? JSONText)?.edit(0, 1, "a")
             (root.text as? JSONText)?.edit(1, 2, "b")
             (root.textWithAttr as? JSONText)?.edit(0, 1, "a", ["b": "1"])
@@ -403,9 +403,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client2.sync()
@@ -414,9 +414,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client1.sync()
@@ -425,9 +425,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client2.sync()
@@ -436,9 +436,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client1.sync()
@@ -447,9 +447,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client2.sync()
@@ -458,9 +458,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.detach(doc1)
@@ -490,7 +490,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root["1"] = Int64(1)
             root["2"] = [Int64(1), Int64(2), Int64(3)]
             root["3"] = Int64(3)
@@ -504,9 +504,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -520,7 +520,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.remove(key: "2")
             (root["4"] as? JSONText)?.edit(0, 1, "h")
             (root["5"] as? JSONText)?.edit(0, 1, "h", ["b": "1"])
@@ -529,9 +529,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 6)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -539,17 +539,17 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 6)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client2.detach(doc2)
 
         try await client2.sync()
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 6)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 6)
 
         try await client1.sync()
@@ -557,9 +557,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 6)
 
         try await client1.detach(doc1)
@@ -582,30 +582,30 @@ class GCIntegrationTests: XCTestCase {
         try await client.attach(doc, [:], .manual)
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [])
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.point = ["x": Int64(0), "y": Int64(0)]
         }
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [
             ActorData(actor: client.id!, lamport: 1)
         ])
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.point = ["x": Int64(1), "y": Int64(1)]
         }
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [
             ActorData(actor: client.id!, lamport: 2)
         ])
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.point = ["x": Int64(2), "y": Int64(2)]
         }
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [
             ActorData(actor: client.id!, lamport: 3)
         ])
 
-        var len = await doc.getGarbageLength()
+        var len = doc.getGarbageLength()
         XCTAssertEqual(len, 6)
-        len = await doc.getGarbageLengthFromClone()
+        len = doc.getGarbageLengthFromClone()
         XCTAssertEqual(len, 6)
     }
 
@@ -622,7 +622,7 @@ class GCIntegrationTests: XCTestCase {
         try await client.attach(doc, [:], .manual)
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [])
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.list = [Int(0), Int(1), Int(2)]
             (root.list as? JSONArray)?.push([Int(3), Int(4), Int(5)])
         }
@@ -630,33 +630,33 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client.id!, lamport: 1)
         ])
 
-        var expectedJson = await doc.toJSON()
+        var expectedJson = doc.toJSON()
         XCTAssertEqual("{\"list\":[0,1,2,[3,4,5]]}", expectedJson)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             (root.list as? JSONArray)?.remove(index: 1)
         }
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [
             ActorData(actor: client.id!, lamport: 2)
         ])
 
-        expectedJson = await doc.toJSON()
+        expectedJson = doc.toJSON()
         XCTAssertEqual("{\"list\":[0,2,[3,4,5]]}", expectedJson)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             ((root.list as? JSONArray)?[2] as? JSONArray)?.remove(index: 1)
         }
         await assertTrue(versionVector: doc.getVersionVector(), actorDatas: [
             ActorData(actor: client.id!, lamport: 3)
         ])
 
-        expectedJson = await doc.toJSON()
+        expectedJson = doc.toJSON()
         XCTAssertEqual("{\"list\":[0,2,[3,5]]}", expectedJson)
 
-        var len = await doc.getGarbageLength()
+        var len = doc.getGarbageLength()
         XCTAssertEqual(len, 2)
 
-        len = await doc.getGarbageLengthFromClone()
+        len = doc.getGarbageLengthFromClone()
         XCTAssertEqual(len, 2)
 
         try await client.deactivate()
@@ -679,26 +679,26 @@ class GCIntegrationTests: XCTestCase {
         try await client1.attach(doc1, [:], .manual)
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.point = ["x": Int64(0), "y": Int64(0)]
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.point as? JSONObject)?.x = Int64(1)
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 1)
 
         try await client1.sync()
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -711,10 +711,10 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 1)
 
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.point as? JSONObject)?.x = Int64(2)
         }
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -722,33 +722,33 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.point = ["x": Int64(3), "y": Int64(3)]
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client1.sync()
-        await assertTrue(versionVector: await doc1.getVersionVector(), actorDatas: [
+        await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client1.sync()
-        await assertTrue(versionVector: await doc1.getVersionVector(), actorDatas: [
+        await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 3)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client2.sync()
@@ -757,7 +757,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 3)
 
         try await client1.sync()
@@ -766,19 +766,19 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client2.sync()
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 4)
 
         try await client1.sync()
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client2.sync()
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.deactivate()
@@ -796,7 +796,7 @@ class GCIntegrationTests: XCTestCase {
 
         try await client.activate()
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.shape = JSONObject()
             (root.shape as? JSONObject)?.point = JSONObject()
             ((root.shape as? JSONObject)?.point as? JSONObject)?.set(key: "x", value: Int32(0))
@@ -804,11 +804,11 @@ class GCIntegrationTests: XCTestCase {
             root.remove(key: "shape")
         }
 
-        var len = await doc.getGarbageLength()
+        var len = doc.getGarbageLength()
         XCTAssertEqual(len, 4)
 
-        let actorID = await doc.changeID.getActorID() ?? ""
-        len = await doc.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [actorID]))
+        let actorID = doc.changeID.getActorID() ?? ""
+        len = doc.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [actorID]))
         XCTAssertEqual(len, 4) // The number of GC nodes must also be 4.
     }
 
@@ -832,7 +832,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "z")
         }
@@ -840,21 +840,21 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(0, 1, "a")
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(1, 1, "b")
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 3)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(2, 2, "d")
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -872,14 +872,14 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        var strDoc1 = await(doc1.getRoot().t as? JSONText)?.toString
-        var strDoc2 = await(doc2.getRoot().t as? JSONText)?.toString
+        var strDoc1 = (doc1.getRoot().t as? JSONText)?.toString
+        var strDoc2 = (doc2.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(strDoc1, "abd")
         XCTAssertEqual(strDoc2, "abd")
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 1)
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -897,12 +897,12 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        strDoc1 = await(doc1.getRoot().t as? JSONText)?.toString
-        strDoc2 = await(doc2.getRoot().t as? JSONText)?.toString
+        strDoc1 = (doc1.getRoot().t as? JSONText)?.toString
+        strDoc2 = (doc2.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(strDoc1, "abcd")
         XCTAssertEqual(strDoc2, "abcd")
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -914,9 +914,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 6)
         ])
 
-        strDoc1 = await(doc1.getRoot().t as? JSONText)?.toString
+        strDoc1 = (doc1.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(strDoc1, "ad")
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2) // b,c
 
         try await client2.sync()
@@ -931,11 +931,11 @@ class GCIntegrationTests: XCTestCase {
         ])
 
         try await client2.sync()
-        strDoc2 = await(doc2.getRoot().t as? JSONText)?.toString
+        strDoc2 = (doc2.getRoot().t as? JSONText)?.toString
         XCTAssertEqual(strDoc2, "ad")
 
         try await client1.sync()
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.deactivate()
@@ -962,7 +962,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "r",
                                     children: [
@@ -974,21 +974,21 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 1)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([0], [1], JSONTreeTextNode(value: "a"))
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1], [1], JSONTreeTextNode(value: "b"))
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 3)
         ])
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([2], [2], JSONTreeTextNode(value: "d"))
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -1006,14 +1006,14 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        var strDoc1 = await(doc1.getRoot().t as? JSONTree)?.toXML()
-        var strDoc2 = await(doc2.getRoot().t as? JSONTree)?.toXML()
+        var strDoc1 = (doc1.getRoot().t as? JSONTree)?.toXML()
+        var strDoc2 = (doc2.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc1, "<r>abd</r>")
         XCTAssertEqual(strDoc2, "<r>abd</r>")
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 1)
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([2], [2], JSONTreeTextNode(value: "c"))
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -1031,12 +1031,12 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        strDoc1 = await(doc1.getRoot().t as? JSONTree)?.toXML()
-        strDoc2 = await(doc2.getRoot().t as? JSONTree)?.toXML()
+        strDoc1 = (doc1.getRoot().t as? JSONTree)?.toXML()
+        strDoc2 = (doc2.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc1, "<r>abcd</r>")
         XCTAssertEqual(strDoc2, "<r>abcd</r>")
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1], [3])
         }
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -1048,9 +1048,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 6)
         ])
 
-        strDoc1 = await(doc1.getRoot().t as? JSONTree)?.toXML()
+        strDoc1 = (doc1.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc1, "<r>ad</r>")
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2) // b, c
 
         try await client2.sync()
@@ -1064,9 +1064,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 6)
         ])
 
-        strDoc2 = await(doc2.getRoot().t as? JSONTree)?.toXML()
+        strDoc2 = (doc2.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc2, "<r>ad</r>")
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await client2.sync()
@@ -1075,9 +1075,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 7)
         ])
 
-        strDoc2 = await(doc2.getRoot().t as? JSONTree)?.toXML()
+        strDoc2 = (doc2.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc2, "<r>ad</r>")
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -1085,9 +1085,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client1.id!, lamport: 6)
         ])
 
-        strDoc1 = await(doc1.getRoot().t as? JSONTree)?.toXML()
+        strDoc1 = (doc1.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(strDoc1, "<r>ad</r>")
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.deactivate()
@@ -1114,7 +1114,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1135,7 +1135,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }, "insert c")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1143,16 +1143,16 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }, "delete bd")
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -1166,12 +1166,12 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "1")
         }, "insert 1")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1185,9 +1185,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -1196,9 +1196,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.deactivate()
@@ -1225,7 +1225,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1245,7 +1245,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "d")
         }, "insert d")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1265,7 +1265,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }, "insert c")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1273,7 +1273,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }, "remove ac")
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -1282,7 +1282,7 @@ class GCIntegrationTests: XCTestCase {
         ])
 
         // Sync with PushOnly
-        try await client2.changeSyncMode(doc2, .realtimePushOnly)
+        try client2.changeSyncMode(doc2, .realtimePushOnly)
         try await client2.sync()
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 1),
@@ -1295,7 +1295,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "1")
         }, "insert 1 (pushonly)")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1315,12 +1315,12 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        var len = await doc1.getGarbageLength()
+        var len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "2")
         }, "insert 2 (pushonly)")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1328,7 +1328,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        try await client2.changeSyncMode(doc2, .manual)
+        try client2.changeSyncMode(doc2, .manual)
         try await client2.sync()
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 5),
@@ -1341,9 +1341,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 2)
 
         try await client2.sync()
@@ -1352,9 +1352,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 7)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 2)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.sync()
@@ -1363,9 +1363,9 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        len = await doc1.getGarbageLength()
+        len = doc1.getGarbageLength()
         XCTAssertEqual(len, 0)
-        len = await doc2.getGarbageLength()
+        len = doc2.getGarbageLength()
         XCTAssertEqual(len, 0)
 
         try await client1.deactivate()
@@ -1392,7 +1392,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1413,7 +1413,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }, "insert c")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1421,7 +1421,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }, "delete bd")
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
@@ -1433,15 +1433,15 @@ class GCIntegrationTests: XCTestCase {
 
         try await client1.deactivate()
 
-        let garbageLength1 = await doc2.getGarbageLength()
-        let getVersionVector1 = await doc2.getVersionVector().size()
+        let garbageLength1 = doc2.getGarbageLength()
+        let getVersionVector1 = doc2.getVersionVector().size()
 
         XCTAssertEqual(garbageLength1, 2)
         XCTAssertEqual(getVersionVector1, 2)
 
         try await client2.sync()
-        let garbageLength2 = await doc2.getGarbageLength()
-        let getVersionVector2 = await doc2.getVersionVector().size()
+        let garbageLength2 = doc2.getGarbageLength()
+        let getVersionVector2 = doc2.getVersionVector().size()
 
         XCTAssertEqual(garbageLength2, 0)
         XCTAssertEqual(getVersionVector2, 2)
@@ -1467,7 +1467,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1488,7 +1488,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }, "insert c")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1496,15 +1496,15 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }, "delete bd")
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        let doc1Garbage1 = await doc1.getGarbageLength()
-        let doc2Garbage1 = await doc2.getGarbageLength()
+        let doc1Garbage1 = doc1.getGarbageLength()
+        let doc2Garbage1 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage1, 2)
         XCTAssertEqual(doc2Garbage1, 0)
@@ -1520,13 +1520,13 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        let doc1Garbage2 = await doc1.getGarbageLength()
-        let doc2Garbage2 = await doc2.getGarbageLength()
+        let doc1Garbage2 = doc1.getGarbageLength()
+        let doc2Garbage2 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage2, 2)
         XCTAssertEqual(doc2Garbage2, 2)
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "1")
         }, "insert 1")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1540,8 +1540,8 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        let doc1Garbage3 = await doc1.getGarbageLength()
-        let doc2Garbage3 = await doc2.getGarbageLength()
+        let doc1Garbage3 = doc1.getGarbageLength()
+        let doc2Garbage3 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage3, 2)
         XCTAssertEqual(doc2Garbage3, 0)
@@ -1560,7 +1560,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(0, 3, "")
         }, "delete all")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1568,7 +1568,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        let doc2Garbage4 = await doc2.getGarbageLength()
+        let doc2Garbage4 = doc2.getGarbageLength()
         XCTAssertEqual(doc2Garbage4, 3)
 
         try await client2.sync()
@@ -1577,7 +1577,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        let doc2Garbage5 = await doc2.getGarbageLength()
+        let doc2Garbage5 = doc2.getGarbageLength()
         XCTAssertEqual(doc2Garbage5, 0)
 
         try await client2.detach(doc2)
@@ -1606,7 +1606,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1627,7 +1627,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 2)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "c")
         }, "insert c")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1635,15 +1635,15 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 3)
         ])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }, "delete bd")
         await assertTrue(versionVector: doc1.getVersionVector(), actorDatas: [
             ActorData(actor: client1.id!, lamport: 2)
         ])
 
-        let doc1Garbage1 = await doc1.getGarbageLength()
-        let doc2Garbage1 = await doc2.getGarbageLength()
+        let doc1Garbage1 = doc1.getGarbageLength()
+        let doc2Garbage1 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage1, 2)
         XCTAssertEqual(doc2Garbage1, 0)
@@ -1659,13 +1659,13 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 4)
         ])
 
-        let doc1Garbage2 = await doc1.getGarbageLength()
-        let doc2Garbage2 = await doc2.getGarbageLength()
+        let doc1Garbage2 = doc1.getGarbageLength()
+        let doc2Garbage2 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage2, 2)
         XCTAssertEqual(doc2Garbage2, 2)
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(2, 2, "1")
         }, "insert 1")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1679,8 +1679,8 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        let doc1Garbage3 = await doc1.getGarbageLength()
-        let doc2Garbage3 = await doc2.getGarbageLength()
+        let doc1Garbage3 = doc1.getGarbageLength()
+        let doc2Garbage3 = doc2.getGarbageLength()
 
         XCTAssertEqual(doc1Garbage3, 2)
         XCTAssertEqual(doc2Garbage3, 0)
@@ -1699,7 +1699,7 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 5)
         ])
 
-        try await doc2.update({ root, _ in
+        try doc2.update({ root, _ in
             (root.t as? JSONText)?.edit(0, 3, "")
         }, "delete all")
         await assertTrue(versionVector: doc2.getVersionVector(), actorDatas: [
@@ -1707,12 +1707,12 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client2.id!, lamport: 6)
         ])
 
-        let doc2Garbage4 = await doc2.getGarbageLength()
+        let doc2Garbage4 = doc2.getGarbageLength()
         XCTAssertEqual(doc2Garbage4, 3)
 
         try await client2.detach(doc2)
 
-        let doc2Garbage5 = await doc2.getGarbageLength()
+        let doc2Garbage5 = doc2.getGarbageLength()
         XCTAssertEqual(doc2Garbage5, 0)
 
         try await client1.deactivate()
@@ -1750,7 +1750,7 @@ class GCIntegrationTests: XCTestCase {
 
         await assertTrue(versionVector: doc3.getVersionVector(), actorDatas: [])
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
             (root.t as? JSONText)?.edit(1, 1, "b")
@@ -1776,29 +1776,29 @@ class GCIntegrationTests: XCTestCase {
         ])
 
         // doc3 update
-        try await doc3.update { root, _ in
+        try doc3.update { root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }
 
         // doc1 update
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "1")
         }
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "2")
         }
 
-        try await doc1.update { root, _ in
+        try doc1.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "3")
         }
 
         // doc2 update
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.t as? JSONText)?.edit(3, 3, "x")
         }
 
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.t as? JSONText)?.edit(4, 4, "y")
         }
 
@@ -1807,8 +1807,8 @@ class GCIntegrationTests: XCTestCase {
         try await client2.sync()
         try await client1.sync()
 
-        let doc1Expected = await doc1.toJSON()
-        let doc2Expected = await doc1.toJSON()
+        let doc1Expected = doc1.toJSON()
+        let doc2Expected = doc1.toJSON()
 
         let doc1JSON = """
         {"t":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"b"},{"val":"c"},{"val":"x"},{"val":"y"}]}
@@ -1837,18 +1837,18 @@ class GCIntegrationTests: XCTestCase {
 
         try await client3.detach(doc3)
 
-        try await doc2.update { root, _ in
+        try doc2.update { root, _ in
             (root.t as? JSONText)?.edit(5, 5, "z")
         }
 
         try await client1.sync()
 
-        let len1 = await doc1.getGarbageLength()
+        let len1 = doc1.getGarbageLength()
         XCTAssertEqual(len1, 2)
 
         try await client1.sync()
 
-        let len2 = await doc1.getGarbageLength()
+        let len2 = doc1.getGarbageLength()
         XCTAssertEqual(len2, 2)
 
         // client 2 sync
@@ -1867,8 +1867,8 @@ class GCIntegrationTests: XCTestCase {
             ActorData(actor: client3.id!, lamport: 3)
         ])
 
-        let doc3Expected = await doc1.toJSON()
-        let doc4Expected = await doc1.toJSON()
+        let doc3Expected = doc1.toJSON()
+        let doc4Expected = doc1.toJSON()
         let doc3JSON = """
         {"t":[{"val":"3"},{"val":"2"},{"val":"1"},{"val":"a"},{"val":"z"},{"val":"x"},{"val":"y"}]}
         """
@@ -1878,20 +1878,20 @@ class GCIntegrationTests: XCTestCase {
         XCTAssertEqual(doc3JSON, doc3Expected)
         XCTAssertEqual(doc4JSON, doc4Expected)
 
-        let len3 = await doc1.getGarbageLength()
+        let len3 = doc1.getGarbageLength()
         XCTAssertEqual(len3, 2)
 
-        let len4 = await doc2.getGarbageLength()
+        let len4 = doc2.getGarbageLength()
         XCTAssertEqual(len4, 2)
 
         // client 2 sync
         try await client2.sync()
         try await client1.sync()
 
-        let len5 = await doc1.getGarbageLength()
+        let len5 = doc1.getGarbageLength()
         XCTAssertEqual(len5, 0)
 
-        let len6 = await doc2.getGarbageLength()
+        let len6 = doc2.getGarbageLength()
         XCTAssertEqual(len6, 0)
 
         try await client1.deactivate()
@@ -1919,7 +1919,7 @@ class GCIntegrationTests: XCTestCase {
         try await client2.attach(doc2, [:], .manual)
         try await client3.attach(doc3, [:], .manual)
 
-        try await doc1.update({ root, _ in
+        try doc1.update({ root, _ in
             root.t = JSONText()
             (root.t as? JSONText)?.edit(0, 0, "a")
         }, "sets text")
@@ -1944,14 +1944,14 @@ class GCIntegrationTests: XCTestCase {
 
         // 01. Updates changes over snapshot threshold.
         for idx in 0 ..< (defaultSnapshotThreshold / 2) {
-            try await doc1.update { root, _ in
+            try doc1.update { root, _ in
                 (root.t as? JSONText)?.edit(0, 0, "\(idx % 10)")
             }
 
             try await client1.sync()
             try await client2.sync()
 
-            try await doc2.update { root, _ in
+            try doc2.update { root, _ in
                 (root.t as? JSONText)?.edit(0, 0, "\(idx % 10)")
             }
 
@@ -1975,13 +1975,13 @@ class GCIntegrationTests: XCTestCase {
         ])
 
         // 02. Makes local changes then pull a snapshot from the server.
-        try await doc3.update { root, _ in
+        try doc3.update { root, _ in
             (root.t as? JSONText)?.edit(0, 0, "c")
         }
 
         try await client3.sync()
 
-        let vectors = await doc3.getVersionVector()
+        let vectors = doc3.getVersionVector()
         await assertTrue(versionVector: vectors, actorDatas: [
             ActorData(actor: client1.id!, lamport: 998),
             ActorData(actor: client2.id!, lamport: 1000),
@@ -1991,16 +1991,16 @@ class GCIntegrationTests: XCTestCase {
 
         try await client3.sync()
 
-        var json3Count = (await doc3.getRoot().t as? JSONText)?.length ?? 0
+        var json3Count = (doc3.getRoot().t as? JSONText)?.length ?? 0
         XCTAssertEqual(defaultSnapshotThreshold + 2, json3Count)
 
         // PASSED
         // 03. Delete text after receiving the snapshot.
-        try await doc3.update { root, _ in
+        try doc3.update { root, _ in
             (root.t as? JSONText)?.edit(1, 3, "")
         }
 
-        json3Count = (await doc3.getRoot().t as? JSONText)?.length ?? 0
+        json3Count = (doc3.getRoot().t as? JSONText)?.length ?? 0
 
         XCTAssertEqual(defaultSnapshotThreshold, json3Count)
 
@@ -2008,10 +2008,10 @@ class GCIntegrationTests: XCTestCase {
         try await client2.sync()
         try await client1.sync()
 
-        let json2Count = (await doc2.getRoot().t as? JSONText)?.length ?? 0
+        let json2Count = (doc2.getRoot().t as? JSONText)?.length ?? 0
         XCTAssertEqual(defaultSnapshotThreshold, json2Count)
 
-        let json1Count = (await doc1.getRoot().t as? JSONText)?.length ?? 0
+        let json1Count = (doc1.getRoot().t as? JSONText)?.length ?? 0
         XCTAssertEqual(defaultSnapshotThreshold, json1Count)
 
         try await client3.deactivate()

--- a/Tests/Integration/PresenceTests.swift
+++ b/Tests/Integration/PresenceTests.swift
@@ -39,18 +39,18 @@ final class PresenceTests: XCTestCase {
         try await c2.attach(doc2, [:], .manual)
 
         for index in 0 ..< defaultSnapshotThreshold {
-            try await doc1.update { _, presence in
+            try doc1.update { _, presence in
                 presence.set(["key": index])
             }
         }
 
-        var presence = await doc1.getPresenceForTest(c1.id!)?["key"] as? Int
+        var presence = doc1.getPresenceForTest(c1.id!)?["key"] as? Int
         XCTAssertEqual(presence, defaultSnapshotThreshold - 1)
 
         try await c1.sync()
         try await c2.sync()
 
-        presence = await doc2.getPresenceForTest(c1.id!)?["key"] as? Int
+        presence = doc2.getPresenceForTest(c1.id!)?["key"] as? Int
         XCTAssertEqual(presence, defaultSnapshotThreshold - 1)
     }
 
@@ -69,23 +69,23 @@ final class PresenceTests: XCTestCase {
         let doc2 = Document(key: docKey)
         try await c2.attach(doc2, ["key": "key2"], .manual)
 
-        var presence = await doc1.getPresenceForTest(c1.id!)?["key"] as? String
+        var presence = doc1.getPresenceForTest(c1.id!)?["key"] as? String
         XCTAssertEqual(presence, "key1")
-        presence = await doc1.getPresenceForTest(c2.id!)?["key"] as? String
+        presence = doc1.getPresenceForTest(c2.id!)?["key"] as? String
         XCTAssertEqual(presence, nil)
-        presence = await doc2.getPresenceForTest(c2.id!)?["key"] as? String
+        presence = doc2.getPresenceForTest(c2.id!)?["key"] as? String
         XCTAssertEqual(presence, "key2")
-        presence = await doc2.getPresenceForTest(c1.id!)?["key"] as? String
+        presence = doc2.getPresenceForTest(c1.id!)?["key"] as? String
         XCTAssertEqual(presence, "key1")
 
         try await c1.sync()
-        presence = await doc1.getPresenceForTest(c2.id!)?["key"] as? String
+        presence = doc1.getPresenceForTest(c2.id!)?["key"] as? String
         XCTAssertEqual(presence, "key2")
 
         try await c2.detach(doc2)
         try await c1.sync()
 
-        let hasPresence = await doc1.hasPresence(c2.id!)
+        let hasPresence = doc1.hasPresence(c2.id!)
         XCTAssertFalse(hasPresence)
     }
 
@@ -104,18 +104,18 @@ final class PresenceTests: XCTestCase {
         let doc2 = Document(key: docKey)
         try await c2.attach(doc2, [:], .manual)
 
-        var presence = await doc1.getPresenceForTest(c1.id!)
+        var presence = doc1.getPresenceForTest(c1.id!)
         XCTAssertTrue(presence!.isEmpty)
-        presence = await doc1.getPresenceForTest(c2.id!)
+        presence = doc1.getPresenceForTest(c2.id!)
         XCTAssertTrue(presence == nil)
-        presence = await doc2.getPresenceForTest(c2.id!)
+        presence = doc2.getPresenceForTest(c2.id!)
         XCTAssertTrue(presence!.isEmpty)
-        presence = await doc2.getPresenceForTest(c1.id!)
+        presence = doc2.getPresenceForTest(c1.id!)
         XCTAssertTrue(presence!.isEmpty)
 
         try await c1.sync()
 
-        presence = await doc2.getPresenceForTest(c1.id!)
+        presence = doc2.getPresenceForTest(c1.id!)
         XCTAssertTrue(presence!.isEmpty)
     }
 
@@ -134,18 +134,18 @@ final class PresenceTests: XCTestCase {
         let doc2 = Document(key: docKey)
         try await c2.attach(doc2, ["key": "key2", "cursor": ["x": 0, "y": 0]])
 
-        try await doc1.update { _, presence in
+        try doc1.update { _, presence in
             presence.set(["cursor": ["x": 1, "y": 1]])
         }
 
-        var presence = await doc1.getPresenceForTest(c1.id!)
+        var presence = doc1.getPresenceForTest(c1.id!)
         XCTAssertEqual(presence?["key"] as? String, "key1")
         XCTAssertEqual(presence?["cursor"] as? [String: Int], ["x": 1, "y": 1])
 
         try await c1.sync()
         try await c2.sync()
 
-        presence = await doc2.getPresenceForTest(c1.id!)
+        presence = doc2.getPresenceForTest(c1.id!)
         XCTAssertEqual(presence?["key"] as? String, "key1")
         XCTAssertEqual(presence?["cursor"] as? [String: Int], ["x": 1, "y": 1])
     }
@@ -158,9 +158,9 @@ final class PresenceTests: XCTestCase {
         try await c1.activate()
         try await c2.activate()
         try await c3.activate()
-        let c1ID = await c1.id!
-        let c2ID = await c2.id!
-        let c3ID = await c3.id!
+        let c1ID = c1.id!
+        let c2ID = c2.id!
+        let c3ID = c3.id!
 
         let docKey = "\(self.description)-\(Date().description)".toDocKey
 
@@ -172,7 +172,7 @@ final class PresenceTests: XCTestCase {
         let doc1 = Document(key: docKey)
         try await c1.attach(doc1, ["name": "a1", "cursor": ["x": 0, "y": 0]])
 
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             eventCount1 += 1
 
             if eventCount1 == 1, event.type == .watched {
@@ -194,23 +194,23 @@ final class PresenceTests: XCTestCase {
 
         await fulfillment(of: [expect1], timeout: 5)
 
-        var resultPresences1 = await doc1.getPresences()
-        var doc1Presence = (await doc1.getMyPresence())!
-        let doc2Presence = (await doc2.getMyPresence())!
+        var resultPresences1 = doc1.getPresences()
+        var doc1Presence = (doc1.getMyPresence())!
+        let doc2Presence = (doc2.getMyPresence())!
 
         XCTAssert(resultPresences1.first { $0.clientID == c1ID }!.presence == doc1Presence)
         XCTAssert(resultPresences1.first { $0.clientID == c2ID }!.presence == doc2Presence)
         XCTAssert(resultPresences1.first { $0.clientID == c3ID } == nil)
 
         // 02. c2 is changed to manual sync, while c3 is changed to realtime sync.
-        try await c2.changeSyncMode(doc2, .manual)
+        try c2.changeSyncMode(doc2, .manual)
         await fulfillment(of: [expect2], timeout: 5) // c2 unwatched
-        try await c3.changeSyncMode(doc3, .realtime)
+        try c3.changeSyncMode(doc3, .realtime)
         await fulfillment(of: [expect3], timeout: 5) // c3 watched
 
-        resultPresences1 = await doc1.getPresences()
-        doc1Presence = (await doc1.getMyPresence())!
-        let doc3Presence = (await doc3.getMyPresence())!
+        resultPresences1 = doc1.getPresences()
+        doc1Presence = (doc1.getMyPresence())!
+        let doc3Presence = (doc3.getMyPresence())!
 
         XCTAssert(resultPresences1.first { $0.clientID == c1ID }!.presence == doc1Presence)
         XCTAssert(resultPresences1.first { $0.clientID == c3ID }!.presence == doc3Presence)
@@ -227,7 +227,7 @@ final class PresenceTests: XCTestCase {
         let c2 = Client(rpcAddress)
         try await c1.activate()
         try await c2.activate()
-        let c1ID = await c1.id!
+        let c1ID = c1.id!
 
         let docKey = "\(self.description)-\(Date().description)".toDocKey
 
@@ -237,19 +237,19 @@ final class PresenceTests: XCTestCase {
         let doc2 = Document(key: docKey)
         try await c2.attach(doc2, ["counter": 0], .manual)
 
-        try await doc1.update { _, presence in
+        try doc1.update { _, presence in
             if let counter: Int = presence.get("counter") {
                 presence.set(["counter": counter + 1])
             }
         }
 
-        var result = await doc1.getPresenceForTest(c1ID)?["counter"] as? Int
+        var result = doc1.getPresenceForTest(c1ID)?["counter"] as? Int
         XCTAssertEqual(result, 1)
 
         try await c1.sync()
         try await c2.sync()
 
-        result = await doc1.getPresenceForTest(c1ID)?["counter"] as? Int
+        result = doc1.getPresenceForTest(c1ID)?["counter"] as? Int
         XCTAssertEqual(result, 1)
     }
 }
@@ -331,18 +331,18 @@ final class PresenceSubscribeTests: XCTestCase {
         let c2 = Client(rpcAddress)
         try await c1.activate()
         try await c2.activate()
-        let c1ID = await c1.id!
-        let c2ID = await c2.id!
+        let c1ID = c1.id!
+        let c2ID = c2.id!
 
         let doc1 = Document(key: docKey)
         try await c1.attach(doc1, ["name": "a"])
 
         let eventCollectorD1 = EventCollector<EventResult>(doc: doc1)
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             eventCollectorD1.add(event: EventResult(event))
         }
 
-        assertPeerElementsEqual(peers1: await doc1.getPresences(),
+        assertPeerElementsEqual(peers1: doc1.getPresences(),
                                 peers2: [
                                     PeerElement(c1ID, ["name": "a"])
                                 ])
@@ -351,11 +351,11 @@ final class PresenceSubscribeTests: XCTestCase {
         try await c2.attach(doc2, ["name": "b"])
 
         let eventCollectorD2 = EventCollector<EventResult>(doc: doc2)
-        await doc2.subscribePresence { event, _ in
+        doc2.subscribePresence { event, _ in
             eventCollectorD2.add(event: EventResult(event))
         }
 
-        assertPeerElementsEqual(peers1: await doc2.getPresences(),
+        assertPeerElementsEqual(peers1: doc2.getPresences(),
                                 peers2: [
                                     PeerElement(c2ID, ["name": "b"]),
                                     PeerElement(c1ID, ["name": "a"])
@@ -376,10 +376,10 @@ final class PresenceSubscribeTests: XCTestCase {
             await eventCollectorD1.verifyNthValue(at: 1, isEqualTo: result1[0])
         }
 
-        try await doc1.update { _, presence in
+        try doc1.update { _, presence in
             presence.set(["name": "A"])
         }
-        try await doc2.update { _, presence in
+        try doc2.update { _, presence in
             presence.set(["name": "B"])
         }
 
@@ -392,8 +392,8 @@ final class PresenceSubscribeTests: XCTestCase {
         await eventCollectorD2.verifyNthValue(at: 1, isEqualTo: result2[0])
         await eventCollectorD2.verifyNthValue(at: 2, isEqualTo: result2[1])
 
-        let resultPresence1 = await doc1.getPresences()
-        let resultPresence2 = await doc2.getPresences()
+        let resultPresence1 = doc1.getPresences()
+        let resultPresence2 = doc2.getPresences()
         assertPeerElementsEqual(peers1: resultPresence2,
                                 peers2: [
                                     PeerElement(c2ID, ["name": "B"]),
@@ -418,7 +418,7 @@ final class PresenceSubscribeTests: XCTestCase {
         let c2 = Client(rpcAddress)
         try await c1.activate()
         try await c2.activate()
-        let c2ID = await c2.id!
+        let c2ID = c2.id!
 
         let doc1 = Document(key: docKey)
 
@@ -426,7 +426,7 @@ final class PresenceSubscribeTests: XCTestCase {
 
         let expect1 = expectation(description: "sub 1")
 
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             if let event = event as? WatchedEvent,
                event.value.clientID == c2ID
             {
@@ -436,7 +436,7 @@ final class PresenceSubscribeTests: XCTestCase {
 
         let expect2 = expectation(description: "sub 2")
 
-        await doc1.subscribeConnection { event, _ in
+        doc1.subscribeConnection { event, _ in
             if let event = event as? ConnectionChangedEvent,
                event.value == .disconnected
             {
@@ -448,18 +448,18 @@ final class PresenceSubscribeTests: XCTestCase {
         try await c2.attach(doc2, ["name": "b"])
 
         await fulfillment(of: [expect1], timeout: 5, enforceOrder: false)
-        await doc1.unsubscribePresence()
+        doc1.unsubscribePresence()
 
-        var presence = await doc1.getPresence(c2ID)
+        var presence = doc1.getPresence(c2ID)
 
         XCTAssertEqual(presence?["name"] as? String, "b")
 
-        try await c1.changeSyncMode(doc1, .manual)
+        try c1.changeSyncMode(doc1, .manual)
 
         await fulfillment(of: [expect2], timeout: 5, enforceOrder: false)
-        await doc1.unsubscribeConnection()
+        doc1.unsubscribeConnection()
 
-        presence = await doc1.getPresence(c2ID)
+        presence = doc1.getPresence(c2ID)
 
         XCTAssert(presence == nil)
 
@@ -475,8 +475,8 @@ final class PresenceSubscribeTests: XCTestCase {
         let c2 = Client(rpcAddress)
         try await c1.activate()
         try await c2.activate()
-        let c1ID = await c1.id!
-        let c2ID = await c2.id!
+        let c1ID = c1.id!
+        let c2ID = c2.id!
         var eventCount1 = 0
         var eventCount2 = 0
 
@@ -489,7 +489,7 @@ final class PresenceSubscribeTests: XCTestCase {
         let doc1 = Document(key: docKey)
         try await c1.attach(doc1, ["name": "a", "cursor": ["x": 0, "y": 0]])
 
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             eventCount1 += 1
 
             eventReceived1.append(EventResult(event))
@@ -502,7 +502,7 @@ final class PresenceSubscribeTests: XCTestCase {
         let doc2 = Document(key: docKey)
         try await c2.attach(doc2, ["name": "b", "cursor": ["x": 0, "y": 0]])
 
-        await doc2.subscribePresence { event, _ in
+        doc2.subscribePresence { event, _ in
             eventCount2 += 1
 
             eventReceived2.append(EventResult(event))
@@ -512,7 +512,7 @@ final class PresenceSubscribeTests: XCTestCase {
             }
         }
 
-        try await doc1.update { _, presence in
+        try doc1.update { _, presence in
             presence.set(["name": "A"])
             presence.set(["cursor": ["x": 1, "y": 1]])
             presence.set(["name": "X"])
@@ -547,8 +547,8 @@ final class PresenceSubscribeTests: XCTestCase {
         let c2 = Client(rpcAddress)
         try await c1.activate()
         try await c2.activate()
-        let c1ID = await c1.id!
-        let c2ID = await c2.id!
+        let c1ID = c1.id!
+        let c2ID = c2.id!
 
         var eventCount1 = 0
 
@@ -560,7 +560,7 @@ final class PresenceSubscribeTests: XCTestCase {
         let doc1 = Document(key: docKey)
         try await c1.attach(doc1, ["name": "a"])
 
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             eventCount1 += 1
 
             eventReceived1.append(EventResult(event))
@@ -592,13 +592,13 @@ final class PresenceSubscribeTests: XCTestCase {
             XCTAssertEqual(value, eventReceived1[index])
         }
 
-        let resultPresence1 = await doc1.getPresences()
+        let resultPresence1 = doc1.getPresences()
         XCTAssertEqual(resultPresence1.count, 1)
         XCTAssertEqual(resultPresence1.first?.clientID, c1ID)
         XCTAssertEqual(resultPresence1.first?.presence as? [String: String], ["name": "a"])
 
         // NOTE(hiddenviewer): js-sdk return [ActorIDs.initial: [:]], but ios-sdk return empty
-        let resultPresence2 = await doc2.getPresences()
+        let resultPresence2 = doc2.getPresences()
         XCTAssertTrue(resultPresence2.isEmpty)
 
         try await c1.deactivate()
@@ -613,8 +613,8 @@ final class PresenceSubscribeTests: XCTestCase {
         try await c1.activate()
         try await c2.activate()
         try await c3.activate()
-        let c2ID = await c2.id!
-        let c3ID = await c3.id!
+        let c2ID = c2.id!
+        let c3ID = c3.id!
 
         let docKey = "\(Date().description)-\(self.description)".toDocKey
 
@@ -631,7 +631,7 @@ final class PresenceSubscribeTests: XCTestCase {
         let doc1 = Document(key: docKey)
         try await c1.attach(doc1, ["name": "a1", "cursor": ["x": 0, "y": 0]])
 
-        await doc1.subscribePresence { event, _ in
+        doc1.subscribePresence { event, _ in
             eventCount1 += 1
 
             eventReceived1.append(EventResult(event))
@@ -670,10 +670,10 @@ final class PresenceSubscribeTests: XCTestCase {
 
         // 02. c2 and c3 update the presence.
         //     c1 receives the presence-changed event from c2.
-        try await doc2.update { _, presence in
+        try doc2.update { _, presence in
             presence.set(["name": "b2"])
         }
-        try await doc3.update { _, presence in
+        try doc3.update { _, presence in
             presence.set(["name": "c2"])
         }
 
@@ -681,17 +681,17 @@ final class PresenceSubscribeTests: XCTestCase {
 
         // 03. c2 is changed to manual sync, c3 resumes the document (in realtime sync).
         //     c1 receives an unwatched event from c2 and a watched event from c3.
-        try await c2.changeSyncMode(doc2, .manual)
+        try c2.changeSyncMode(doc2, .manual)
         await fulfillment(of: [expect3], timeout: 5) // c2 unwatched
-        try await c3.changeSyncMode(doc3, .realtime)
+        try c3.changeSyncMode(doc3, .realtime)
         await fulfillment(of: [expect5], timeout: 5) // c3 watched, c3 presence-changed
 
         // 04. c2 and c3 update the presence.
         //     c1 receives the presence-changed event from c3.
-        try await doc2.update { _, presence in
+        try doc2.update { _, presence in
             presence.set(["name": "b3"])
         }
-        try await doc3.update { _, presence in
+        try doc3.update { _, presence in
             presence.set(["name": "c3"])
         }
 
@@ -699,7 +699,7 @@ final class PresenceSubscribeTests: XCTestCase {
 
         // 05. c3 is changed to manual sync,
         //     c1 receives an unwatched event from c3.
-        try await c3.changeSyncMode(doc3, .manual)
+        try c3.changeSyncMode(doc3, .manual)
         await fulfillment(of: [expect7], timeout: 5) // c3 unwatched
 
         // 06. c2 performs manual sync and then resumes(switches to realtime sync).
@@ -709,7 +709,7 @@ final class PresenceSubscribeTests: XCTestCase {
         // We need to fix this issue.
         try await c2.sync()
         try await Task.sleep(nanoseconds: 1_500_000_000)
-        try await c2.changeSyncMode(doc2, .realtime)
+        try c2.changeSyncMode(doc2, .realtime)
         await fulfillment(of: [expect8], timeout: 5) // c2 watched
 
         let result1 = [

--- a/Tests/Integration/SnapshotTests.swift
+++ b/Tests/Integration/SnapshotTests.swift
@@ -28,27 +28,27 @@ final class SnapshotTests: XCTestCase {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             // 01. Updates changes over snapshot threshold.
             for idx in 0 ..< defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     root["\(idx)"] = Int32(idx)
                 }
             }
             try await c1.sync()
 
             // 02. Makes local changes then pull a snapshot from the agent.
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 root["key"] = "value"
             }
             try await c2.sync()
 
-            let value = await d2.getRoot()["key"] as? String
+            let value = d2.getRoot()["key"] as? String
             XCTAssertEqual(value, "value")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            let d1JSON = await d1.toSortedJSON()
-            let d2JSON = await d2.toSortedJSON()
+            let d1JSON = d1.toSortedJSON()
+            let d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
@@ -57,7 +57,7 @@ final class SnapshotTests: XCTestCase {
     func test_should_handle_snapshot_for_text_object() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
             for _ in 0 ..< defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     root.k1 = JSONText()
                 }
             }
@@ -66,13 +66,13 @@ final class SnapshotTests: XCTestCase {
 
             // 01. Updates changes over snapshot threshold by c1.
             for idx in 0 ..< defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     (root.k1 as? JSONText)?.edit(idx, idx, "x")
                 }
             }
 
             // 02. Makes local change by c2.
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "o")
             }
 
@@ -80,8 +80,8 @@ final class SnapshotTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            let d1JSON = await d1.toSortedJSON()
-            let d2JSON = await d2.toSortedJSON()
+            let d1JSON = d1.toSortedJSON()
+            let d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
@@ -89,7 +89,7 @@ final class SnapshotTests: XCTestCase {
     @MainActor
     func test_should_handle_snapshot_for_text_with_attributes() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "a")
             }
@@ -98,7 +98,7 @@ final class SnapshotTests: XCTestCase {
 
             // 01. Updates changes over snapshot threshold by c1.
             for _ in 0 ..< defaultSnapshotThreshold {
-                try await d1.update { root, _ in
+                try d1.update { root, _ in
                     (root.k1 as? JSONText)?.setStyle(0, 1, ["bold": true])
                 }
             }
@@ -106,8 +106,8 @@ final class SnapshotTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            let d1JSON = await d1.toSortedJSON()
-            let d2JSON = await d2.toSortedJSON()
+            let d1JSON = d1.toSortedJSON()
+            let d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }

--- a/Tests/Integration/TextIntegrationTests.swift
+++ b/Tests/Integration/TextIntegrationTests.swift
@@ -24,7 +24,7 @@ final class TextIntegrationTests: XCTestCase {
     @MainActor
     func test_should_handle_edit_operations() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
             }
@@ -32,13 +32,13 @@ final class TextIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "1234")
             }
@@ -47,8 +47,8 @@ final class TextIntegrationTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
@@ -58,47 +58,47 @@ final class TextIntegrationTests: XCTestCase {
     @MainActor
     func test_should_handle_concurrent_edit_operations() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "ABCD")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"ABCD\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "1234")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"1234\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "XX")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "YY")
             }
 
@@ -106,16 +106,16 @@ final class TextIntegrationTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 5, "ZZ")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 3, "TT")
             }
 
@@ -123,8 +123,8 @@ final class TextIntegrationTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -133,7 +133,7 @@ final class TextIntegrationTests: XCTestCase {
     @MainActor
     func test_should_handle_concurrent_insertion_and_deletion() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "AB")
             }
@@ -141,32 +141,32 @@ final class TextIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"AB\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 2, "")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 1, "C")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"A\"},{\"val\":\"C\"},{\"val\":\"B\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"C\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -175,7 +175,7 @@ final class TextIntegrationTests: XCTestCase {
     @MainActor
     func test_should_handle_concurrent_block_deletions() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "123")
                 (root.k1 as? JSONText)?.edit(3, 3, "456")
@@ -185,32 +185,32 @@ final class TextIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"123\"},{\"val\":\"456\"},{\"val\":\"789\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 7, "")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"1\"},{\"val\":\"89\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(2, 5, "")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"12\"},{\"val\":\"6\"},{\"val\":\"789\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -219,11 +219,11 @@ final class TextIntegrationTests: XCTestCase {
     @MainActor
     func test_should_maintain_the_correct_weight_for_nodes_newly_created_then_concurrently_removed() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 0, "O")
                 (root.k1 as? JSONText)?.edit(1, 1, "O")
                 (root.k1 as? JSONText)?.edit(2, 2, "O")
@@ -232,13 +232,13 @@ final class TextIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 2, "X")
                 (root.k1 as? JSONText)?.edit(1, 2, "X")
                 (root.k1 as? JSONText)?.edit(1, 2, "")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 3, "N")
             }
 
@@ -246,8 +246,8 @@ final class TextIntegrationTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            let d1Check = await(d1.getRoot().k1 as? JSONText)?.getTreeByIndex()?.checkWeight() ?? false
-            let d2Check = await(d2.getRoot().k1 as? JSONText)?.getTreeByIndex()?.checkWeight() ?? false
+            let d1Check = (d1.getRoot().k1 as? JSONText)?.getTreeByIndex()?.checkWeight() ?? false
+            let d2Check = (d2.getRoot().k1 as? JSONText)?.getTreeByIndex()?.checkWeight() ?? false
             XCTAssertTrue(d1Check)
             XCTAssertTrue(d2Check)
         }
@@ -258,7 +258,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex1_concurrent_insertions_on_plain_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -266,32 +266,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -300,7 +300,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex2_concurrent_formatting_and_insertion() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -308,32 +308,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "brown ")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"brown \"},{\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"val\":\"brown \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
         }
     }
@@ -341,7 +341,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex3_overlapping_formatting_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -349,32 +349,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": true])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox\"},{\"attrs\":{\"bold\":true},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -383,7 +383,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex4_overlapping_different_formatting_bold_and_italic() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -391,32 +391,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["bold": true])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["italic": true])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"italic\":true},\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":true,\"italic\":true},\"val\":\"fox\"},{\"attrs\":{\"italic\":true},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -425,7 +425,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex5_conflicting_overlaps_highlighting() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -433,32 +433,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["highlight": "red"])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["highlight": "blue"])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"highlight\":\"red\"},\"val\":\"The \"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\"fox\"},{\"attrs\":{\"highlight\":\"blue\"},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -468,7 +468,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex6_conflicting_overlaps_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -476,39 +476,39 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -517,7 +517,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex6_conflicting_overlaps_bold_2() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -525,42 +525,42 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 15, ["bold": true])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["bold": false])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(8, 15, ["bold": true])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"attrs\":{\"bold\":true},\"val\":\"The \"},{\"attrs\":{\"bold\":false},\"val\":\"fox \"},{\"attrs\":{\"bold\":true},\"val\":\"jumped.\"}]}")
 
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
@@ -568,7 +568,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex7_multiple_instances_of_the_same_mark() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
             }
@@ -576,32 +576,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The fox jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(0, 7, ["comment": "Alice's comment"])
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The fox\"},{\"val\":\" jumped.\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.setStyle(4, 15, ["comment": "Bob's comment"])
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox jumped.\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"attrs\":{\"comment\":\"Alice's comment\"},\"val\":\"The \"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\"fox\"},{\"attrs\":{\"comment\":\"Bob's comment\"},\"val\":\" jumped.\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -610,7 +610,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex8_text_insertion_at_span_boundaries_bold() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
                 (root.k1 as? JSONText)?.setStyle(4, 14, ["bold": true])
@@ -619,32 +619,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"bold\":true},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -653,7 +653,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_ex9_text_insertion_at_span_boundaries_link() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "The fox jumped.")
                 (root.k1 as? JSONText)?.setStyle(4, 14, ["link": "https://www.google.com/search?q=jumping+fox"])
@@ -662,32 +662,32 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(4, 4, "quick ")
             }
 
-            d1JSON = await d1.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\".\"}]}")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(14, 14, " over the dog")
             }
 
-            d2JSON = await d2.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d2JSON, "{\"k1\":[{\"val\":\"The \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"The \"},{\"val\":\"quick \"},{\"attrs\":{\"link\":\"https://www.google.com/search?q=jumping+fox\"},\"val\":\"fox jumped\"},{\"val\":\" over the dog\"},{\"val\":\".\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -697,7 +697,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_causal_deletion_preserves_original_timestamps() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "abcd")
             }
@@ -705,20 +705,20 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"abcd\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 3, "")
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 2, "")
             }
 
@@ -760,8 +760,8 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
         }
@@ -771,7 +771,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_concurrent_deletion_test_for_LWW_behavior_complete_inclusion_larger_range_later() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "abcd")
             }
@@ -779,17 +779,17 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"abcd\"}]}")
             XCTAssertEqual(d1JSON, d2JSON)
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 3, "")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 4, "")
             }
 
@@ -797,8 +797,8 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
 
             XCTAssertEqual(d1JSON, d2JSON)
 
@@ -817,7 +817,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text = await getAllNodes(from: d1)
-            var iterator = text?.makeIterator()
+            let iterator = text?.makeIterator()
             var (aNode1, bcNode1, dNode1): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator?.next() {
                 switch node.value.toString {
@@ -833,7 +833,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text2 = await getAllNodes(from: d2)
-            var iterator2 = text2?.makeIterator()
+            let iterator2 = text2?.makeIterator()
             var (aNode2, bcNode2, dNode2): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator2?.next() {
                 switch node.value.toString {
@@ -871,7 +871,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_concurrent_deletion_test_for_LWW_behavior_complete_inclusion_smaller_range_later() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "abcd")
             }
@@ -879,17 +879,17 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"abcd\"}]}")
             XCTAssertEqual(d2JSON, d1JSON)
 
             // Concurrent deletions
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 4, "")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 3, "")
             }
 
@@ -905,7 +905,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text = await getAllNodes(from: d1)
-            var iterator = text?.makeIterator()
+            let iterator = text?.makeIterator()
             var (aNode1, bcNode1, dNode1): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator?.next() {
                 switch node.value.toString {
@@ -921,7 +921,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text2 = await getAllNodes(from: d2)
-            var iterator2 = text2?.makeIterator()
+            let iterator2 = text2?.makeIterator()
             var (aNode2, bcNode2, dNode2): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator2?.next() {
                 switch node.value.toString {
@@ -953,8 +953,8 @@ final class TextIntegrationConcurrentTests: XCTestCase {
 
             XCTAssertEqual(laterExpectedRemovedAt.toIDString, bcNode2!.removedAt!.toIDString)
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
             XCTAssertEqual(d2JSON, "{\"k1\":[]}")
         }
@@ -964,7 +964,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
     @MainActor
     func test_concurrent_deletion_test_for_LWW_behavior_partial_overlap() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.k1 = JSONText()
                 (root.k1 as? JSONText)?.edit(0, 0, "abcd")
             }
@@ -972,17 +972,17 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1JSON = await d1.toSortedJSON()
-            var d2JSON = await d2.toSortedJSON()
+            var d1JSON = d1.toSortedJSON()
+            var d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[{\"val\":\"abcd\"}]}")
             XCTAssertEqual(d2JSON, d1JSON)
 
             // Concurrent deletions
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 (root.k1 as? JSONText)?.edit(0, 3, "")
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 (root.k1 as? JSONText)?.edit(1, 4, "")
             }
 
@@ -998,7 +998,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text = await getAllNodes(from: d1)
-            var iterator = text?.makeIterator()
+            let iterator = text?.makeIterator()
             var (aNode1, bcNode1, dNode1): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator?.next() {
                 switch node.value.toString {
@@ -1014,7 +1014,7 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             }
 
             let text2 = await getAllNodes(from: d2)
-            var iterator2 = text2?.makeIterator()
+            let iterator2 = text2?.makeIterator()
             var (aNode2, bcNode2, dNode2): (RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?, RGATreeSplitNode<CRDTTextValue>?) = (nil, nil, nil)
             while let node = iterator2?.next() {
                 switch node.value.toString {
@@ -1046,8 +1046,8 @@ final class TextIntegrationConcurrentTests: XCTestCase {
             XCTAssertEqual(laterExpectedRemovedAt.toIDString, dNode1!.removedAt!.toIDString)
             XCTAssertEqual(laterExpectedRemovedAt.toIDString, dNode2!.removedAt!.toIDString)
 
-            d1JSON = await d1.toSortedJSON()
-            d2JSON = await d2.toSortedJSON()
+            d1JSON = d1.toSortedJSON()
+            d2JSON = d2.toSortedJSON()
             XCTAssertEqual(d1JSON, "{\"k1\":[]}")
             XCTAssertEqual(d2JSON, "{\"k1\":[]}")
         }

--- a/Tests/Integration/TreeIntegrationTests.swift
+++ b/Tests/Integration/TreeIntegrationTests.swift
@@ -86,7 +86,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree()
             try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "p"))
@@ -115,7 +115,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "p",
@@ -138,7 +138,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "p",
@@ -156,7 +156,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "doc",
                                                                children: [JSONTreeElementNode(type: "p",
@@ -176,10 +176,10 @@ final class TreeIntegrationTests: XCTestCase {
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><p>ab</p></doc>")
         }
 
-        let tree = await doc.getRoot().t as? JSONTree
+        let tree = doc.getRoot().t as? JSONTree
         XCTAssertEqual(tree?.toXML(), /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "doc",
                                                                children: [JSONTreeElementNode(type: "p",
                                                                                               children: [JSONTreeTextNode(value: "ab")])]))
@@ -201,7 +201,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "doc",
                                                                children: [JSONTreeElementNode(type: "p",
@@ -211,13 +211,13 @@ final class TreeIntegrationTests: XCTestCase {
 
         var treeOperations = [TreeEditOpInfo]()
 
-        await doc.subscribe("$.t") { event, _ in
+        doc.subscribe("$.t") { event, _ in
             if let event = event as? LocalChangeEvent {
                 treeOperations.append(contentsOf: event.value.operations.compactMap { $0 as? TreeEditOpInfo })
             }
         }
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "X"))
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><p>Xab</p></doc>")
         }
@@ -235,7 +235,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -259,14 +259,14 @@ final class TreeIntegrationTests: XCTestCase {
 
         let expect = expectation(description: "wait event")
 
-        await doc.subscribe("$.t") { event, _ in
+        doc.subscribe("$.t") { event, _ in
             if let event = event as? LocalChangeEvent {
                 treeOperations.append(contentsOf: event.value.operations.compactMap { $0 as? TreeEditOpInfo })
                 expect.fulfill()
             }
         }
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([0, 0, 0, 1], [0, 0, 0, 1], JSONTreeTextNode(value: "X"))
 
             XCTAssertEqual((root.t as? JSONTree)?.toXML(), /* html */ "<doc><tc><p><tn>aXb</tn></p></tc></doc>")
@@ -285,7 +285,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -339,7 +339,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -390,7 +390,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "tc", children: [
@@ -433,7 +433,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "tc", children: [
@@ -465,7 +465,7 @@ final class TreeIntegrationTests: XCTestCase {
     @MainActor
     func test_can_sync_its_split_with_other_clients() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc", children: [
                         JSONTreeElementNode(type: "tc", children: [
@@ -487,33 +487,33 @@ final class TreeIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>1234</tn></p><p><tn>5678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>1234</tn></p><p><tn>5678</tn></p></tc></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.splitByPath([0, 0, 0, 2])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>12</tn><tn>34</tn></p><p><tn>5678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>12</tn><tn>34</tn></p><p><tn>5678</tn></p></tc></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.splitByPath([0, 0, 1])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>12</tn></p><p><tn>34</tn></p><p><tn>5678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>12</tn></p><p><tn>34</tn></p><p><tn>5678</tn></p></tc></doc>")
@@ -524,7 +524,7 @@ final class TreeIntegrationTests: XCTestCase {
     @MainActor
     func test_can_sync_its_merge_with_other_clients() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc", children: [
                         JSONTreeElementNode(type: "tc", children: [
@@ -546,34 +546,34 @@ final class TreeIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>1234</tn></p><p><tn>5678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>1234</tn></p><p><tn>5678</tn></p></tc></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.mergeByPath([0, 1])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>1234</tn><tn>5678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>1234</tn><tn>5678</tn></p></tc></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.mergeByPath([0, 0, 1])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><tc><p><tn>12345678</tn></p></tc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><tc><p><tn>12345678</tn></p></tc></doc>")
@@ -583,28 +583,28 @@ final class TreeIntegrationTests: XCTestCase {
     @MainActor
     func test_can_sync_its_content_with_other_clients() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "doc", children: [JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "hello")])]))
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>hello</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(7, 7, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "yorkie")]))
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p><p>yorkie</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>hello</p><p>yorkie</p></doc>")
@@ -616,7 +616,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -635,7 +635,7 @@ final class TreeIntegrationTests: XCTestCase {
             )
         }
 
-        let tree = await doc.getRoot().t as? JSONTree
+        let tree = doc.getRoot().t as? JSONTree
         //     0  1  2   3 4 5    6   7   8
         // <root><p><b><i> a b </i></b></p></root>
         let docXML = tree?.toXML()
@@ -659,7 +659,7 @@ final class TreeIntegrationTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -678,7 +678,7 @@ final class TreeIntegrationTests: XCTestCase {
             )
         }
 
-        let tree = await doc.getRoot().t as? JSONTree
+        let tree = doc.getRoot().t as? JSONTree
         //     0  1  2   3 4 5    6   7   8
         // <root><p><b><i> a b </i></b></p></root>
         let docXML = tree?.toXML()
@@ -700,20 +700,20 @@ final class TreeIntegrationTests: XCTestCase {
     @MainActor
     func test_should_return_correct_range_from_index_within_doc_subscribe() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "doc", children: [JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "hello")])]))
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>hello</p></doc>")
 
-            try await d1.update { root, presence in
+            try d1.update { root, presence in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "a"))
                 let posSelection = try (root.t as? JSONTree)?.indexRangeToPosRange((2, 2))
                 presence.set(["selection": [posSelection!.0, posSelection!.1]])
@@ -722,28 +722,28 @@ final class TreeIntegrationTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ahello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>ahello</p></doc>")
 
-            let selection = await d1.getMyPresence()!["selection"] as? [Any]
+            let selection = d1.getMyPresence()!["selection"] as? [Any]
             let from: CRDTTreePosStruct = self.decodeDictionary(selection?[0])!
             let to: CRDTTreePosStruct = self.decodeDictionary(selection?[1])!
-            let indexRange = try await(d1.getRoot().t as? JSONTree)?.posRangeToIndexRange((from, to))
+            let indexRange = try (d1.getRoot().t as? JSONTree)?.posRangeToIndexRange((from, to))
             XCTAssertEqual(indexRange?.0, 2)
             XCTAssertEqual(indexRange?.1, 2)
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "b"))
             }
 
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>abhello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>abhello</p></doc>")
@@ -767,7 +767,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -777,16 +777,16 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        var docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        var docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeTextNode(value: "c"),
                 JSONTreeTextNode(value: "d")
             ])
         }
-        docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>abcd</p></doc>")
     }
 
@@ -795,7 +795,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -805,16 +805,16 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        var docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        var docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             try (root.t as? JSONTree)?.editBulk(4, 4, [
                 JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")]),
                 JSONTreeElementNode(type: "i", children: [JSONTreeTextNode(value: "fg")])
             ])
         }
-        docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p><p>cd</p><i>fg</i></doc>")
     }
 
@@ -823,7 +823,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(
@@ -893,7 +893,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -903,10 +903,10 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             XCTAssertThrowsError(try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeTextNode(value: "C"),
                 JSONTreeTextNode(value: "")
@@ -919,7 +919,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -929,10 +929,10 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             XCTAssertThrowsError(try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeElementNode(type: "p", children: []),
                 JSONTreeTextNode(value: "d")
@@ -945,7 +945,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -955,10 +955,10 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             XCTAssertThrowsError(try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeElementNode(type: "p", children: [
                     JSONTreeTextNode(value: "c"),
@@ -974,7 +974,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -984,10 +984,10 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             XCTAssertThrowsError(try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeElementNode(type: "p", children: [
                     JSONTreeTextNode(value: "c")
@@ -1004,7 +1004,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -1014,10 +1014,10 @@ final class TreeIntegrationEditTests: XCTestCase {
                 ])
             )
         }
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             XCTAssertThrowsError(try (root.t as? JSONTree)?.editBulk(3, 3, [
                 JSONTreeTextNode(value: "d"),
                 JSONTreeElementNode(type: "p", children: [
@@ -1032,7 +1032,7 @@ final class TreeIntegrationEditTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -1062,14 +1062,14 @@ final class TreeIntegrationEditTests: XCTestCase {
             )
         }
 
-        var docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        var docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>ab<p>x</p></p><p><p>cd</p></p><p><p>y</p>ef</p></doc>")
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             try (root.t as? JSONTree)?.edit(2, 18)
         }
 
-        docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        docXML = (doc.getRoot().t as? JSONTree)?.toXML()
         XCTAssertEqual(docXML, /* html */ "<doc><p>af</p></doc>")
     }
 }
@@ -1080,7 +1080,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "p",
@@ -1089,7 +1089,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
             )
         }
 
-        let docXML = await(doc.getRoot().t as? JSONTree)?.toXML()
+        let docXML = (doc.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(docXML, /* html */ "<doc><p><span bold=true>hello</span></p></doc>")
     }
@@ -1099,7 +1099,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "tc",
@@ -1137,7 +1137,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc",
                                     children: [JSONTreeElementNode(type: "tc",
@@ -1165,7 +1165,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
     @MainActor
     func test_can_sync_its_content_containing_attributes_with_other_replicas() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [JSONTreeElementNode(type: "p",
@@ -1176,21 +1176,21 @@ final class TreeIntegrationStyleTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p italic=\"true\">hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p italic=\"true\">hello</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.style(0, 1, ["bold": "true"])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p bold=\"true\" italic=\"true\">hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p bold=\"true\" italic=\"true\">hello</p></doc>")
@@ -1202,7 +1202,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "doc", children: [
                     JSONTreeElementNode(type: "p",
@@ -1244,7 +1244,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
     @MainActor
     func test_can_sync_its_content_with_remove_style() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [JSONTreeElementNode(type: "p",
@@ -1256,21 +1256,21 @@ final class TreeIntegrationStyleTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p italic=\"true\">hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p italic=\"true\">hello</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.removeStyle(0, 1, ["italic"])
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>hello</p></doc>")
@@ -1280,7 +1280,7 @@ final class TreeIntegrationStyleTests: XCTestCase {
     @MainActor
     func test_should_return_correct_range_path_within_doc_subscribe() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [JSONTreeElementNode(type: "c",
@@ -1298,55 +1298,55 @@ final class TreeIntegrationStyleTests: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 0], [1, 0, 0, 0], JSONTreeTextNode(value: "1"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 1], [1, 0, 0, 1], JSONTreeTextNode(value: "2"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 2], [1, 0, 0, 2], JSONTreeTextNode(value: "3"))
             }
 
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>123</n></p></c></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>123</n></p></c></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 1], [1, 0, 0, 1], JSONTreeTextNode(value: "abcdefgh"))
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1abcdefgh23</n></p></c></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1abcdefgh23</n></p></c></r>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 5], [1, 0, 0, 5], JSONTreeTextNode(value: "4"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 6], [1, 0, 0, 7])
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 6], [1, 0, 0, 6], JSONTreeTextNode(value: "5"))
             }
 
@@ -1358,15 +1358,15 @@ final class TreeIntegrationStyleTests: XCTestCase {
                                 nil,
                                 [TreeEditOpInfoForDebug(from: nil, to: nil, value: nil, fromPath: [1, 0, 0, 7], toPath: [1, 0, 0, 8])])
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([1, 0, 0, 7], [1, 0, 0, 8])
             }
 
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd45gh23</n></p></c></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1abcd45gh23</n></p></c></r>")
@@ -1395,13 +1395,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         // Perform a dummy update to apply changes up to the snapshot threshold.
         let snapshotThreshold = defaultSnapshotThreshold
         for _ in 0 ..< snapshotThreshold {
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.num = Int64(0)
             }
         }
 
         // Start scenario.
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             root.t = JSONTree(initialRoot:
                 JSONTreeElementNode(type: "r",
                                     children: [JSONTreeElementNode(type: "c",
@@ -1419,13 +1419,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c1.sync()
         try await c2.sync()
 
-        var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>")
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 0], [1, 0, 0, 0], JSONTreeTextNode(value: "1"))
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 1], [1, 0, 0, 1], JSONTreeTextNode(value: "2"))
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 2], [1, 0, 0, 2], JSONTreeTextNode(value: "3"))
@@ -1436,13 +1436,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c1.sync()
         try await c2.sync()
 
-        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>12 네이버랑 3</n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>12 네이버랑 3</n></p></c></r>")
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 1], [1, 0, 0, 8], JSONTreeTextNode(value: " 2 네이버랑 "))
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 2], [1, 0, 0, 2], JSONTreeTextNode(value: "ㅋ"))
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 2], [1, 0, 0, 3], JSONTreeTextNode(value: "카"))
@@ -1459,13 +1459,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c2.sync()
         try await c1.sync()
 
-        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버랑 3</n></p></c></r>")
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버랑 3</n></p></c></r>")
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 13], [1, 0, 0, 14])
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 12], [1, 0, 0, 13])
         }
@@ -1473,13 +1473,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c1.sync()
         try await c2.sync()
 
-        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버3</n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버3</n></p></c></r>")
 
-        try await d2.update { root, _ in
+        try d2.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 6], [1, 0, 0, 7])
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 5], [1, 0, 0, 6])
         }
@@ -1487,21 +1487,21 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c2.sync()
         try await c1.sync()
 
-        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이버3</n></p></c></r>")
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이버3</n></p></c></r>")
 
-        try await d1.update { root, _ in
+        try d1.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 9], [1, 0, 0, 10])
         }
 
         try await c1.sync()
         try await c2.sync()
 
-        d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d1XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>")
@@ -1512,13 +1512,13 @@ final class TreeIntegrationStyleTests: XCTestCase {
         let d3 = Document(key: docKey)
         try await c3.attach(d3, [:], .manual)
 
-        var d3XML = await(d3.getRoot().t as? JSONTree)?.toXML()
+        var d3XML = (d3.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d3XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>")
 
         try await c2.sync()
 
-        try await d3.update { root, _ in
+        try d3.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 4], [1, 0, 0, 5])
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 3], [1, 0, 0, 4])
         }
@@ -1526,21 +1526,21 @@ final class TreeIntegrationStyleTests: XCTestCase {
         try await c3.sync()
         try await c2.sync()
 
-        d3XML = await(d3.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d3XML = (d3.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d3XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카2 네이3</n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 카2 네이3</n></p></c></r>")
 
-        try await d3.update { root, _ in
+        try d3.update { root, _ in
             try (root.t as? JSONTree)?.editByPath([1, 0, 0, 2], [1, 0, 0, 3])
         }
 
         try await c3.sync()
         try await c2.sync()
 
-        d3XML = await(d3.getRoot().t as? JSONTree)?.toXML()
-        d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+        d3XML = (d3.getRoot().t as? JSONTree)?.toXML()
+        d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
         XCTAssertEqual(d3XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 2 네이3</n></p></c></r>")
         XCTAssertEqual(d2XML, /* html */ "<r><c><u><p><n></n></p></u></c><c><p><n>1 2 네이3</n></p></c></r>")
@@ -1556,7 +1556,7 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_overlapping_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [JSONTreeElementNode(type: "p"),
@@ -1568,22 +1568,22 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p><i></i><b></b></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p><i></i><b></b></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 4)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 6)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><b></b></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1592,8 +1592,8 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -1603,7 +1603,7 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_overlapping_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1617,22 +1617,22 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>abcd</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>abcd</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 4)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 5)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>d</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>a</p></r>")
@@ -1641,8 +1641,8 @@ final class TreeIntegrationOverlappingRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1654,7 +1654,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_and_delete_contained_elements_of_the_same_depth() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1671,22 +1671,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p><p>abcd</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p><p>abcd</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(6, 6, JSONTreeElementNode(type: "p"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 12)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p><p></p><p>abcd</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -1695,8 +1695,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1706,7 +1706,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_multiple_insert_and_delete_contained_elements_of_the_same_depth() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1723,34 +1723,34 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p><p>abcd</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p><p>abcd</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(6, 6, JSONTreeElementNode(type: "p"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(8, 8, JSONTreeElementNode(type: "p"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(10, 10, JSONTreeElementNode(type: "p"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(12, 12, JSONTreeElementNode(type: "p"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 12)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p><p></p><p></p><p></p><p></p><p>abcd</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -1759,8 +1759,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p><p></p><p></p><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p><p></p><p></p><p></p></r>")
@@ -1770,7 +1770,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_detecting_error_when_inserting_and_deleting_contained_elements_at_different_depths() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1784,22 +1784,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeElementNode(type: "i"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i><i></i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1808,8 +1808,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1819,7 +1819,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_contained_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1835,22 +1835,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i>1234</i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i>1234</i></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 8)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 7)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1859,8 +1859,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -1870,7 +1870,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_and_delete_contained_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1884,22 +1884,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 5)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "a"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12a34</p></r>")
@@ -1908,8 +1908,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>a</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>a</p></r>")
@@ -1919,7 +1919,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_contained_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1933,22 +1933,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 5)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 4)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>14</p></r>")
@@ -1957,8 +1957,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -1968,7 +1968,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_and_delete_contained_text_and_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -1982,22 +1982,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 6)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "a"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12a34</p></r>")
@@ -2006,8 +2006,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -2017,7 +2017,7 @@ final class TreeIntegrationContainedRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_contained_text_and_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2031,22 +2031,22 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 6)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 5)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -2055,8 +2055,8 @@ final class TreeIntegrationContainedRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r></r>")
@@ -2068,7 +2068,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_side_by_side_elements_left() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2080,22 +2080,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "b"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "i"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><b></b><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><i></i><p></p></r>")
@@ -2104,8 +2104,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><i></i><b></b><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><i></i><b></b><p></p></r>")
@@ -2115,7 +2115,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_side_by_side_elements_middle() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2127,22 +2127,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeElementNode(type: "b"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeElementNode(type: "i"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><b></b></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i></p></r>")
@@ -2151,8 +2151,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i></i><b></b></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i><b></b></p></r>")
@@ -2162,7 +2162,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_side_by_side_elements_right() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2174,22 +2174,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeElementNode(type: "b"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeElementNode(type: "i"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p><b></b></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p><i></i></r>")
@@ -2198,8 +2198,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p><i></i><b></b></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p><i></i><b></b></r>")
@@ -2209,7 +2209,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_and_delete_side_by_side_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2223,22 +2223,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><b></b></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><b></b></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeElementNode(type: "i"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i><b></b></p></r>")
@@ -2247,8 +2247,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i></p></r>")
@@ -2258,7 +2258,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_and_insert_side_by_side_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2272,22 +2272,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><b></b></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><b></b></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeElementNode(type: "i"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><b></b><i></i></p></r>")
@@ -2296,8 +2296,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><i></i></p></r>")
@@ -2307,7 +2307,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_side_by_side_elements() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2322,22 +2322,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><b></b><i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><b></b><i></i></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 5)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p><i></i></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p><b></b></p></r>")
@@ -2346,8 +2346,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -2357,7 +2357,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_insert_text_to_the_same_position_left_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2371,22 +2371,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "B"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>A12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>B12</p></r>")
@@ -2395,8 +2395,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>BA12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>BA12</p></r>")
@@ -2406,7 +2406,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_insert_text_to_the_same_position_middle_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2420,22 +2420,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "B"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1A2</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1B2</p></r>")
@@ -2444,8 +2444,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1BA2</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1BA2</p></r>")
@@ -2455,7 +2455,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_insert_text_content_to_the_same_position_right_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2469,22 +2469,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "B"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12A</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12B</p></r>")
@@ -2493,8 +2493,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12BA</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12BA</p></r>")
@@ -2504,7 +2504,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_insert_and_delete_side_by_side_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2518,22 +2518,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "a"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 5)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12a34</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
@@ -2542,8 +2542,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12a</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12a</p></r>")
@@ -2553,7 +2553,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_and_insert_side_by_side_text() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2567,22 +2567,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "a"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12a34</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>34</p></r>")
@@ -2591,8 +2591,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>a34</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>a34</p></r>")
@@ -2602,7 +2602,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_concurrently_delete_side_by_side_text_blocks() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2616,22 +2616,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 5)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>34</p></r>")
@@ -2640,8 +2640,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -2651,7 +2651,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_delete_text_content_at_the_same_position_left_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2665,22 +2665,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>123</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>23</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>23</p></r>")
@@ -2689,8 +2689,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>23</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>23</p></r>")
@@ -2700,7 +2700,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_delete_text_content_at_the_same_position_middle_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2714,22 +2714,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>123</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 3)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>13</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>13</p></r>")
@@ -2738,8 +2738,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>13</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>13</p></r>")
@@ -2749,7 +2749,7 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
     @MainActor
     func test_can_delete_text_content_at_the_same_position_right_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2763,22 +2763,22 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>123</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 4)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 4)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
@@ -2787,8 +2787,8 @@ final class TreeIntegrationSideBySideRange: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
@@ -2800,7 +2800,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_delete_text_content_anchored_to_another_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2814,22 +2814,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>123</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>23</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>13</p></r>")
@@ -2838,8 +2838,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>3</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>3</p></r>")
@@ -2849,7 +2849,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_produce_complete_deletion_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2863,22 +2863,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>123</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 4)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>23</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1</p></r>")
@@ -2887,8 +2887,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -2898,7 +2898,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_block_delete_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2912,22 +2912,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(4, 6)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>123</p></r>")
@@ -2936,8 +2936,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>3</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>3</p></r>")
@@ -2947,7 +2947,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_insert_within_block_delete_concurrently() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -2961,22 +2961,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 5)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "B"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>15</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12B345</p></r>")
@@ -2985,8 +2985,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1B5</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1B5</p></r>")
@@ -2996,7 +2996,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_insert_within_block_delete_concurrently_2() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3010,22 +3010,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 6)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editBulk(3, 3, [JSONTreeTextNode(value: "a"), JSONTreeTextNode(value: "bc")])
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12abc345</p></r>")
@@ -3034,8 +3034,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1abc</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1abc</p></r>")
@@ -3045,7 +3045,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_block_element_insertion_within_delete_2() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3062,25 +3062,25 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1234</p><p>5678</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p><p>5678</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 12)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editBulk(6, 6, [
                     JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")]),
                     JSONTreeElementNode(type: "i", children: [JSONTreeTextNode(value: "fg")])
                 ])
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>1234</p><p>cd</p><i>fg</i><p>5678</p></r>")
@@ -3089,8 +3089,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
@@ -3100,7 +3100,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_concurrent_element_insert_deletion_left() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3114,25 +3114,25 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 7)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editBulk(0, 0, [
                     JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")]),
                     JSONTreeElementNode(type: "i", children: [JSONTreeTextNode(value: "fg")])
                 ])
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>cd</p><i>fg</i><p>12345</p></r>")
@@ -3141,8 +3141,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
@@ -3152,7 +3152,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_concurrent_element_insert_deletion_right() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3166,25 +3166,25 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12345</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 7)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editBulk(7, 7, [
                     JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")]),
                     JSONTreeElementNode(type: "i", children: [JSONTreeTextNode(value: "fg")])
                 ])
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12345</p><p>cd</p><i>fg</i></r>")
@@ -3193,8 +3193,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>cd</p><i>fg</i></r>")
@@ -3204,7 +3204,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_deletion_of_insertion_anchor_concurreltly() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3218,22 +3218,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>1A2</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>2</p></r>")
@@ -3242,8 +3242,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>A2</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>A2</p></r>")
@@ -3253,7 +3253,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_deletion_after_insertion_concurreltly() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3267,22 +3267,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>A12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -3291,8 +3291,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>A</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>A</p></r>")
@@ -3302,7 +3302,7 @@ final class TreeIntegrationComplexCases: XCTestCase {
     @MainActor
     func test_can_handle_deletion_before_insertion_concurreltly() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3316,22 +3316,22 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>12</p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "A"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>12A</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
@@ -3340,8 +3340,8 @@ final class TreeIntegrationComplexCases: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<r><p>A</p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p>A</p></r>")
@@ -3355,7 +3355,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             root.t = JSONTree()
 
             try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "abcdefghi")]))
@@ -3392,7 +3392,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
         let docKey = "\(self.description)-\(Date().description)".toDocKey
         let doc = Document(key: docKey)
 
-        try await doc.update { root, _ in
+        try doc.update { root, _ in
             // 01. Create a tree and insert a paragraph.
             root.t = JSONTree()
 
@@ -3425,7 +3425,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_split_link_can_transmitted_through_rpc() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3436,43 +3436,43 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "1"))
             }
 
             try await c1.sync()
             try await c2.sync()
 
-            let d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            let d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, /* html */ "<doc><p>a1b</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>a1b</p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "1"))
             }
 
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>a11b</p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 3, JSONTreeTextNode(value: "12"))
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(4, 5, JSONTreeTextNode(value: "21"))
             }
 
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>a1221b</p></doc>")
 
             // if split link is not transmitted, then left sibling in from index below, is "b" not "a"
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 4, JSONTreeTextNode(value: "123"))
             }
 
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>a12321b</p></doc>")
         }
     }
@@ -3480,7 +3480,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_calculate_size_of_index_tree_correctly() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3491,30 +3491,30 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "123"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "456"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "789"))
             }
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "0123"))
             }
 
-            let d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            let d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>a0123789456123b</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            let sized1 = try await(d1.getRoot().t as? JSONTree)?.getIndexTree().root.size
-            let sized2 = try await(d2.getRoot().t as? JSONTree)?.getIndexTree().root.size
+            let sized1 = try (d1.getRoot().t as? JSONTree)?.getIndexTree().root.size
+            let sized2 = try (d2.getRoot().t as? JSONTree)?.getIndexTree().root.size
 
             XCTAssertEqual(sized1, sized2)
         }
@@ -3523,7 +3523,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_calculate_size_of_index_tree_correctly_during_concurrent_editing() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3537,42 +3537,42 @@ final class TreeIntegrationEdgeCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc><p>hello</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 7)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2, JSONTreeTextNode(value: "p"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc></doc>")
 
-            var sized1 = try await(d1.getRoot().t as? JSONTree)?.getSize()
+            var sized1 = try (d1.getRoot().t as? JSONTree)?.getSize()
             XCTAssertEqual(0, sized1)
 
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>pello</p></doc>")
 
-            var sized2 = try await(d2.getRoot().t as? JSONTree)?.getSize()
+            var sized2 = try (d2.getRoot().t as? JSONTree)?.getSize()
             XCTAssertEqual(7, sized2)
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc></doc>")
             XCTAssertEqual(d2XML, /* html */ "<doc></doc>")
 
-            sized1 = try await(d1.getRoot().t as? JSONTree)?.getSize()
-            sized2 = try await(d2.getRoot().t as? JSONTree)?.getSize()
+            sized1 = try (d1.getRoot().t as? JSONTree)?.getSize()
+            sized2 = try (d2.getRoot().t as? JSONTree)?.getSize()
             XCTAssertEqual(sized1, sized2)
         }
     }
@@ -3580,7 +3580,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_keep_index_tree_consistent_from_snapshot() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "r",
                                         children: [
@@ -3592,50 +3592,50 @@ final class TreeIntegrationEdgeCases: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<r><p></p></r>")
             XCTAssertEqual(d2XML, /* html */ "<r><p></p></r>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 2)
             }
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, JSONTreeElementNode(type: "i", children: [JSONTreeTextNode(value: "a")]))
                 try (root.t as? JSONTree)?.edit(2, 3, JSONTreeTextNode(value: "b"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
-            let sized1 = try await(d1.getRoot().t as? JSONTree)?.getSize()
+            let sized1 = try (d1.getRoot().t as? JSONTree)?.getSize()
             XCTAssertEqual(0, sized1)
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<r><p><i>b</i></p></r>")
-            let sized2 = try await(d2.getRoot().t as? JSONTree)?.getSize()
+            let sized2 = try (d2.getRoot().t as? JSONTree)?.getSize()
             XCTAssertEqual(5, sized2)
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<r></r>")
 
             var d1Nodes = [(String, Int, Bool)]()
             var d2Nodes = [(String, Int, Bool)]()
             var sNodes = [(String, Int, Bool)]()
 
-            try await(d1.getRoot().t as? JSONTree)?.getIndexTree().traverseAll { node, _ in
+            try (d1.getRoot().t as? JSONTree)?.getIndexTree().traverseAll { node, _ in
                 d1Nodes.append((node.toJSONString, node.size, node.isRemoved))
             }
-            try await(d2.getRoot().t as? JSONTree)?.getIndexTree().traverseAll { node, _ in
+            try (d2.getRoot().t as? JSONTree)?.getIndexTree().traverseAll { node, _ in
                 d2Nodes.append((node.toJSONString, node.size, node.isRemoved))
             }
 
-            let sRoot = try await Converter.bytesToObject(bytes: Converter.objectToBytes(obj: d1.getRootObject()))
+            let sRoot = try Converter.bytesToObject(bytes: Converter.objectToBytes(obj: d1.getRootObject()))
 
             (sRoot.get(key: "t") as? CRDTTree)?.indexTree.traverseAll { node, _ in
                 sNodes.append((node.toJSONString, node.size, node.isRemoved))
@@ -3662,7 +3662,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_split_and_merge_with_empty_paragraph_left() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3674,28 +3674,28 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 1, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p></p><p>ab</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3704,7 +3704,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_split_and_merge_with_empty_paragraph_right() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3716,28 +3716,28 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p><p></p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 5)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3746,7 +3746,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_split_and_merge_with_empty_paragraph_and_multiple_split_level_left() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3760,28 +3760,28 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p><p>ab</p></p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, nil, 2)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p><p></p></p><p><p>ab</p></p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 6)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p><p>ab</p></p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3790,7 +3790,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_split_at_the_same_offset_multiple_times() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3802,42 +3802,42 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>a</p><p>b</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "c"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ac</p><p>b</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>a</p><p>c</p><p>b</p></doc>")
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 7)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3846,7 +3846,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_concurrently_split_and_insert_into_original_node() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3860,32 +3860,32 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>abcd</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p><p>cd</p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "e"))
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>aebcd</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3894,7 +3894,7 @@ final class TreeIntegrationEdgeCases: XCTestCase {
     @MainActor
     func test_can_concurrently_split_and_insert_into_split_node() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3908,32 +3908,32 @@ final class TreeIntegrationEdgeCases: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>abcd</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p><p>cd</p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "e"))
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>aebcd</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
 
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -3944,7 +3944,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_delete_and_delete() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -3955,7 +3955,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
@@ -3967,26 +3967,26 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                 [TreeEditOpInfoForDebug(from: 1, to: 2, value: nil, fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 0, to: 3, value: nil, fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 4)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>b</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }
@@ -3994,7 +3994,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_delete_and_insert() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4005,7 +4005,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
@@ -4018,26 +4018,26 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                 [TreeEditOpInfoForDebug(from: 2, to: 2, value: [JSONTreeTextNode(value: "c")], fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 3, to: 4, value: [], fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 1, to: 2, value: [], fromPath: nil, toPath: nil)])
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 3)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p></p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "c"))
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>acb</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }
@@ -4045,7 +4045,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_delete_and_insert_when_parent_removed() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4056,7 +4056,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab</p></doc>")
 
             try await c1.sync()
@@ -4068,26 +4068,26 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                 [TreeEditOpInfoForDebug(from: 2, to: 2, value: [JSONTreeTextNode(value: "c")], fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 0, to: 5, value: [], fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 4)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "c"))
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>acb</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }
@@ -4095,7 +4095,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_delete_with_contents_and_insert() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4106,7 +4106,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>a</p></doc>")
 
             try await c1.sync()
@@ -4119,26 +4119,26 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                 [TreeEditOpInfoForDebug(from: 2, to: 2, value: [JSONTreeTextNode(value: "c")], fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 1, to: 2, value: [JSONTreeTextNode(value: "b")], fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2, JSONTreeTextNode(value: "b"))
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>b</p></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "c"))
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>ac</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }
@@ -4146,7 +4146,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_insert_and_style() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4158,8 +4158,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p></p></doc>")
             XCTAssertEqual(d1XML, d2XML)
 
@@ -4172,13 +4172,13 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                  TreeStyleOpInfoForDebug(from: 2, to: 3, value: .attributes(["key": "a"]), fromPath: [1], toPath: [1, 0]),
                                  TreeStyleOpInfoForDebug(from: 2, to: 3, value: .attributes(["key": "a"]), fromPath: [1], toPath: [1, 0])])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.style(0, 1, ["key": "a"])
             }
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.style(0, 1, ["key": "a"])
             }
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "p"))
             }
 
@@ -4186,8 +4186,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p></p><p key=\"a\"></p></doc>")
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -4196,7 +4196,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_insert_and_removeStyle() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4208,8 +4208,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p key=\"a\"></p></doc>")
             XCTAssertEqual(d1XML, d2XML)
 
@@ -4222,13 +4222,13 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                  TreeStyleOpInfoForDebug(from: 2, to: 3, value: .attributesToRemove(["key"]), fromPath: [1], toPath: [1, 0]),
                                  TreeStyleOpInfoForDebug(from: 2, to: 3, value: .attributesToRemove(["key"]), fromPath: [1], toPath: [1, 0])])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.removeStyle(0, 1, ["key"])
             }
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.removeStyle(0, 1, ["key"])
             }
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 0, JSONTreeElementNode(type: "p"))
             }
 
@@ -4236,8 +4236,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p></p><p></p></doc>")
             XCTAssertEqual(d1XML, d2XML)
         }
@@ -4246,7 +4246,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_delete_and_style() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: DefaultTreeNodeType.root.rawValue,
                                         children: [
@@ -4256,7 +4256,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<root><t id=\"1\" value=\"init\"></t><t id=\"2\" value=\"init\"></t></root>")
 
             try await c1.sync()
@@ -4268,10 +4268,10 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                  TreeEditOpInfoForDebug(from: 0, to: 2, value: nil, fromPath: nil, toPath: nil)],
                                 [TreeEditOpInfoForDebug(from: 0, to: 2, value: nil, fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.styleByPath([0], ["value": "changed"])
             }
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.editByPath([0], [1])
             }
 
@@ -4279,10 +4279,10 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<root><t id=\"2\" value=\"init\"></t></root>")
 
-            let d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            let d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }
@@ -4290,7 +4290,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_concurrent_style_and_style() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4305,8 +4305,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c1.sync()
             try await c2.sync()
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
             XCTAssertEqual(d1XML, /* html */ "<doc><p>hello</p></doc>")
 
@@ -4316,10 +4316,10 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                  TreeStyleOpInfoForDebug(from: 0, to: 1, value: .attributes(["bold": "false"]), fromPath: nil, toPath: nil)],
                                 [TreeStyleOpInfoForDebug(from: 0, to: 1, value: .attributes(["bold": "false"]), fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.style(0, 1, ["bold": "true"])
             }
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.style(0, 1, ["bold": "false"])
             }
 
@@ -4327,8 +4327,8 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
             XCTAssertEqual(d1XML, /* html */ "<doc><p bold=\"false\">hello</p></doc>")
         }
@@ -4337,7 +4337,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
     @MainActor
     func test_emoji() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 root.t = JSONTree(initialRoot:
                     JSONTreeElementNode(type: "doc",
                                         children: [
@@ -4348,7 +4348,7 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                 )
             }
 
-            var d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            var d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc><p>ab🇱🇰</p></doc>")
 
             try await c1.sync()
@@ -4360,26 +4360,26 @@ final class TreeIntegrationTreeChangeGeneration: XCTestCase {
                                 [TreeEditOpInfoForDebug(from: 1, to: 2, value: nil, fromPath: nil, toPath: nil),
                                  TreeEditOpInfoForDebug(from: 0, to: 7, value: nil, fromPath: nil, toPath: nil)])
 
-            try await d1.update { root, _ in
+            try d1.update { root, _ in
                 try (root.t as? JSONTree)?.edit(0, 8)
             }
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, /* html */ "<doc></doc>")
 
-            try await d2.update { root, _ in
+            try d2.update { root, _ in
                 try (root.t as? JSONTree)?.edit(1, 2)
             }
 
-            var d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            var d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d2XML, /* html */ "<doc><p>b🇱🇰</p></doc>")
 
             try await c1.sync()
             try await c2.sync()
             try await c1.sync()
 
-            d1XML = await(d1.getRoot().t as? JSONTree)?.toXML()
-            d2XML = await(d2.getRoot().t as? JSONTree)?.toXML()
+            d1XML = (d1.getRoot().t as? JSONTree)?.toXML()
+            d2XML = (d2.getRoot().t as? JSONTree)?.toXML()
             XCTAssertEqual(d1XML, d2XML)
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs yorkie-ios-sdk with **yorkie-js-sdk v0.6.39** and resolves the build warnings that followed.

- Regenerate protobuf/API (Revision RPCs + `ChannelSummary`/`RevisionSummary`; additive, wire-compatible) and bump the CI yorkie-server pin to v0.6.39.
- Build-warning cleanup (no behaviour change): drop spurious `await` on APIs that became synchronous (1348 call sites across the integration suite + the `TextViewModel` example); `_ = try?` for the discarded `insert` result in `CRDTArray.deepcopy`; remove a dead `var vector` clone in `ChangeID.setClocks`; drop a no-op `@discardableResult` on `JSONArray.moveAfterByIndex`; `var` → `let` for never-mutated iterators in `TextIntegrationTests`.
- Add `CHANGELOG.md` (reconstructed from all 43 GitHub Releases, v0.2.19 → v0.6.37) and a `v0.6.39` entry for this PR.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Two pre-existing warnings are intentionally left:
- A deprecated `_NameMap` initializer in *generated* `googleapis` protobuf code — the correct fix is regeneration with the current SwiftProtobuf plugin, not a hand-edit.
- 3 `@Sendable` capture warnings in `TreeConcurrencyTests` — these need a deliberate concurrency change, not a mechanical silence.

Verification: `swift build` / `swift build --build-tests` clean; `swift test --skip YorkieIntegrationTests --skip YorkieBenchmarkTests` → 316 unit tests pass, 0 failures. SwiftFormat 0.55.6 + SwiftLint 0.58.2 (CI-pinned) lint clean.

**Does this PR introduce a user-facing change?**:

\`\`\`release-note
Sync with yorkie-js-sdk 0.6.39.
\`\`\`

**Additional documentation**:

\`\`\`docs
- Added CHANGELOG.md (reconstructed from GitHub Releases)
\`\`\`

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything