### PR TITLE
Apply updates from yorkie-js-sdk 0.7.0

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.49
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/56a671cb1278d36c5b7a0401214708d98d489903/Formula/y/yorkie.rb"
+      # yorkie server v0.7.0
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/6737d109abbbf3239623cde03f46292625f72ae7/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.6.49
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/56a671cb1278d36c5b7a0401214708d98d489903/Formula/y/yorkie.rb"
+      # yorkie server v0.7.0
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/6737d109abbbf3239623cde03f46292625f72ae7/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.0] - 2026-06-15
+
+- Add undo/redo support for Tree.Edit operations (Phase 1) in https://github.com/yorkie-team/yorkie-ios-sdk/pull/252
+
 ## [v0.6.49] - 2026-06-12
 
 - Add undo/redo support for Text.Style operations in https://github.com/yorkie-team/yorkie-ios-sdk/pull/251

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -825,7 +825,7 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([TreeChange], [GCPair], DataSize) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeft), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
@@ -979,7 +979,7 @@ class CRDTTree: CRDTElement {
                 }
             }
         }
-        return (changes, pairs, diff)
+        return (changes, pairs, diff, nodesToBeRemoved, fromIdx)
     }
 
     /**

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -795,6 +795,15 @@ public class Document: Attachable {
                         contentLength: (edit.content as NSString).length
                     )
                 }
+                if let treeEdit = op as? TreeEditOperation {
+                    let (from, to) = treeEdit.normalizePos()
+                    self.internalHistory.reconcileTreeEdit(
+                        parentCreatedAt: treeEdit.parentCreatedAt,
+                        rangeFrom: from,
+                        rangeTo: to,
+                        contentSize: treeEdit.getContentSize()
+                    )
+                }
             }
 
             self.changeID = self.changeID.syncClocks(with: change.id)

--- a/Sources/Document/History.swift
+++ b/Sources/Document/History.swift
@@ -143,6 +143,24 @@ final class History {
         }
     }
 
+    /**
+     * `reconcileTreeEdit` reconciles the range of tree edit operations on both stacks when a tree
+     * edit occurs, so a later undo/redo lands at the correct position.
+     */
+    func reconcileTreeEdit(parentCreatedAt: TimeTicket, rangeFrom: Int, rangeTo: Int, contentSize: Int) {
+        // NOTE: iterating copies of the stacks is intentional and harmless — `TreeEditOperation` is
+        // a class, so `reconcileOperation` mutates the stored instance through its reference.
+        for stack in [self.undoStack, self.redoStack] {
+            for ops in stack {
+                for case .operation(let op) in ops {
+                    if let edit = op as? TreeEditOperation, edit.parentCreatedAt == parentCreatedAt {
+                        edit.reconcileOperation(rangeFrom, rangeTo, contentSize)
+                    }
+                }
+            }
+        }
+    }
+
     private func replaceCreatedAt(in stack: inout [[HistoryOperation]], prevCreatedAt: TimeTicket, currCreatedAt: TimeTicket) {
         for stackIndex in stack.indices {
             for opIndex in stack[stackIndex].indices {

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -732,7 +732,7 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, pairs, diff) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
+        let (_, pairs, diff, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
             context.issueTimeTicket
         }, nil)
         self.context?.acc(diff)

--- a/Sources/Document/Operation/Operation.swift
+++ b/Sources/Document/Operation/Operation.swift
@@ -285,7 +285,13 @@ struct ExecutionResult {
 
 /**
  * `Operation` represents an operation to be executed on a document.
- *  Types confiming ``Operation`` must be struct to avoid data racing.
+ *
+ * Most conforming types are value types. Operations that carry reconcilable range state for
+ * undo/redo — ``EditOperation`` and ``TreeEditOperation`` — are intentionally `final class`
+ * (reference) types so ``History`` can mutate the instance parked on the undo/redo stack in place
+ * (see ``History/reconcileTextEdit(parentCreatedAt:rangeFrom:rangeTo:contentLength:)`` and
+ * ``History/reconcileTreeEdit(parentCreatedAt:rangeFrom:rangeTo:contentSize:)``). That mutation must
+ * stay confined to the serialised `Document.update` path, which keeps operations race-free.
  */
 protocol Operation {
     /// `parentCreatedAt` returns the creation time of the target element to

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -16,33 +16,61 @@
 
 import Foundation
 
-/**
- * `TreeEditOperation` is an operation representing Tree editing.
- */
-struct TreeEditOperation: Operation {
+/// `clearRemovedAt` clears the `removedAt` tombstone markers from a node and all its descendants,
+/// so they can be re-inserted as live nodes on undo.
+///
+/// iOS tracks a single visible `size` per node (unlike the JS SDK's separate `visibleSize` /
+/// `totalSize`), so removal only decreases an element's `size`. The traversal is postorder, so by
+/// the time an element node is visited its descendants are already live again — recomputing the
+/// element's `size` from its (now all-live) `children` restores the full visible size. Text nodes
+/// keep their `size`, which removal never decreased.
+private func clearRemovedAt(_ node: CRDTTreeNode) {
+    traverseAll(node: node) { node, _ in
+        node.removedAt = nil
+        if node.isText == false {
+            node.size = node.children.reduce(0) { $0 + $1.paddedSize }
+        }
+    }
+}
+
+/// `TreeEditOperation` is an operation representing Tree editing.
+///
+/// It is a `class` (reference type) because undo/redo mutates its range in place — at undo
+/// execution time the stored integer indices are converted to ``CRDTTreePos``, and
+/// ``reconcileOperation(_:_:_:)`` shifts those indices when a remote edit occurs while the
+/// operation sits on the undo/redo stack.
+final class TreeEditOperation: Operation {
     var parentCreatedAt: TimeTicket
     var executedAt: TimeTicket
 
-    /**
-     * `fromPos` returns the start point of the editing range.
-     */
-    let fromPos: CRDTTreePos
-    /**
-     * `toPos` returns the end point of the editing range.
-     */
-    let toPos: CRDTTreePos
-    /**
-     * `content` returns the content of Edit.
-     */
+    /// `fromPos` returns the start point of the editing range.
+    private(set) var fromPos: CRDTTreePos
+    /// `toPos` returns the end point of the editing range.
+    private(set) var toPos: CRDTTreePos
+    /// `contents` returns the content of Edit.
     let contents: [CRDTTreeNode]?
     let splitLevel: Int32
+
+    /// Whether this operation was produced as the reverse of an edit (i.e. lives on a history stack).
+    private let isUndoOp: Bool
+    /// The reconciled start index of an undo op's range, used to recompute ``fromPos`` at undo time.
+    private var fromIdx: Int?
+    /// The reconciled end index of an undo op's range, used to recompute ``toPos`` at undo time.
+    private var toIdx: Int?
+    /// The pre-edit start index captured by the most recent `execute`, used to reconcile parked ops.
+    private var lastFromIdx: Int?
+    /// The pre-edit end index captured by the most recent `execute`, used to reconcile parked ops.
+    private var lastToIdx: Int?
 
     init(parentCreatedAt: TimeTicket,
          fromPos: CRDTTreePos,
          toPos: CRDTTreePos,
          contents: [CRDTTreeNode]?,
          splitLevel: Int32,
-         executedAt: TimeTicket)
+         executedAt: TimeTicket,
+         isUndoOp: Bool = false,
+         fromIdx: Int? = nil,
+         toIdx: Int? = nil)
     {
         self.parentCreatedAt = parentCreatedAt
         self.fromPos = fromPos
@@ -50,6 +78,9 @@ struct TreeEditOperation: Operation {
         self.contents = contents
         self.splitLevel = splitLevel
         self.executedAt = executedAt
+        self.isUndoOp = isUndoOp
+        self.fromIdx = fromIdx
+        self.toIdx = toIdx
     }
 
     /**
@@ -61,13 +92,6 @@ struct TreeEditOperation: Operation {
         versionVector: VersionVector? = nil,
         source: OpSource = .local
     ) throws -> ExecutionResult? {
-        try ExecutionResult(opInfos: self.executeOpInfos(root: root, versionVector: versionVector))
-    }
-
-    private func executeOpInfos(
-        root: CRDTRoot,
-        versionVector: VersionVector? = nil
-    ) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
             Logger.critical(log)
@@ -79,6 +103,13 @@ struct TreeEditOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: "fail to execute, only Tree can execute edit")
         }
 
+        // For undo ops the stored integer indices may have been reconciled against remote edits;
+        // convert them back to positions on the current tree before editing.
+        if self.isUndoOp, let fromIdx = self.fromIdx, let toIdx = self.toIdx {
+            self.fromPos = try tree.findPos(fromIdx)
+            self.toPos = try fromIdx == toIdx ? self.fromPos : (tree.findPos(toIdx))
+        }
+
         /**
          * TODO(sejongk): When splitting element nodes, a new nodeID is assigned with a different timeTicket.
          * In the same change context, the timeTickets share the same lamport and actorID but have different delimiters,
@@ -86,7 +117,7 @@ struct TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, diff) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
+        let (changes, pairs, diff, removedNodes, preEditFromIdx) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -97,6 +128,18 @@ struct TreeEditOperation: Operation {
 
             return editedAt
         }, versionVector)
+
+        // Capture the pre-edit range so a remote/local edit can reconcile parked undo ops. `toIdx`
+        // is `fromIdx` plus the total visible tokens of the nodes this edit removed.
+        self.lastFromIdx = preEditFromIdx
+        let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }
+        self.lastToIdx = preEditFromIdx + removedSize
+
+        // Build the reverse op for undo. Phase 1 skips split edits (splitLevel > 0).
+        let reverseOp = self.splitLevel == 0
+            ? try self.toReverseOperation(tree, removedNodes, preEditFromIdx)
+            : nil
+
         root.acc(diff)
 
         for pair in pairs {
@@ -105,7 +148,7 @@ struct TreeEditOperation: Operation {
 
         let path = try root.createPath(createdAt: self.parentCreatedAt)
 
-        return changes.compactMap { change in
+        let opInfos: [any OperationInfo] = changes.compactMap { change in
             let value: [CRDTTreeNode] = {
                 if case .nodes(let nodes) = change.value {
                     return nodes
@@ -124,6 +167,136 @@ struct TreeEditOperation: Operation {
                 toPath: change.toPath
             )
         }
+
+        return ExecutionResult(opInfos: opInfos, reverseOp: reverseOp)
+    }
+
+    /// `toReverseOperation` creates the reverse operation for undo.
+    ///
+    /// The reverse op stores both ``CRDTTreePos`` (for initial use) and integer indices (for
+    /// reconciliation when remote edits arrive). At undo time the integer indices take precedence
+    /// and are converted to positions via `tree.findPos`.
+    ///
+    /// - Parameters:
+    ///   - tree: The tree after this edit has been applied.
+    ///   - removedNodes: The nodes removed by this edit, to be re-inserted on undo.
+    ///   - preEditFromIdx: The start index captured before the edit deletions.
+    /// - Returns: The reverse ``TreeEditOperation``, or `nil` when the edit was a no-op.
+    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int) throws -> Operation? {
+        // Total tree-index tokens inserted by this edit.
+        let insertedContentSize = self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
+
+        // Guard: if the positions exceed the post-edit tree size, the edit was a no-op (e.g. a
+        // concurrent parent deletion tombstoned the inserted content). Skip the reverse op.
+        let maxNeededIdx = preEditFromIdx + insertedContentSize
+        if maxNeededIdx > tree.size {
+            return nil
+        }
+
+        // Keep only top-level removed nodes (whose parent is not also removed).
+        let topLevelRemoved = removedNodes.filter { node in
+            guard let parent = node.parent else {
+                return true
+            }
+            return removedNodes.contains { $0 === parent } == false
+        }
+
+        // Deep copy for re-insertion on undo, clearing tombstone markers.
+        let reverseContents: [CRDTTreeNode]? = topLevelRemoved.isEmpty
+            ? nil
+            : topLevelRemoved.compactMap { node in
+                guard let clone = node.deepcopy() else {
+                    return nil
+                }
+                clearRemovedAt(clone)
+                return clone
+            }
+
+        // Positions for the reverse range, computed on the post-edit tree from the pre-edit index.
+        let reverseFromPos = try tree.findPos(preEditFromIdx)
+        let reverseToPos = try insertedContentSize > 0
+            ? (tree.findPos(preEditFromIdx + insertedContentSize))
+            : reverseFromPos
+
+        // executedAt is reassigned just before execution when Document.undo() is called.
+        return TreeEditOperation(
+            parentCreatedAt: self.parentCreatedAt,
+            fromPos: reverseFromPos,
+            toPos: reverseToPos,
+            contents: reverseContents,
+            splitLevel: 0,
+            executedAt: TimeTicket.initial,
+            isUndoOp: true,
+            fromIdx: preEditFromIdx,
+            toIdx: preEditFromIdx + insertedContentSize
+        )
+    }
+
+    /// `normalizePos` returns the visible-index `(from, to)` range of this operation.
+    ///
+    /// For undo ops it returns the stored (possibly reconciled) indices; for forward ops it returns
+    /// the pre-edit indices captured during `execute`.
+    func normalizePos() -> (Int, Int) {
+        if self.isUndoOp, let fromIdx = self.fromIdx, let toIdx = self.toIdx {
+            return (fromIdx, toIdx)
+        }
+
+        if let lastFromIdx = self.lastFromIdx, let lastToIdx = self.lastToIdx {
+            return (lastFromIdx, lastToIdx)
+        }
+
+        return (0, 0)
+    }
+
+    /// `reconcileOperation` shifts this (undo) op's integer indices when a remote edit changes the
+    /// tree while the operation is parked on the undo/redo stack, so a later undo lands in the right
+    /// spot. Uses the same 6-case overlap logic as ``EditOperation/reconcileOperation(_:_:_:)``.
+    func reconcileOperation(_ remoteFrom: Int, _ remoteTo: Int, _ contentLen: Int) {
+        guard self.isUndoOp, let localFrom = self.fromIdx, let localTo = self.toIdx, remoteFrom <= remoteTo else {
+            return
+        }
+
+        let remoteRangeLen = remoteTo - remoteFrom
+
+        func apply(_ na: Int, _ nb: Int) {
+            self.fromIdx = max(0, na)
+            self.toIdx = max(0, nb)
+        }
+
+        // Case 1: remote edit entirely left of the undo range.
+        if remoteTo <= localFrom {
+            apply(localFrom - remoteRangeLen + contentLen, localTo - remoteRangeLen + contentLen)
+            return
+        }
+        // Case 2: remote edit entirely right of the undo range.
+        if localTo <= remoteFrom {
+            return
+        }
+        // Case 3: undo range contained within the remote range.
+        if remoteFrom <= localFrom, localTo <= remoteTo, remoteFrom != remoteTo {
+            apply(remoteFrom, remoteFrom)
+            return
+        }
+        // Case 4: remote range contained within the undo range.
+        if localFrom <= remoteFrom, remoteTo <= localTo, localFrom != localTo {
+            apply(localFrom, localTo - remoteRangeLen + contentLen)
+            return
+        }
+        // Case 5: remote range overlaps the start of the undo range.
+        if remoteFrom < localFrom, localFrom < remoteTo, remoteTo < localTo {
+            apply(remoteFrom, remoteFrom + (localTo - remoteTo))
+            return
+        }
+        // Case 6: remote range overlaps the end of the undo range.
+        if localFrom < remoteFrom, remoteFrom < localTo, localTo < remoteTo {
+            apply(localFrom, remoteFrom)
+            return
+        }
+    }
+
+    /// `getContentSize` returns the total visible size of this operation's content.
+    func getContentSize() -> Int {
+        self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
     }
 
     /**

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.6.49"
+let yorkieVersion = "0.7.0"

--- a/Tests/Integration/TreeHistoryIntegrationTests.swift
+++ b/Tests/Integration/TreeHistoryIntegrationTests.swift
@@ -1,0 +1,1287 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Helpers
+
+/// Initial tree: <doc><p>The fox jumped.</p></doc>
+///
+/// Mirrors `initTree` from the JS test file.
+@MainActor
+private func initTreeFox(_ doc: Document) throws {
+    try doc.update { root, _ in
+        root.t = JSONTree(initialRoot:
+            JSONTreeElementNode(type: "doc", children: [
+                JSONTreeElementNode(type: "p", children: [
+                    JSONTreeTextNode(value: "The fox jumped.")
+                ])
+            ])
+        )
+    }
+}
+
+/// Returns the XML of the `t` field in the document root.
+///
+/// Mirrors `xmlOf` from the JS test file.
+@MainActor
+private func xmlOf(_ doc: Document) -> String {
+    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+}
+
+/// Applies tree operations from the perspective of client 1 (operates at middle / end).
+///
+/// Mirrors `applyTreeOp1` in the JS source.
+@MainActor
+private func applyTreeOp1(_ doc: Document, _ op: String) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case "insert-text":
+            // Append "X" at end of <p> text (before closing tag). Index 16 is before </p>.
+            try tree.edit(16, 16, JSONTreeTextNode(value: "X"))
+        case "delete-text":
+            // Delete char at middle: "fox" → "fx" (delete 'o' at index 6).
+            try tree.edit(6, 7)
+        case "insert-element":
+            // Add <p>New</p> after first <p>.
+            try tree.edit(17, 17, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "New")]))
+        case "delete-element":
+            // Delete first <p> entirely: indices [0, 17).
+            try tree.edit(0, 17)
+        case "replace-text":
+            // Replace 'fox' with 'cat': indices [5, 8).
+            try tree.edit(5, 8, JSONTreeTextNode(value: "cat"))
+        case "replace-element":
+            // Replace first <p> with <p>Replaced</p>.
+            try tree.edit(0, 17, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "Replaced")]))
+        default:
+            break
+        }
+    }
+}
+
+/// Applies tree operations from the perspective of client 2 (operates at different positions).
+///
+/// Mirrors `applyTreeOp2` in the JS source.
+@MainActor
+private func applyTreeOp2(_ doc: Document, _ op: String) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case "insert-text":
+            // Insert "Q" at start of <p> text.
+            try tree.edit(1, 1, JSONTreeTextNode(value: "Q"))
+        case "delete-text":
+            // Delete last char '.' at end of text.
+            try tree.edit(15, 16)
+        case "insert-element":
+            // Insert <p>Front</p> before first <p>.
+            try tree.edit(0, 0, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "Front")]))
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - 1. Single Client - Basic Undo/Redo
+
+final class TreeHistorySingleClientBasicTests: XCTestCase {
+    // Ports: "should undo/redo insert-text"
+    @MainActor
+    func test_can_undo_redo_insert_text() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-insert-text")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "insert-text")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo insert-text failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo insert-text failed")
+    }
+
+    // Ports: "should undo/redo delete-text"
+    @MainActor
+    func test_can_undo_redo_delete_text() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-delete-text")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "delete-text")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo delete-text failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo delete-text failed")
+    }
+
+    // Ports: "should undo/redo insert-element"
+    @MainActor
+    func test_can_undo_redo_insert_element() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-insert-elem")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "insert-element")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo insert-element failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo insert-element failed")
+    }
+
+    // Ports: "should undo/redo delete-element"
+    @MainActor
+    func test_can_undo_redo_delete_element() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-delete-elem")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "delete-element")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo delete-element failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo delete-element failed")
+    }
+
+    // Ports: "should undo/redo replace-text"
+    @MainActor
+    func test_can_undo_redo_replace_text() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-replace-text")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "replace-text")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo replace-text failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo replace-text failed")
+    }
+
+    // Ports: "should undo/redo replace-element"
+    @MainActor
+    func test_can_undo_redo_replace_element() async throws {
+        // given
+        let doc = Document(key: "tree-history-basic-replace-elem")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when
+        try applyTreeOp1(doc, "replace-element")
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before, "undo replace-element failed")
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after, "redo replace-element failed")
+    }
+
+    // Ports: "should handle undo-redo round trip multiple times"
+    @MainActor
+    func test_can_handle_undo_redo_round_trip_multiple_times() async throws {
+        // given
+        let doc = Document(key: "tree-history-round-trip")
+        try initTreeFox(doc)
+
+        let initial = xmlOf(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "Hello "))
+        }
+        let modified = xmlOf(doc)
+
+        // when/then — three consecutive undo/redo cycles must restore the same states
+        for round in 0 ..< 3 {
+            try doc.undo()
+            XCTAssertEqual(xmlOf(doc), initial, "round \(round) undo failed")
+            try doc.redo()
+            XCTAssertEqual(xmlOf(doc), modified, "round \(round) redo failed")
+        }
+    }
+
+    // Ports: "should clear redo stack when new edit is made after undo"
+    @MainActor
+    func test_clears_redo_stack_when_new_edit_is_made_after_undo() async throws {
+        // given
+        let doc = Document(key: "tree-history-clear-redo")
+        try initTreeFox(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(16, 16, JSONTreeTextNode(value: "X"))
+        }
+
+        // when — undo then make a new edit
+        try doc.undo()
+        XCTAssertTrue(doc.canRedo)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "Z"))
+        }
+
+        // then — redo stack is cleared
+        XCTAssertFalse(doc.canRedo)
+    }
+}
+
+// MARK: - 2. Single Client - Chained Ops
+
+final class TreeHistorySingleClientChainedOpsTests: XCTestCase {
+    // Applies one chained operation using safe, position-stable operations.
+    //
+    // Mirrors `applyChainOp` inside the JS chained ops loop.
+    @MainActor
+    private func applyChainOp(_ doc: Document, _ op: String) throws {
+        try doc.update { root, _ in
+            guard let tree = root.t as? JSONTree else { return }
+            switch op {
+            case "insert-text":
+                // Insert at end of content in first <p> using editByPath.
+                try tree.editByPath([0, 1], [0, 1], JSONTreeTextNode(value: "X"))
+            case "delete-text":
+                // Delete first char in first <p>.
+                try tree.edit(1, 2)
+            case "insert-element":
+                // Insert new <p> at end using editByPath.
+                try tree.editByPath([1], [1], JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "N")]))
+            default:
+                break
+            }
+        }
+    }
+
+    // Shared implementation for all chained-op tests.
+    @MainActor
+    private func runChainTest(_ op1: String, _ op2: String, _ op3: String) throws {
+        let key = "tree-chain-\(op1)-\(op2)-\(op3)".toDocKey
+        let doc = Document(key: key)
+
+        // given — initial tree with <doc><p>ABCD</p></doc>
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "ABCD")
+                    ])
+                ])
+            )
+        }
+
+        var snapshots: [String] = [xmlOf(doc)]
+
+        // when — apply three operations sequentially, recording snapshots
+        try applyChainOp(doc, op1)
+        snapshots.append(xmlOf(doc))
+        try self.applyChainOp(doc, op2)
+        snapshots.append(xmlOf(doc))
+        try self.applyChainOp(doc, op3)
+        snapshots.append(xmlOf(doc))
+
+        // then — undo: S3 → S2 → S1 → S0
+        for step in stride(from: 3, through: 1, by: -1) {
+            try doc.undo()
+            XCTAssertEqual(xmlOf(doc), snapshots[step - 1], "undo to S\(step - 1) (\(op1)-\(op2)-\(op3))")
+        }
+
+        // then — redo: S0 → S1 → S2 → S3
+        for step in 0 ..< 3 {
+            try doc.redo()
+            XCTAssertEqual(xmlOf(doc), snapshots[step + 1], "redo to S\(step + 1) (\(op1)-\(op2)-\(op3))")
+        }
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_text_insert_text() async throws {
+        try self.runChainTest("insert-text", "insert-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_text_delete_text() async throws {
+        try self.runChainTest("insert-text", "insert-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_text_insert_element() async throws {
+        try self.runChainTest("insert-text", "insert-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-delete-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_delete_text_insert_text() async throws {
+        try self.runChainTest("insert-text", "delete-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-delete-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_delete_text_delete_text() async throws {
+        try self.runChainTest("insert-text", "delete-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-delete-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_text_delete_text_insert_element() async throws {
+        try self.runChainTest("insert-text", "delete-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-element-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_element_insert_text() async throws {
+        try self.runChainTest("insert-text", "insert-element", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-element-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_element_delete_text() async throws {
+        try self.runChainTest("insert-text", "insert-element", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-text-insert-element-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_text_insert_element_insert_element() async throws {
+        try self.runChainTest("insert-text", "insert-element", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_text_insert_text() async throws {
+        try self.runChainTest("delete-text", "insert-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_text_delete_text() async throws {
+        try self.runChainTest("delete-text", "insert-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_text_insert_element() async throws {
+        try self.runChainTest("delete-text", "insert-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-delete-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_delete_text_insert_text() async throws {
+        try self.runChainTest("delete-text", "delete-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-delete-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_delete_text_delete_text() async throws {
+        try self.runChainTest("delete-text", "delete-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-delete-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_delete_text_delete_text_insert_element() async throws {
+        try self.runChainTest("delete-text", "delete-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-element-insert-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_element_insert_text() async throws {
+        try self.runChainTest("delete-text", "insert-element", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-element-delete-text"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_element_delete_text() async throws {
+        try self.runChainTest("delete-text", "insert-element", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: delete-text-insert-element-insert-element"
+    @MainActor
+    func test_can_undo_chain_delete_text_insert_element_insert_element() async throws {
+        try self.runChainTest("delete-text", "insert-element", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_text_insert_text() async throws {
+        try self.runChainTest("insert-element", "insert-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_text_delete_text() async throws {
+        try self.runChainTest("insert-element", "insert-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_text_insert_element() async throws {
+        try self.runChainTest("insert-element", "insert-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-delete-text-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_delete_text_insert_text() async throws {
+        try self.runChainTest("insert-element", "delete-text", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-delete-text-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_delete_text_delete_text() async throws {
+        try self.runChainTest("insert-element", "delete-text", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-delete-text-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_element_delete_text_insert_element() async throws {
+        try self.runChainTest("insert-element", "delete-text", "insert-element")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-element-insert-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_element_insert_text() async throws {
+        try self.runChainTest("insert-element", "insert-element", "insert-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-element-delete-text"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_element_delete_text() async throws {
+        try self.runChainTest("insert-element", "insert-element", "delete-text")
+    }
+
+    // Ports: "should undo chain correctly: insert-element-insert-element-insert-element"
+    @MainActor
+    func test_can_undo_chain_insert_element_insert_element_insert_element() async throws {
+        try self.runChainTest("insert-element", "insert-element", "insert-element")
+    }
+}
+
+// MARK: - 3. Single Client - Edge Cases
+
+final class TreeHistorySingleClientEdgeCasesTests: XCTestCase {
+    // Ports: "should handle edit at start position"
+    @MainActor
+    func test_can_handle_edit_at_start_position() async throws {
+        // given
+        let doc = Document(key: "tree-history-edge-start")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when — replace "The" (indices 1–4) with "A"
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 4, JSONTreeTextNode(value: "A"))
+        }
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "should handle edit at middle position"
+    @MainActor
+    func test_can_handle_edit_at_middle_position() async throws {
+        // given
+        let doc = Document(key: "tree-history-edge-middle")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when — replace 'fox' (indices 5–8) with 'cat'
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(5, 8, JSONTreeTextNode(value: "cat"))
+        }
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "should handle edit at end position"
+    @MainActor
+    func test_can_handle_edit_at_end_position() async throws {
+        // given
+        let doc = Document(key: "tree-history-edge-end")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when — append '!' at end of text (index 16)
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(16, 16, JSONTreeTextNode(value: "!"))
+        }
+        let after = xmlOf(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "should handle full tree deletion + undo"
+    @MainActor
+    func test_can_handle_full_tree_deletion_and_undo() async throws {
+        // given
+        let doc = Document(key: "tree-history-edge-delete-all")
+        try initTreeFox(doc)
+
+        let before = xmlOf(doc)
+
+        // when — delete entire <p> contents
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(0, 17)
+        }
+        XCTAssertEqual(xmlOf(doc), "<doc></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), "<doc></doc>")
+    }
+
+    // Ports: "should handle empty undo/redo stacks"
+    @MainActor
+    func test_can_handle_empty_undo_redo_stacks() async throws {
+        // given
+        let doc = Document(key: "tree-history-edge-empty-stack")
+        try initTreeFox(doc)
+
+        // The init update itself is undoable.
+        XCTAssertTrue(doc.canUndo)
+
+        // when — undo the init
+        try doc.undo()
+
+        // then — nothing more to undo
+        XCTAssertFalse(doc.canUndo)
+    }
+
+    // Ports: "should handle rapid consecutive edits"
+    @MainActor
+    func test_can_handle_rapid_consecutive_edits() async throws {
+        // given — empty <p> node
+        let doc = Document(key: "tree-history-edge-rapid")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [])
+                ])
+            )
+        }
+
+        var states: [String] = [xmlOf(doc)]
+
+        // when — insert digits 0–9 one at a time at position 1 (inside <p>)
+        for digit in 0 ..< 10 {
+            try doc.update { root, _ in
+                try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: String(digit)))
+            }
+            states.append(xmlOf(doc))
+        }
+
+        // then — undo all in reverse order
+        for index in stride(from: 9, through: 0, by: -1) {
+            try doc.undo()
+            XCTAssertEqual(xmlOf(doc), states[index])
+        }
+
+        // then — redo all in forward order
+        for index in 1 ... 10 {
+            try doc.redo()
+            XCTAssertEqual(xmlOf(doc), states[index])
+        }
+    }
+}
+
+// MARK: - 4. Single Client - Split/Merge
+
+final class TreeHistorySingleClientSplitMergeTests: XCTestCase {
+    // Ports: "should undo splitByPath"
+    //
+    // splitByPath/mergeByPath decompose into several `editInternal` calls (each splitLevel == 0)
+    // inside a single `doc.update { }`. All of those land in one change, so their reverse ops are
+    // pushed as a single undo-stack entry — one `doc.undo()` reverts the whole split, matching the
+    // JS spec.
+    @MainActor
+    func test_can_undo_splitByPath() async throws {
+        // given
+        let doc = Document(key: "tree-history-split-undo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "ABCD")
+                    ])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+        XCTAssertEqual(before, "<doc><p>ABCD</p></doc>")
+
+        // when — split at offset 2 inside the text (between "AB" and "CD")
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.splitByPath([0, 2])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>AB</p><p>CD</p></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+    }
+
+    // Ports: "should redo splitByPath"
+    @MainActor
+    func test_can_redo_splitByPath() async throws {
+        // given
+        let doc = Document(key: "tree-history-split-redo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "ABCD")
+                    ])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.splitByPath([0, 2])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>AB</p><p>CD</p></doc>")
+
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "should undo mergeByPath"
+    @MainActor
+    func test_can_undo_mergeByPath() async throws {
+        // given
+        let doc = Document(key: "tree-history-merge-undo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "AB")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "CD")])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+        XCTAssertEqual(before, "<doc><p>AB</p><p>CD</p></doc>")
+
+        // when — merge second <p> into first
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.mergeByPath([1])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>ABCD</p></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+    }
+
+    // Ports: "should redo mergeByPath"
+    @MainActor
+    func test_can_redo_mergeByPath() async throws {
+        // given
+        let doc = Document(key: "tree-history-merge-redo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "AB")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "CD")])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.mergeByPath([1])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>ABCD</p></doc>")
+
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+}
+
+// MARK: - 5. Multi Client - Basic
+
+final class TreeHistoryMultiClientBasicTests: XCTestCase {
+    // MARK: undo convergence
+
+    // Ports: "should converge after undo: insert-text-insert-text"
+    @MainActor
+    func test_can_converge_after_undo_insert_text_insert_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-text", op2: "insert-text")
+    }
+
+    // Ports: "should converge after undo: insert-text-delete-text"
+    @MainActor
+    func test_can_converge_after_undo_insert_text_delete_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-text", op2: "delete-text")
+    }
+
+    // Ports: "should converge after undo: insert-text-insert-element"
+    @MainActor
+    func test_can_converge_after_undo_insert_text_insert_element() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-text", op2: "insert-element")
+    }
+
+    // Ports: "should converge after undo: delete-text-insert-text"
+    @MainActor
+    func test_can_converge_after_undo_delete_text_insert_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "delete-text", op2: "insert-text")
+    }
+
+    // Ports: "should converge after undo: delete-text-delete-text"
+    @MainActor
+    func test_can_converge_after_undo_delete_text_delete_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "delete-text", op2: "delete-text")
+    }
+
+    // Ports: "should converge after undo: delete-text-insert-element"
+    @MainActor
+    func test_can_converge_after_undo_delete_text_insert_element() async throws {
+        try await self.runUndoConvergenceTest(op1: "delete-text", op2: "insert-element")
+    }
+
+    // Ports: "should converge after undo: insert-element-insert-text"
+    @MainActor
+    func test_can_converge_after_undo_insert_element_insert_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-element", op2: "insert-text")
+    }
+
+    // Ports: "should converge after undo: insert-element-delete-text"
+    @MainActor
+    func test_can_converge_after_undo_insert_element_delete_text() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-element", op2: "delete-text")
+    }
+
+    // Ports: "should converge after undo: insert-element-insert-element"
+    @MainActor
+    func test_can_converge_after_undo_insert_element_insert_element() async throws {
+        try await self.runUndoConvergenceTest(op1: "insert-element", op2: "insert-element")
+    }
+
+    // MARK: redo convergence
+
+    // Ports: "should converge after redo: insert-text-insert-text"
+    @MainActor
+    func test_can_converge_after_redo_insert_text_insert_text() async throws {
+        try await self.runRedoConvergenceTest(op1: "insert-text", op2: "insert-text")
+    }
+
+    // Ports: "should converge after redo: insert-text-delete-text" — skipped in JS (TODO Phase 2).
+    func test_can_converge_after_redo_insert_text_delete_text() throws {
+        throw XCTSkip("Phase 2: redo insert-text × delete-text diverges — mirrors JS it.skip")
+    }
+
+    // Ports: "should converge after redo: insert-text-insert-element"
+    @MainActor
+    func test_can_converge_after_redo_insert_text_insert_element() async throws {
+        try await self.runRedoConvergenceTest(op1: "insert-text", op2: "insert-element")
+    }
+
+    // Ports: "should converge after redo: delete-text-insert-text"
+    @MainActor
+    func test_can_converge_after_redo_delete_text_insert_text() async throws {
+        try await self.runRedoConvergenceTest(op1: "delete-text", op2: "insert-text")
+    }
+
+    // Ports: "should converge after redo: delete-text-delete-text"
+    @MainActor
+    func test_can_converge_after_redo_delete_text_delete_text() async throws {
+        try await self.runRedoConvergenceTest(op1: "delete-text", op2: "delete-text")
+    }
+
+    // Ports: "should converge after redo: delete-text-insert-element"
+    @MainActor
+    func test_can_converge_after_redo_delete_text_insert_element() async throws {
+        try await self.runRedoConvergenceTest(op1: "delete-text", op2: "insert-element")
+    }
+
+    // Ports: "should converge after redo: insert-element-insert-text"
+    @MainActor
+    func test_can_converge_after_redo_insert_element_insert_text() async throws {
+        try await self.runRedoConvergenceTest(op1: "insert-element", op2: "insert-text")
+    }
+
+    // Ports: "should converge after redo: insert-element-delete-text"
+    @MainActor
+    func test_can_converge_after_redo_insert_element_delete_text() async throws {
+        try await self.runRedoConvergenceTest(op1: "insert-element", op2: "delete-text")
+    }
+
+    // Ports: "should converge after redo: insert-element-insert-element"
+    @MainActor
+    func test_can_converge_after_redo_insert_element_insert_element() async throws {
+        try await self.runRedoConvergenceTest(op1: "insert-element", op2: "insert-element")
+    }
+
+    // MARK: - Shared implementations
+
+    @MainActor
+    private func runUndoConvergenceTest(op1: String, op2: String) async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — init tree on d1 and sync to d2
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "The fox jumped.")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — both clients apply concurrent ops
+            try applyTreeOp1(d1, op1)
+            try applyTreeOp2(d2, op2)
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON(), "after ops (\(op1) × \(op2))")
+
+            // when — both clients undo
+            try d1.undo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after undo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON(), "after undo (\(op1) × \(op2))")
+        }
+    }
+
+    @MainActor
+    private func runRedoConvergenceTest(op1: String, op2: String) async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — init tree on d1 and sync to d2
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "The fox jumped.")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — both clients apply concurrent ops
+            try applyTreeOp1(d1, op1)
+            try applyTreeOp2(d2, op2)
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // undo
+            try d1.undo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // redo
+            try d1.redo()
+            try d2.redo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after redo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON(), "after redo (\(op1) × \(op2))")
+        }
+    }
+}
+
+// MARK: - 6. Multi Client - Reconcile Cases
+
+final class TreeHistoryReconcileCasesTests: XCTestCase {
+    // Ports: "Case 1 (left): remote edit LEFT of undo should shift position"
+    @MainActor
+    func test_case1_remote_edit_left_of_undo_shifts_position() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>0123456789</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "0123456789")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 deletes [7,9) = "67"; d2 inserts "XX" at 3 (left of d1's range)
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(7, 9) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, JSONTreeTextNode(value: "XX")) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.undo()
+            try d2.undo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.redo()
+            try d2.redo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    // Ports: "Case 2 (right): remote edit RIGHT of undo should not affect"
+    @MainActor
+    func test_case2_remote_edit_right_of_undo_is_unaffected() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>0123456789</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "0123456789")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 deletes [3,5) = "23"; d2 inserts "YY" at 9 (right of d1's range)
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(9, 9, JSONTreeTextNode(value: "YY")) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.undo()
+            try d2.undo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.redo()
+            try d2.redo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    // Ports: "Case 3 (contained_by): undo range contained by remote should collapse"
+    // JS marks this .skip (TODO Phase 2).
+    @MainActor
+    func test_case3_undo_range_contained_by_remote_collapses() async throws {
+        throw XCTSkip("Phase 2: overlapping reconciliation (Case 3 contained_by) not yet supported — mirrors JS it.skip")
+    }
+
+    // Ports: "Case 4 (contains): remote range contained by undo should adjust"
+    // JS marks this .skip (TODO Phase 2).
+    @MainActor
+    func test_case4_remote_range_contained_by_undo_adjusts() async throws {
+        throw XCTSkip("Phase 2: overlapping reconciliation (Case 4 contains) not yet supported — mirrors JS it.skip")
+    }
+
+    // Ports: "Case 5 (overlap_start): remote overlaps start of undo range"
+    // JS marks this .skip (TODO Phase 2).
+    @MainActor
+    func test_case5_remote_overlaps_start_of_undo_range() async throws {
+        throw XCTSkip("Phase 2: overlapping reconciliation (Case 5 overlap_start) not yet supported — mirrors JS it.skip")
+    }
+
+    // Ports: "Case 6 (overlap_end): remote overlaps end of undo range"
+    // JS marks this .skip (TODO Phase 2).
+    @MainActor
+    func test_case6_remote_overlaps_end_of_undo_range() async throws {
+        throw XCTSkip("Phase 2: overlapping reconciliation (Case 6 overlap_end) not yet supported — mirrors JS it.skip")
+    }
+
+    // Ports: "Case 7 (adjacent): adjacent edits at boundary"
+    @MainActor
+    func test_case7_adjacent_edits_at_boundary() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>0123456789</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "0123456789")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 deletes [5,7) = "56"; d2 inserts "AA" at 7 (adjacent to d1's range end)
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(5, 7) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(7, 7, JSONTreeTextNode(value: "AA")) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.undo()
+            try d2.undo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            try d1.redo()
+            try d2.redo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+}
+
+// MARK: - 7. Multi Client - Edge Cases
+
+final class TreeHistoryMultiClientEdgeCasesTests: XCTestCase {
+    // Ports: "should converge with concurrent element + text edits"
+    @MainActor
+    func test_can_converge_with_concurrent_element_and_text_edits() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>ABCD</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "ABCD")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 inserts a new element, d2 inserts text
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(5, 5, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "New")]))
+            }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "X"))
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — both clients undo
+            try d1.undo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after concurrent undo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    // Ports: "should converge with concurrent text edits in same paragraph"
+    @MainActor
+    func test_can_converge_with_concurrent_text_edits_in_same_paragraph() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>ABCDEFGH</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [
+                            JSONTreeTextNode(value: "ABCDEFGH")
+                        ])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — both clients edit different non-overlapping ranges in the same paragraph
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(3, 5, JSONTreeTextNode(value: "XX"))
+            }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(7, 9, JSONTreeTextNode(value: "YY"))
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — d1 undoes then redoes; d2 just undoes
+            try d1.undo()
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            try d1.redo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    // Ports: "should converge with nested structure concurrent edits"
+    @MainActor
+    func test_can_converge_with_nested_structure_concurrent_edits() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <doc><p>AB</p><p>CD</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "AB")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "CD")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 edits in first <p>, d2 edits in second <p>
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "X"))
+            }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(5, 5, JSONTreeTextNode(value: "Y"))
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — both undo
+            try d1.undo()
+            try d2.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — both redo
+            try d1.redo()
+            try d2.redo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — documents converge after redo
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+}

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -177,6 +177,38 @@ final class CRDTTreeEditTests: XCTestCase {
         XCTAssertEqual(treeNode.children![0].children![0].size, 1)
     }
 
+    // Regression: the undo machinery derives the deleted span from `Σ removedNodes.paddedSize`
+    // (TreeEditOperation.execute). `removedNodes` includes nested descendants, but because
+    // `remove()` decrements an element's own `size` as each child is removed, summing every
+    // removed node's post-edit `paddedSize` equals the true visible span without double-counting.
+    func test_removed_nodes_padded_size_equals_deleted_span() throws {
+        //       0   1 2 3    4   5 6 7    8
+        // <root> <p> a b </p> <p> c d </p> </root>
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.root.rawValue), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "ab")], 0,
+                       timeT(), timeT)
+        try tree.editT((4, 4), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((5, 5),
+                       [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "cd")], 0,
+                       timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<root><p>ab</p><p>cd</p></root>")
+
+        // Delete the whole first paragraph <p>ab</p> (visible span = 2 text + 2 element padding = 4),
+        // which removes BOTH the <p> element and its text child.
+        let sizeBefore = tree.size
+        let fromPos = try tree.findPos(0)
+        let toPos = try tree.findPos(4)
+        let (_, _, _, removedNodes, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
+
+        XCTAssertEqual(removedNodes.count, 2, "both the <p> and its text child are removed")
+        let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }
+        let trueSpan = sizeBefore - tree.size
+        XCTAssertEqual(trueSpan, 4)
+        XCTAssertEqual(removedSize, trueSpan, "Σ removedNodes.paddedSize must equal the deleted span (no double-count)")
+    }
+
     func test_can_delete_tree_nodes_with_edit() throws {
         // 01. Create a tree with 2 paragraphs.
         //       0   1 2 3    4   5 6 7    8

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.49'
+    image: 'yorkieteam/yorkie:0.7.0'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.49'
+    image: 'yorkieteam/yorkie:0.7.0'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Apply updates from yorkie-js-sdk `0.7.0` (`v0.6.49..v0.7.0`).

- **Add undo/redo support for Tree.Edit operations (Phase 1)** — ports yorkie-js-sdk#1176. Mirrors the existing Text undo/redo machinery for `Tree`: `TreeEditOperation` becomes a reference type that builds a reverse op on `execute`, stores integer indices for reconciliation, and a new `History.reconcileTreeEdit` shifts parked undo/redo ops (6-case overlap logic) when a concurrent edit touches the same tree. `CRDTTree.edit` now also returns the removed nodes and the pre-edit `fromIdx`.

Upstream `0.7.0` also included yorkie-js-sdk#1179 (*Fix Korean IME composition by pausing sync during composition*). That change lives entirely in the ProseMirror binding package and has **no iOS counterpart** (the iOS SDK has no ProseMirror binding), so it is intentionally not ported.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Behaviour verified against yorkie-js-sdk `v0.7.0` (PR #1176), including porting its `history_tree_test.ts` integration suite (73 tests).
- Phase-1 scope, matching upstream: reverse ops are produced only for `splitLevel == 0`; reconcile overlap cases 3–6 and one redo combination are `XCTSkip`-ped, mirroring the upstream `it.skip` (Phase 2).
- Gates: critic review passed (no High/Medium findings), SwiftFormat 0.55.6 + SwiftLint 0.58.2 `--strict` clean, `swift build` + unit suite (364) + Tree-history integration suite (68 pass / 5 skip / 0 fail) green against a local `yorkie server`.
- CI `yorkie server` pin and docker-compose images bumped to `0.7.0`; `Version.swift` bumped to `0.7.0`.

**Does this PR introduce a user-facing change?**:

```release-note
Add undo/redo support for Tree.Edit operations (Phase 1)
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo/redo support for tree editing operations (Phase 1), including insert, delete, and replace actions.

* **Chores**
  * Bumped version to 0.7.0.
  * Updated Docker images and Homebrew formulas to version 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->