### PR TITLE
Apply updates from yorkie-js-sdk 0.6.42

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.41
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ccade7bf5a3732bb6861c3d603ee31cdeca38f53/Formula/y/yorkie.rb"
+      # yorkie server v0.6.42
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/679444629e6dddd28a78b0a9e345c489b79c875d/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.41
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ccade7bf5a3732bb6861c3d603ee31cdeca38f53/Formula/y/yorkie.rb"
+      # yorkie server v0.6.42
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/679444629e6dddd28a78b0a9e345c489b79c875d/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.6.42] - 2026-06-10
+
+- Rename presence_count to session_count in https://github.com/yorkie-team/yorkie-ios-sdk/pull/246
+
 ## [v0.6.41] - 2026-06-04
 
 - Implement YSON module with parser and types in https://github.com/yorkie-team/yorkie-ios-sdk/pull/244

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [Getting Started with iOS SDK](https://yorkie.dev/docs/getting-started/with-
 
 Example projects can be found in the [examples](https://github.com/yorkie-team/yorkie-ios-sdk/tree/main/Examples) folder.
 
-Read the [full documentation](https://yorkie.dev/docs) for all details.
+Read the [full documentation](https://yorkie.dev/docs/sdks/ios-sdk) for all details.
 
 ## Testing yorkie-ios-sdk with Envoy, Yorkie and MongoDB.
 

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -2192,7 +2192,7 @@ public struct Yorkie_V1_ChannelSummary: Sendable {
 
   public var key: String = String()
 
-  public var presenceCount: Int32 = 0
+  public var sessionCount: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -5584,7 +5584,7 @@ extension Yorkie_V1_Presence: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
 extension Yorkie_V1_ChannelSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ChannelSummary"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{3}presence_count\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{3}session_count\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5593,7 +5593,7 @@ extension Yorkie_V1_ChannelSummary: SwiftProtobuf.Message, SwiftProtobuf._Messag
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.key) }()
-      case 2: try { try decoder.decodeSingularInt32Field(value: &self.presenceCount) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.sessionCount) }()
       default: break
       }
     }
@@ -5603,15 +5603,15 @@ extension Yorkie_V1_ChannelSummary: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if !self.key.isEmpty {
       try visitor.visitSingularStringField(value: self.key, fieldNumber: 1)
     }
-    if self.presenceCount != 0 {
-      try visitor.visitSingularInt32Field(value: self.presenceCount, fieldNumber: 2)
+    if self.sessionCount != 0 {
+      try visitor.visitSingularInt32Field(value: self.sessionCount, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Yorkie_V1_ChannelSummary, rhs: Yorkie_V1_ChannelSummary) -> Bool {
     if lhs.key != rhs.key {return false}
-    if lhs.presenceCount != rhs.presenceCount {return false}
+    if lhs.sessionCount != rhs.sessionCount {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -382,7 +382,7 @@ message Presence {
 
 message ChannelSummary {
   string key = 1;
-  int32 presence_count = 2;
+  int32 session_count = 2;
 }
 
 message Checkpoint {

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.6.36"
+let yorkieVersion = "0.6.42"

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.41'
+    image: 'yorkieteam/yorkie:0.6.42'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.41'
+    image: 'yorkieteam/yorkie:0.6.42'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk v0.6.42 to keep the iOS SDK in sync.

- Rename the `ChannelSummary` protobuf field `presence_count` → `session_count` (field number 2, `int32` unchanged — binary wire-compatible), mirroring yorkie-js-sdk#1142. Regenerated `resources.pb.swift` via `buf generate` with the pinned plugins.
- Bump `Sources/Version.swift` to `0.6.42` to match the release tag (per `MAINTAINING.md`).
- Bump the CI yorkie-server pin and docker-compose image tags to `0.6.42`.
- Point the README "full documentation" link at the current docs URL (`https://yorkie.dev/docs/sdks/ios-sdk`).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- The proto change is a field **rename only** — field number and type are unchanged, so it is binary-wire-compatible with the server and other clients. The generated `ChannelSummary` type has no consumers in the SDK (the hand-written `Channel.sessionCount` is fed from a separate field), so there is no behavioural change.
- Gates: critic review (clean), `swift build`, and unit tests all green locally. Integration tests run on CI against the pinned `0.6.42` server.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK version to v0.6.42
  * Updated Yorkie server dependency to v0.6.42
  * Updated CI and deployment configurations

* **Refactor**
  * Renamed API field `presence_count` to `session_count`

* **Documentation**
  * Enhanced iOS SDK documentation link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->