### PR TITLE
Apply updates from yorkie-js-sdk 0.6.49

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.48
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/89b3cc187b08bf2812999dbb45292835dd0f7e3c/Formula/y/yorkie.rb"
+      # yorkie server v0.6.49
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/56a671cb1278d36c5b7a0401214708d98d489903/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.48
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/89b3cc187b08bf2812999dbb45292835dd0f7e3c/Formula/y/yorkie.rb"
+      # yorkie server v0.6.49
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/56a671cb1278d36c5b7a0401214708d98d489903/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.6.49] - 2026-06-12
+
+- Add undo/redo support for Text.Style operations in https://github.com/yorkie-team/yorkie-ios-sdk/pull/251
+- Return unwrapped primitive values from Array iterator in https://github.com/yorkie-team/yorkie-ios-sdk/pull/251
+
 ## [v0.6.48] - 2026-06-12
 
 - Replace WatchDocument and WatchChannel with unified Watch RPC in https://github.com/yorkie-team/yorkie-ios-sdk/pull/250

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -461,6 +461,7 @@ extension Converter {
             styleOperation.attributes.forEach {
                 pbStyleOperation.attributes[$0.key] = $0.value
             }
+            pbStyleOperation.attributesToRemove = styleOperation.attributesToRemove
             pbStyleOperation.executedAt = toTimeTicket(styleOperation.executedAt)
             pbOperation.style = pbStyleOperation
         } else if let increaseOperation = operation as? IncreaseOperation {
@@ -547,6 +548,7 @@ extension Converter {
                                       fromPos: fromTextNodePos(pbStyleOperation.from),
                                       toPos: fromTextNodePos(pbStyleOperation.to),
                                       attributes: pbStyleOperation.attributes,
+                                      attributesToRemove: pbStyleOperation.attributesToRemove,
                                       executedAt: fromTimeTicket(pbStyleOperation.executedAt))
             } else if case let .increase(pbIncreaseOperation) = pbOperation.body {
                 return IncreaseOperation(parentCreatedAt: fromTimeTicket(pbIncreaseOperation.parentCreatedAt),

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -721,6 +721,11 @@ public struct Yorkie_V1_Operation: Sendable {
       set {_uniqueStorage()._createdAtMapByActor = newValue}
     }
 
+    public var attributesToRemove: [String] {
+      get {_storage._attributesToRemove}
+      set {_uniqueStorage()._attributesToRemove = newValue}
+    }
+
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     public init() {}
@@ -3343,7 +3348,7 @@ extension Yorkie_V1_Operation.Edit: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Yorkie_V1_Operation.protoMessageName + ".Style"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{1}attributes\0\u{3}executed_at\0\u{3}created_at_map_by_actor\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{1}attributes\0\u{3}executed_at\0\u{3}created_at_map_by_actor\0\u{3}attributes_to_remove\0")
 
   fileprivate class _StorageClass {
     var _parentCreatedAt: Yorkie_V1_TimeTicket? = nil
@@ -3352,6 +3357,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _attributes: Dictionary<String,String> = [:]
     var _executedAt: Yorkie_V1_TimeTicket? = nil
     var _createdAtMapByActor: Dictionary<String,Yorkie_V1_TimeTicket> = [:]
+    var _attributesToRemove: [String] = []
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -3368,6 +3374,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
       _attributes = source._attributes
       _executedAt = source._executedAt
       _createdAtMapByActor = source._createdAtMapByActor
+      _attributesToRemove = source._attributesToRemove
     }
   }
 
@@ -3392,6 +3399,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 4: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._attributes) }()
         case 5: try { try decoder.decodeSingularMessageField(value: &_storage._executedAt) }()
         case 6: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_TimeTicket>.self, value: &_storage._createdAtMapByActor) }()
+        case 7: try { try decoder.decodeRepeatedStringField(value: &_storage._attributesToRemove) }()
         default: break
         }
       }
@@ -3422,6 +3430,9 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
       if !_storage._createdAtMapByActor.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_TimeTicket>.self, value: _storage._createdAtMapByActor, fieldNumber: 6)
       }
+      if !_storage._attributesToRemove.isEmpty {
+        try visitor.visitRepeatedStringField(value: _storage._attributesToRemove, fieldNumber: 7)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3437,6 +3448,7 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if _storage._attributes != rhs_storage._attributes {return false}
         if _storage._executedAt != rhs_storage._executedAt {return false}
         if _storage._createdAtMapByActor != rhs_storage._createdAtMapByActor {return false}
+        if _storage._attributesToRemove != rhs_storage._attributesToRemove {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -108,6 +108,7 @@ message Operation {
     map<string, string> attributes = 4;
     TimeTicket executed_at = 5;
     map<string, TimeTicket> created_at_map_by_actor = 6; // deprecated
+    repeated string attributes_to_remove = 7;
   }
   message Increase {
     TimeTicket parent_created_at = 1;

--- a/Sources/Document/CRDT/CRDTText.swift
+++ b/Sources/Document/CRDT/CRDTText.swift
@@ -289,7 +289,7 @@ final class CRDTText: CRDTElement {
         _ attributes: [String: String],
         _ editedAt: TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([GCPair], DataSize, [TextChange]) {
+    ) throws -> ([GCPair], DataSize, [TextChange], [String: String], [String]) {
         var diff = DataSize(data: 0, meta: 0)
         // 01. split nodes with from and to
         let (_, diffTo, toRight) = try self.rgaTreeSplit.findNodeWithSplit(range.1, editedAt)
@@ -318,10 +318,29 @@ final class CRDTText: CRDTElement {
             }
         }
 
+        // Capture previous attribute values from the first styled node for reverse op.
+        var prevAttributes = [String: String]()
+        var attributesToRemove = [String]()
+        var capturedPrev = false
+
         var pairs = [GCPair]()
         for node in toBeStyleds {
             if node.isRemoved {
                 continue
+            }
+
+            if !capturedPrev {
+                let attrs = node.value.getAttrs()
+                for key in attributes.keys {
+                    if attrs.has(key: key) {
+                        if let value = try? attrs.get(key: key) {
+                            prevAttributes[key] = value
+                        }
+                    } else {
+                        attributesToRemove.append(key)
+                    }
+                }
+                capturedPrev = true
             }
 
             let (fromIdx, toIdx) = try self.rgaTreeSplit.findIndexesFromRange(node.createPosRange)
@@ -344,7 +363,93 @@ final class CRDTText: CRDTElement {
             }
         }
 
-        return (pairs, diff, changes)
+        return (pairs, diff, changes, prevAttributes, attributesToRemove)
+    }
+
+    /**
+     * `removeStyle` removes the style attributes of the given range.
+     *
+     * Returns previous attribute values (from the first styled node) for the reverse operation.
+     */
+    @discardableResult
+    func removeStyle(
+        _ range: RGATreeSplitPosRange,
+        _ attributesToRemove: [String],
+        _ editedAt: TimeTicket,
+        _ versionVector: VersionVector? = nil
+    ) throws -> ([GCPair], DataSize, [TextChange], [String: String]) {
+        var diff = DataSize(data: 0, meta: 0)
+        // 01. split nodes with from and to
+        let (_, diffTo, toRight) = try self.rgaTreeSplit.findNodeWithSplit(range.1, editedAt)
+        let (_, diffFrom, fromRight) = try self.rgaTreeSplit.findNodeWithSplit(range.0, editedAt)
+
+        diff.addDataSizes(others: diffTo, diffFrom)
+
+        // 02. find nodes to remove style from
+        var changes = [TextChange]()
+        let nodes = self.rgaTreeSplit.findBetween(fromRight, toRight)
+        var toBeStyleds = [RGATreeSplitNode<CRDTTextValue>]()
+        for node in nodes {
+            let actorID = node.createdAt.actorID
+
+            var clientLamportAtChange: Int64 = .max
+
+            if let versionVector {
+                clientLamportAtChange = versionVector.get(actorID) ?? 0
+            }
+            let canStyle = node.canStyle(
+                editedAt,
+                clientLamportAtChange: clientLamportAtChange
+            )
+            if canStyle {
+                toBeStyleds.append(node)
+            }
+        }
+
+        // Capture previous attribute values from the first styled node for reverse op.
+        var prevAttributes = [String: String]()
+        var capturedPrev = false
+
+        var pairs = [GCPair]()
+        for node in toBeStyleds {
+            if node.isRemoved {
+                continue
+            }
+
+            if !capturedPrev {
+                let attrs = node.value.getAttrs()
+                for key in attributesToRemove where attrs.has(key: key) {
+                    if let value = try? attrs.get(key: key) {
+                        prevAttributes[key] = value
+                    }
+                }
+                capturedPrev = true
+            }
+
+            let (fromIdx, toIdx) = try self.rgaTreeSplit.findIndexesFromRange(node.createPosRange)
+
+            // `nil` per key signals attribute removal to editors (e.g. Quill).
+            var removedAttributes = [String: String?]()
+            for key in attributesToRemove {
+                removedAttributes.updateValue(nil, forKey: key)
+            }
+            changes.append(TextChange(type: .style,
+                                      actor: editedAt.actorID,
+                                      from: fromIdx,
+                                      to: toIdx,
+                                      content: nil,
+                                      attributes: removedAttributes))
+
+            for key in attributesToRemove {
+                let gcNodes = node.value.getAttrs().remove(key: key, executedAt: editedAt)
+                for rhtNode in gcNodes {
+                    pairs.append(GCPair(parent: node.value, child: rhtNode))
+                    diff.addDataSizes(others: rhtNode.getDataSize())
+                }
+            }
+        }
+
+        return (pairs, diff, changes, prevAttributes)
     }
 
     /**

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -777,3 +777,53 @@ public class JSONArrayIterator: IteratorProtocol {
         return ElementConverter.toJSONElement(from: value, context: self.context)
     }
 }
+
+public extension JSONArray {
+    /**
+     * `elements` returns a sequence of wrapped elements including CRDT metadata.
+     */
+    func elements() -> JSONArrayWrappedSequence {
+        JSONArrayWrappedSequence(self.target, self.context)
+    }
+}
+
+public struct JSONArrayWrappedSequence: Sequence {
+    private let target: CRDTArray
+    private let context: ChangeContext
+
+    init(_ target: CRDTArray, _ context: ChangeContext) {
+        self.target = target
+        self.context = context
+    }
+
+    public func makeIterator() -> JSONArrayWrappedIterator {
+        JSONArrayWrappedIterator(self.target, self.context)
+    }
+}
+
+public class JSONArrayWrappedIterator: IteratorProtocol {
+    private var values: [CRDTElement]
+    private var iteratorNext: Int = 0
+    private let context: ChangeContext
+
+    init(_ crdtArray: CRDTArray, _ context: ChangeContext) {
+        self.context = context
+        self.values = []
+        for element in crdtArray {
+            self.values.append(element)
+        }
+    }
+
+    public func next() -> Any? {
+        defer {
+            self.iteratorNext += 1
+        }
+
+        guard self.iteratorNext < self.values.count else {
+            return nil
+        }
+
+        let value = self.values[self.iteratorNext]
+        return ElementConverter.toWrappedElement(from: value, context: self.context)
+    }
+}

--- a/Sources/Document/Json/JSONText.swift
+++ b/Sources/Document/Json/JSONText.swift
@@ -168,7 +168,7 @@ public class JSONText {
         let ticket = context.issueTimeTicket
         let stringAttrs = StringValueTypeDictionary.stringifyAttributes(attributes)
 
-        let (pairs, diff, _) = try text.setStyle(
+        let (pairs, diff, _, _, _) = try text.setStyle(
             range,
             stringAttrs,
             ticket
@@ -176,7 +176,7 @@ public class JSONText {
         self.context?.acc(diff)
 
         context.push(
-            operation: StyleOperation(
+            operation: StyleOperation.create(
                 parentCreatedAt: text.createdAt,
                 fromPos: range.0,
                 toPos: range.1,

--- a/Sources/Document/Operation/StyleOperation.swift
+++ b/Sources/Document/Operation/StyleOperation.swift
@@ -34,18 +34,65 @@ struct StyleOperation: Operation {
      */
     private(set) var attributes: [String: String]
 
+    /**
+     * `attributesToRemove` returns the style attributes to remove.
+     */
+    private(set) var attributesToRemove: [String]
+
     init(
         parentCreatedAt: TimeTicket,
         fromPos: RGATreeSplitPos,
         toPos: RGATreeSplitPos,
         attributes: [String: String],
-        executedAt: TimeTicket
+        attributesToRemove: [String] = [],
+        executedAt: TimeTicket = .initial
     ) {
         self.parentCreatedAt = parentCreatedAt
         self.fromPos = fromPos
         self.toPos = toPos
         self.attributes = attributes
+        self.attributesToRemove = attributesToRemove
         self.executedAt = executedAt
+    }
+
+    /**
+     * `create` creates a new instance of StyleOperation for setting style attributes.
+     */
+    static func create(
+        parentCreatedAt: TimeTicket,
+        fromPos: RGATreeSplitPos,
+        toPos: RGATreeSplitPos,
+        attributes: [String: String],
+        executedAt: TimeTicket = .initial
+    ) -> StyleOperation {
+        StyleOperation(
+            parentCreatedAt: parentCreatedAt,
+            fromPos: fromPos,
+            toPos: toPos,
+            attributes: attributes,
+            attributesToRemove: [],
+            executedAt: executedAt
+        )
+    }
+
+    /**
+     * `createRemoveStyleOperation` creates a new instance of StyleOperation for style removal.
+     */
+    static func createRemoveStyleOperation(
+        parentCreatedAt: TimeTicket,
+        fromPos: RGATreeSplitPos,
+        toPos: RGATreeSplitPos,
+        attributesToRemove: [String],
+        executedAt: TimeTicket = .initial
+    ) -> StyleOperation {
+        StyleOperation(
+            parentCreatedAt: parentCreatedAt,
+            fromPos: fromPos,
+            toPos: toPos,
+            attributes: [:],
+            attributesToRemove: attributesToRemove,
+            executedAt: executedAt
+        )
     }
 
     /**
@@ -57,13 +104,14 @@ struct StyleOperation: Operation {
         versionVector: VersionVector? = nil,
         source: OpSource = .local
     ) throws -> ExecutionResult? {
-        try ExecutionResult(opInfos: self.executeOpInfos(root: root, versionVector: versionVector))
+        let (opInfos, reverseOp) = try self.executeOpInfos(root: root, versionVector: versionVector)
+        return ExecutionResult(opInfos: opInfos, reverseOp: reverseOp)
     }
 
     private func executeOpInfos(
         root: CRDTRoot,
         versionVector: VersionVector? = nil
-    ) throws -> [any OperationInfo] {
+    ) throws -> ([any OperationInfo], Operation?) {
         let parent = root.find(createdAt: self.parentCreatedAt)
         guard let text = parent as? CRDTText else {
             let log: String
@@ -75,23 +123,86 @@ struct StyleOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        let (pairs, diff, changes) = try text.setStyle(
-            (self.fromPos, self.toPos),
-            self.attributes,
-            self.executedAt,
-            versionVector
-        )
-        root.acc(diff)
+        var allPairs = [GCPair]()
+        var allChanges = [TextChange]()
+        var allDiff = DataSize(data: 0, meta: 0)
+        var reversePrevAttributes = [String: String]()
+        var reverseAttrsToRemove = [String]()
 
-        for pair in pairs {
+        // 01. Handle attributesToRemove (remove style attributes).
+        if self.attributesToRemove.isEmpty == false {
+            let (pairs, diff, changes, prevAttributes) = try text.removeStyle(
+                (self.fromPos, self.toPos),
+                self.attributesToRemove,
+                self.executedAt,
+                versionVector
+            )
+            allDiff.addDataSizes(others: diff)
+            allPairs.append(contentsOf: pairs)
+            allChanges.append(contentsOf: changes)
+            for (key, value) in prevAttributes {
+                reversePrevAttributes[key] = value
+            }
+        }
+
+        // 02. Handle attributes (set style attributes).
+        if self.attributes.isEmpty == false {
+            let (pairs, diff, changes, prevAttributes, attrsToRemove) = try text.setStyle(
+                (self.fromPos, self.toPos),
+                self.attributes,
+                self.executedAt,
+                versionVector
+            )
+            allDiff.addDataSizes(others: diff)
+            allPairs.append(contentsOf: pairs)
+            allChanges.append(contentsOf: changes)
+            for (key, value) in prevAttributes {
+                reversePrevAttributes[key] = value
+            }
+            reverseAttrsToRemove.append(contentsOf: attrsToRemove)
+        }
+
+        root.acc(allDiff)
+
+        for pair in allPairs {
             root.registerGCPair(pair)
+        }
+
+        // Build the reverse operation for undo/redo.
+        var reverseOp: Operation?
+        if reversePrevAttributes.isEmpty == false || reverseAttrsToRemove.isEmpty == false {
+            if reversePrevAttributes.isEmpty == false, reverseAttrsToRemove.isEmpty == false {
+                reverseOp = StyleOperation(
+                    parentCreatedAt: self.parentCreatedAt,
+                    fromPos: self.fromPos,
+                    toPos: self.toPos,
+                    attributes: reversePrevAttributes,
+                    attributesToRemove: reverseAttrsToRemove
+                )
+            } else if reverseAttrsToRemove.isEmpty == false {
+                reverseOp = StyleOperation.createRemoveStyleOperation(
+                    parentCreatedAt: self.parentCreatedAt,
+                    fromPos: self.fromPos,
+                    toPos: self.toPos,
+                    attributesToRemove: reverseAttrsToRemove
+                )
+            } else {
+                reverseOp = StyleOperation.create(
+                    parentCreatedAt: self.parentCreatedAt,
+                    fromPos: self.fromPos,
+                    toPos: self.toPos,
+                    attributes: reversePrevAttributes
+                )
+            }
         }
 
         let path = try root.createPath(createdAt: self.parentCreatedAt)
 
-        return changes.compactMap {
+        let opInfos: [any OperationInfo] = allChanges.compactMap {
             StyleOpInfo(path: path, from: $0.from, to: $0.to, attributes: $0.attributes?.createdDictionary)
         }
+
+        return (opInfos, reverseOp)
     }
 
     /**

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.6.48"
+let yorkieVersion = "0.6.49"

--- a/Tests/Integration/UndoRedoIntegrationTests.swift
+++ b/Tests/Integration/UndoRedoIntegrationTests.swift
@@ -64,4 +64,62 @@ final class UndoRedoIntegrationTests: XCTestCase {
             XCTAssertEqual(d1JSON, d2JSON)
         }
     }
+
+    /// Ports "should converge with concurrent style operations" from yorkie-js-sdk v0.6.49
+    /// `packages/sdk/test/integration/history_text_test.ts` (Text History - multi client edge cases).
+    ///
+    /// Two clients concurrently apply `setStyle` on overlapping ranges of the same text node,
+    /// then sync. After convergence, both clients undo their style operations and sync again —
+    /// the documents must still converge. Then both clients redo and sync once more.
+    @MainActor
+    func test_can_converge_with_concurrent_style_operations() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — both clients establish a shared text node with initial content
+            try d1.update { root, _ in
+                root.t = JSONText()
+                (root.t as? JSONText)?.edit(0, 0, "The fox jumped.")
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — c1 applies bold over the full text, c2 applies italic from index 4
+            try d1.update { root, _ in
+                (root.t as? JSONText)?.setStyle(0, 15, ["bold": true])
+            }
+
+            try d2.update { root, _ in
+                (root.t as? JSONText)?.setStyle(4, 15, ["italic": true])
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after concurrent style operations
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — both clients undo their style operations
+            try d1.undo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after concurrent undo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — both clients redo their style operations
+            try d1.redo()
+            try d2.redo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after concurrent redo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
 }

--- a/Tests/Unit/Document/DocumentUndoRedoTests.swift
+++ b/Tests/Unit/Document/DocumentUndoRedoTests.swift
@@ -506,6 +506,42 @@ final class DocumentUndoRedoTests: XCTestCase {
         XCTAssertEqual(json, redJSON)
     }
 
+    /// Verifies the combined reverse-op branch: a single `setStyle` that both *overwrites*
+    /// an existing attribute and *adds* a new one. The reverse op must compose both
+    /// `attributes` (restore the previous value) and `attributesToRemove` (drop the newly
+    /// added key), so undo reconstructs the prior state in one operation.
+    func test_undo_mixed_overwrite_and_add_style_op() async throws {
+        // given — text styled with color:red
+        let doc = Document(key: "undo-style-mixed")
+        try await doc.update { root, _ in
+            root.t = JSONText()
+            (root.t as? JSONText)?.edit(0, 0, "Hello")
+        }
+        try await doc.update { root, _ in
+            (root.t as? JSONText)?.setStyle(0, 5, ["color": "red"])
+        }
+        let redJSON = await doc.toSortedJSON()
+        XCTAssertEqual(redJSON, "{\"t\":[{\"attrs\":{\"color\":\"red\"},\"val\":\"Hello\"}]}")
+
+        // when — one op overwrites color (red -> blue) AND adds a new "weight" attribute
+        try await doc.update { root, _ in
+            (root.t as? JSONText)?.setStyle(0, 5, ["color": "blue", "weight": "bold"])
+        }
+        let mixedJSON = "{\"t\":[{\"attrs\":{\"color\":\"blue\",\"weight\":\"bold\"},\"val\":\"Hello\"}]}"
+        var json = await doc.toSortedJSON()
+        XCTAssertEqual(json, mixedJSON)
+
+        // then — undo restores color:red AND removes the newly added "weight" in one reverse op
+        try await doc.undo()
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, redJSON)
+
+        // redo re-applies both the overwrite and the addition
+        try await doc.redo()
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, mixedJSON)
+    }
+
     // MARK: - Ancestor-removed undo-skip
 
     func test_undo_skips_safely_when_ancestor_container_is_removed() async throws {

--- a/Tests/Unit/Document/DocumentUndoRedoTests.swift
+++ b/Tests/Unit/Document/DocumentUndoRedoTests.swift
@@ -436,6 +436,76 @@ final class DocumentUndoRedoTests: XCTestCase {
         XCTAssertNotNil(finalContent)
     }
 
+    // MARK: - Text style undo/redo (#1174)
+
+    /// Ports the upstream JS test `should undo/redo style op` from
+    /// `packages/sdk/test/integration/history_text_test.ts` at tag v0.6.49.
+    ///
+    /// Scenario: text starts unstyled; applying bold is undone (removes the attribute)
+    /// and redone (restores it). This exercises the `StyleOperation.execute` reverse-op
+    /// path where a new attribute is added for the first time — undo must remove it.
+    func test_undo_and_redo_style_op() async throws {
+        // given
+        let doc = Document(key: "undo-style-op")
+        try await doc.update { root, _ in
+            root.t = JSONText()
+            (root.t as? JSONText)?.edit(0, 0, "The fox jumped.")
+        }
+
+        let initialJSON = await doc.toSortedJSON()
+        let styledJSON = "{\"t\":[{\"attrs\":{\"bold\":true},\"val\":\"The fox jumped.\"}]}"
+
+        // when — apply bold style to the entire text
+        try await doc.update { root, _ in
+            (root.t as? JSONText)?.setStyle(0, 15, ["bold": true])
+        }
+
+        var json = await doc.toSortedJSON()
+        XCTAssertEqual(json, styledJSON)
+
+        // then — undo removes the attribute that was newly added
+        try await doc.undo()
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, initialJSON)
+
+        // redo restores the bold style
+        try await doc.redo()
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, styledJSON)
+    }
+
+    /// Verifies that undoing a style op that *overwrote* an existing attribute
+    /// restores the previous value rather than deleting the attribute altogether.
+    ///
+    /// Scenario: text is styled red; overwriting with blue is undone, restoring red.
+    func test_undo_style_op_restores_previous_attribute_value() async throws {
+        // given — text with an existing "color" attribute set to "red"
+        let doc = Document(key: "undo-style-overwrite")
+        try await doc.update { root, _ in
+            root.t = JSONText()
+            (root.t as? JSONText)?.edit(0, 0, "Hello")
+        }
+        try await doc.update { root, _ in
+            (root.t as? JSONText)?.setStyle(0, 5, ["color": "red"])
+        }
+
+        let redJSON = await doc.toSortedJSON()
+        XCTAssertEqual(redJSON, "{\"t\":[{\"attrs\":{\"color\":\"red\"},\"val\":\"Hello\"}]}")
+
+        // when — overwrite "red" with "blue"
+        try await doc.update { root, _ in
+            (root.t as? JSONText)?.setStyle(0, 5, ["color": "blue"])
+        }
+
+        var json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{\"t\":[{\"attrs\":{\"color\":\"blue\"},\"val\":\"Hello\"}]}")
+
+        // then — undo restores the previous "red" value
+        try await doc.undo()
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, redJSON)
+    }
+
     // MARK: - Ancestor-removed undo-skip
 
     func test_undo_skips_safely_when_ancestor_container_is_removed() async throws {

--- a/Tests/Unit/Document/Json/JSONArrayTests.swift
+++ b/Tests/Unit/Document/Json/JSONArrayTests.swift
@@ -406,4 +406,42 @@ class JSONArrayTests: XCTestCase {
             XCTAssertEqual(defaultCount, wrappedCount)
         }
     }
+
+    /// Verifies that `elements()` traverses every live element without early termination
+    /// for a heterogeneous (mixed-type) array, matching the default iterator's coverage.
+    func test_elements_iterator_traverses_all_heterogeneous_elements() async throws {
+        // given — a mixed-type array (Int32, String, Bool)
+        let doc = Document(key: "elements-iterator-mixed")
+        try await doc.update { root, _ in
+            root.array = [Int32(7), "hello", true]
+        }
+
+        try await doc.update { root, _ in
+            guard let array = root.array as? JSONArray else {
+                XCTFail("array not found")
+                return
+            }
+
+            // when — default iterator yields unwrapped heterogeneous values
+            var unwrapped = [Any]()
+            for element in array {
+                unwrapped.append(element)
+            }
+
+            // when — elements() yields wrapped Primitive objects
+            var wrapped = [Primitive]()
+            for element in array.elements() {
+                if let primitive = element as? Primitive {
+                    wrapped.append(primitive)
+                }
+            }
+
+            // then — both iterators cover all three live elements (no early termination)
+            XCTAssertEqual(unwrapped.count, 3)
+            XCTAssertEqual(wrapped.count, 3)
+            XCTAssertEqual(unwrapped[0] as? Int32, 7)
+            XCTAssertEqual(unwrapped[1] as? String, "hello")
+            XCTAssertEqual(unwrapped[2] as? Bool, true)
+        }
+    }
 }

--- a/Tests/Unit/Document/Json/JSONArrayTests.swift
+++ b/Tests/Unit/Document/Json/JSONArrayTests.swift
@@ -322,4 +322,88 @@ class JSONArrayTests: XCTestCase {
             XCTAssertEqual(root.debugDescription, "{\"array\":[1]}")
         }
     }
+
+    // MARK: - elements() iterator (#1178)
+
+    /// Verifies that the default `for-in` iterator yields unwrapped Swift values for
+    /// primitive elements, while `elements()` yields wrapped `Primitive` objects that
+    /// carry CRDT metadata such as `createdAt`.
+    func test_default_iterator_yields_unwrapped_values_and_elements_yields_wrapped() async throws {
+        // given — an array of three Int32 primitives
+        let doc = Document(key: "elements-iterator")
+        try await doc.update { root, _ in
+            root.array = [Int32(10), Int32(20), Int32(30)]
+        }
+
+        try await doc.update { root, _ in
+            guard let array = root.array as? JSONArray else {
+                XCTFail("array not found")
+                return
+            }
+
+            // when — collect via the default for-in iterator (unwrapped path)
+            var unwrappedValues = [Int32]()
+            for element in array {
+                if let value = element as? Int32 {
+                    unwrappedValues.append(value)
+                }
+            }
+
+            // then — default iterator returns plain Swift Int32 values
+            XCTAssertEqual(unwrappedValues, [10, 20, 30])
+
+            // when — collect via elements() (wrapped path)
+            var wrappedElements = [Primitive]()
+            for element in array.elements() {
+                if let primitive = element as? Primitive {
+                    wrappedElements.append(primitive)
+                }
+            }
+
+            // then — elements() returns Primitive objects carrying CRDT metadata
+            XCTAssertEqual(wrappedElements.count, 3)
+            XCTAssertNotNil(wrappedElements.first?.createdAt)
+
+            // The wrapped values carry the correct underlying data
+            let values = wrappedElements.compactMap { primitive -> Int32? in
+                if case .integer(let intValue) = primitive.value { return intValue }
+                return nil
+            }
+            XCTAssertEqual(values, [10, 20, 30])
+        }
+    }
+
+    /// Verifies that `elements()` and the default for-in iterator both cover the same
+    /// number of live elements, confirming the two iterators share the same underlying
+    /// `CRDTArray` sequence.
+    func test_elements_iterator_count_matches_default_iterator_count() async throws {
+        // given
+        let doc = Document(key: "elements-iterator-count")
+        try await doc.update { root, _ in
+            root.array = [Int32(1), Int32(2), Int32(3), Int32(4), Int32(5)]
+        }
+
+        try await doc.update { root, _ in
+            guard let array = root.array as? JSONArray else {
+                XCTFail("array not found")
+                return
+            }
+
+            // when
+            var defaultCount = 0
+            for _ in array {
+                defaultCount += 1
+            }
+
+            var wrappedCount = 0
+            for _ in array.elements() {
+                wrappedCount += 1
+            }
+
+            // then
+            XCTAssertEqual(defaultCount, 5)
+            XCTAssertEqual(wrappedCount, 5)
+            XCTAssertEqual(defaultCount, wrappedCount)
+        }
+    }
 }

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.48'
+    image: 'yorkieteam/yorkie:0.6.49'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.48'
+    image: 'yorkieteam/yorkie:0.6.49'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk v0.6.49. Two upstream changes are iOS-relevant (the rest are ProseMirror/React/example changes with no iOS counterpart):

- **Add undo/redo support for Text.Style operations** (yorkie-js-sdk#1174). A `StyleOperation` now produces a reverse operation, so `Document.undo()` / `redo()` correctly revert and replay text style changes. Undoing a style that added a new attribute removes it; undoing a style that overwrote an existing value restores the previous value. This adds an additive proto field `Operation.Style.attributes_to_remove` (regenerated), a new `CRDTText.removeStyle`, extends `CRDTText.setStyle` to capture previous attribute values, and threads the reverse op through `StyleOperation.execute`.
- **Return unwrapped primitive values from Array iterator** (yorkie-js-sdk#1178). The default `JSONArray` iterator already returns unwrapped values on iOS; this adds a parallel `JSONArray.elements()` that yields wrapped elements (with CRDT metadata), mirroring the JS API.

Also bumps `yorkieVersion` to `0.6.49` and the CI yorkie-server pin to v0.6.49.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:

- The proto change is **additive** (new repeated field, tag 7) — binary-compatible with the server, JS, and Android.
- Behavioral note for consumers: `Document.undo()`/`redo()` now also cover `Text.Style` — e.g. the RichTextEditor example's undo/redo will now revert/replay bold/font changes (previously style ops produced no reverse op). The RichTextEditor example builds and launches cleanly against this branch.
- Gates green: critic review approved (reverse-op fidelity, GC pairs, and the null-removal signal all verified against the JS source; the concurrent style undo/redo convergence integration test was added per review), SwiftFormat 0.55.6 clean, SwiftLint 0.58.2 `--strict` 0 violations, `swift build` + 362 unit tests pass. Style-undo behavior is covered by new unit tests; the concurrent-convergence path runs in CI against the live v0.6.49 server.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation**:
```docs
- CHANGELOG.md updated with the v0.6.49 entry.
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo/redo support for text style operations
  * Array iterator returns unwrapped primitive values; new `elements()` method provides CRDT metadata
  * Text styling now supports attribute removal

* **Tests**
  * Added integration tests for concurrent style operations and convergence
  * Added unit tests for text style undo/redo and array iteration behavior

* **Chores**
  * Updated to Yorkie server v0.6.49
  * Updated Docker Compose images and GitHub Actions workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->