### PR TITLE
Apply updates from yorkie-js-sdk 0.6.44

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.43
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b5771433abfd0140e5b4f91e4bd630d75e0c8c85/Formula/y/yorkie.rb"
+      # yorkie server v0.6.44
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/fc1e731facb3a75bba1eb2e067720bc3881ac75a/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.43
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/b5771433abfd0140e5b4f91e4bd630d75e0c8c85/Formula/y/yorkie.rb"
+      # yorkie server v0.6.44
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/fc1e731facb3a75bba1eb2e067720bc3881ac75a/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.6.44] - 2026-06-11
+
+- Fix SplayTree Find semantics for CRDT Array in https://github.com/yorkie-team/yorkie-ios-sdk/pull/248
+
 ## [v0.6.43] - 2026-06-10
 
 - Refactor room management with categories in https://github.com/yorkie-team/yorkie-ios-sdk/pull/247

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -318,31 +318,13 @@ class RGATreeList {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        let (node, offset) = try self.nodeMapByIndex.find(index)
+        let node = try self.nodeMapByIndex.findForArray(index)
         guard let rgaNode = node as? RGATreeListNode else {
             let log = "failed to find the given index: \(index)"
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        guard (index == 0 && rgaNode === self.dummyHead) || offset >= 1 else {
-            return rgaNode
-        }
-
-        var nextRgaNode: RGATreeListNode? = rgaNode
-        repeat {
-            if nextRgaNode == nil {
-                break
-            }
-            nextRgaNode = nextRgaNode?.next
-
-        } while nextRgaNode?.isRemoved == true
-
-        guard let nextRgaNode else {
-            let log = "failed to find the given index: \(index)"
-            throw YorkieError(code: .errUnexpected, message: log)
-        }
-
-        return nextRgaNode
+        return rgaNode
     }
 
     /**

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -594,7 +594,7 @@ class RGATreeSplit<T: RGATreeSplitValue> {
      * `findNodePos` finds RGATreeSplitNodePos of given offset.
      */
     func indexToPos(_ idx: Int) throws -> RGATreeSplitPos {
-        let (node, offset) = try self.treeByIndex.find(idx)
+        let (node, offset) = try self.treeByIndex.findForText(idx)
         guard let splitNode = node as? RGATreeSplitNode<T> else {
             throw YorkieError(code: .errInvalidArgument, message: "no element for index \(idx)")
         }

--- a/Sources/Util/SplayTree.swift
+++ b/Sources/Util/SplayTree.swift
@@ -138,9 +138,10 @@ class SplayTree<V> {
     }
 
     /**
-     * `find` returns the Node and offset of the given index.
+     * `findForText` returns the Node and offset of the given position (cursor).
+     * Used for Text where cursor placed between characters.
      */
-    func find(_ position: Int) throws -> (node: SplayNode<V>?, offset: Int) {
+    func findForText(_ position: Int) throws -> (node: SplayNode<V>?, offset: Int) {
         guard let root = self.root, position >= 0 else {
             return (nil, 0)
         }
@@ -166,6 +167,38 @@ class SplayTree<V> {
         self.splayNode(node)
 
         return (node, offset)
+    }
+
+    /**
+     * `findForArray` returns the Node of the given position (index).
+     * Used for Array where index points to the element.
+     */
+    func findForArray(_ index: Int) throws -> SplayNode<V>? {
+        guard let root = self.root else {
+            return nil
+        }
+
+        if index < 0 || index >= self.length {
+            let message = "out of index range: idx: \(index), length: \(self.length)"
+            throw YorkieError(code: .errInvalidArgument, message: message)
+        }
+
+        var idx = index
+        var node = root
+        while true {
+            if let left = node.left, idx < node.leftWeight {
+                node = left
+            } else if node.hasRight, node.leftWeight + node.length <= idx {
+                idx -= node.leftWeight + node.length
+                node = node.right!
+            } else {
+                break
+            }
+        }
+
+        self.splayNode(node)
+
+        return node
     }
 
     /**

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.6.43"
+let yorkieVersion = "0.6.44"

--- a/Tests/Benchmark/SplayTreeBenchmarkTests.swift
+++ b/Tests/Benchmark/SplayTreeBenchmarkTests.swift
@@ -49,7 +49,7 @@ final class SplayTreeBenchmarkTests: XCTestCase {
             tree.insert(StringNode("A"))
         }
         for index in 0 ..< 1000 {
-            _ = try tree.find(self.randomValue(zeroUpTo: index))
+            _ = try tree.findForText(self.randomValue(zeroUpTo: index))
         }
     }
 
@@ -60,16 +60,16 @@ final class SplayTreeBenchmarkTests: XCTestCase {
         for _ in 0 ..< size {
             let op = Int.random(in: 0 ..< 3)
             if op == 0 {
-                if let node = try tree.find(Int.random(in: 0 ..< treeSize)).node {
+                if let node = try tree.findForText(Int.random(in: 0 ..< treeSize)).node {
                     tree.insert(previousNode: node, newNode: StringNode("A"))
                 } else {
                     tree.insert(StringNode("A"))
                 }
                 treeSize += 1
             } else if op == 1 {
-                _ = try tree.find(Int.random(in: 0 ..< treeSize))
+                _ = try tree.findForText(Int.random(in: 0 ..< treeSize))
             } else {
-                if let node = try tree.find(Int.random(in: 0 ..< treeSize)).node {
+                if let node = try tree.findForText(Int.random(in: 0 ..< treeSize)).node {
                     tree.delete(node)
                     treeSize -= 1
                 }
@@ -131,11 +131,11 @@ final class SplayTreeBenchmarkTests: XCTestCase {
 
                 switch operation {
                 case 0:
-                    if let value = edit[2] as? String, let node = try? tree.find(position).node {
+                    if let value = edit[2] as? String, let node = try? tree.findForText(position).node {
                         tree.insert(previousNode: node, newNode: StringNode(value))
                     }
                 case 1:
-                    if let nodeToDelete = try? tree.find(position).node {
+                    if let nodeToDelete = try? tree.findForText(position).node {
                         tree.delete(nodeToDelete)
                     }
                 default:

--- a/Tests/Unit/Util/SplayTreeTests.swift
+++ b/Tests/Unit/Util/SplayTreeTests.swift
@@ -35,8 +35,26 @@ private class StringNode: SplayNode<String> {
     }
 }
 
+private class ElementNode: SplayNode<Int> {
+    var removed: Bool = false
+    override init(_ value: Int) {
+        super.init(value)
+    }
+
+    static func create(_ value: Int) -> ElementNode {
+        return ElementNode(value)
+    }
+
+    override var length: Int {
+        if self.removed {
+            return 0
+        }
+        return 1
+    }
+}
+
 class SplayTreeTests: XCTestCase {
-    func test_can_insert_values_and_splay_them() throws {
+    func test_can_insert_text_values_and_splay_them() throws {
         let tree = SplayTree<String>()
 
         let nodeA = tree.insert(StringNode.create("A2"))
@@ -57,37 +75,70 @@ class SplayTreeTests: XCTestCase {
         XCTAssertEqual(tree.indexOf(nodeC), 5)
         XCTAssertEqual(tree.indexOf(nodeD), 9)
 
-        var result = try tree.find(-1)
+        var result = try tree.findForText(-1)
         XCTAssertNil(result.node)
         XCTAssertEqual(result.offset, 0)
 
-        result = try tree.find(0)
+        result = try tree.findForText(0)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 0)
 
-        result = try tree.find(1)
+        result = try tree.findForText(1)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 1)
 
-        result = try tree.find(2)
+        result = try tree.findForText(2)
         XCTAssertEqual(result.node?.value, "A2")
         XCTAssertEqual(result.offset, 2)
 
-        result = try tree.find(3)
+        result = try tree.findForText(3)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 1)
 
-        result = try tree.find(4)
+        result = try tree.findForText(4)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 2)
 
-        result = try tree.find(5)
+        result = try tree.findForText(5)
         XCTAssertEqual(result.node?.value, "B23")
         XCTAssertEqual(result.offset, 3)
 
-        result = try tree.find(6)
+        result = try tree.findForText(6)
         XCTAssertEqual(result.node?.value, "C234")
         XCTAssertEqual(result.offset, 1)
+    }
+
+    func test_can_insert_delete_array_values_and_splay_them() throws {
+        let tree = SplayTree<Int>()
+
+        var node = try tree.findForArray(0)
+        XCTAssertNil(node)
+
+        let nodeA = tree.insert(ElementNode.create(2))
+        XCTAssertEqual(tree.toTestString, "[1,1]2")
+        let nodeB = ElementNode.create(3)
+        tree.insert(nodeB)
+        XCTAssertEqual(tree.toTestString, "[1,1]2[2,1]3")
+        let nodeC = tree.insert(ElementNode.create(4))
+        XCTAssertEqual(tree.toTestString, "[1,1]2[2,1]3[3,1]4")
+        let nodeD = tree.insert(ElementNode.create(5))
+        XCTAssertEqual(tree.toTestString, "[1,1]2[2,1]3[3,1]4[4,1]5")
+
+        nodeB.removed = true
+        tree.splayNode(nodeB)
+        XCTAssertEqual(tree.toTestString, "[1,1]2[3,0]3[2,1]4[1,1]5")
+        XCTAssertEqual(tree.indexOf(nodeA), 0)
+        XCTAssertEqual(tree.indexOf(nodeC), 1)
+        XCTAssertEqual(tree.indexOf(nodeD), 2)
+
+        node = try tree.findForArray(0)
+        XCTAssertTrue(node === nodeA)
+        node = try tree.findForArray(1)
+        XCTAssertTrue(node === nodeC)
+        node = try tree.findForArray(2)
+        XCTAssertTrue(node === nodeD)
+
+        XCTAssertThrowsError(try tree.findForArray(3))
     }
 
     func test_can_delete_the_given_node() {
@@ -195,7 +246,7 @@ class SplayTreeTests: XCTestCase {
         tree.splayNode(nodeB)
         XCTAssertEqual(tree.toTestString, "[2,2]A2[14,3]B23[9,4]C234[5,5]D2345")
 
-        let (node, _) = try tree.find(6)
+        let (node, _) = try tree.findForText(6)
         XCTAssertEqual(node?.value, "C234")
     }
 

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.43'
+    image: 'yorkieteam/yorkie:0.6.44'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.43'
+    image: 'yorkieteam/yorkie:0.6.44'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk v0.6.44.

Upstream v0.6.44 is a single change — "Fix SplayTree Find semantics for CRDT Array" (yorkie-js-sdk#1150). The iOS port mirrors it:

- `SplayTree.find(_:)` is renamed to `findForText(_:)` (cursor-between-characters semantics for Text); body unchanged.
- A new `SplayTree.findForArray(_:)` returns the element node at an array index directly, throwing on an out-of-range index.
- `RGATreeSplit.indexToPos(_:)` now calls `findForText(_:)`.
- `RGATreeList.getNode(index:)` now calls `findForArray(_:)`, dropping the former offset-based skip-removed-nodes loop (removed nodes carry length 0, so `findForArray` lands on the right element directly).

Also bumps `yorkieVersion` to `0.6.44` and the CI yorkie-server pin to v0.6.44.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:

- Test parity with upstream: renamed `test_can_insert_text_values_and_splay_them`, added `test_can_insert_delete_array_values_and_splay_them` (mirrors the JS `Can insert, delete array values and splay them` test, including the post-splay `[1,1]2[3,0]3[2,1]4[1,1]5` state and the out-of-range throw). `find`→`findForText` also renamed in the SplayTree benchmark.
- Gates green: critic review approved (behavioural parity with v0.6.44 verified), SwiftFormat 0.55.6 clean, SwiftLint 0.58.2 `--strict` 0 violations, `swift build` + 358 unit tests pass.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation**:
```docs
- CHANGELOG.md updated with the v0.6.44 entry.
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array indexing behavior in core data structures to ensure accurate element access.

* **Chores**
  * Updated Yorkie server dependency to v0.6.44 in CI/CD pipelines and Docker configurations.
  * Bumped SDK version to 0.6.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->