### PR TITLE
Apply updates from yorkie-js-sdk 0.7.1

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.0
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/6737d109abbbf3239623cde03f46292625f72ae7/Formula/y/yorkie.rb"
+      # yorkie server v0.7.1
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/27896666c027da81b58f149db1575636d6c6544c/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.0
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/6737d109abbbf3239623cde03f46292625f72ae7/Formula/y/yorkie.rb"
+      # yorkie server v0.7.1
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/27896666c027da81b58f149db1575636d6c6544c/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 
 ## [v0.7.1] - 2026-06-15
 
-- Add tree-level schema validation and ProseMirror example in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253
+- Add tree-level schema validation in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253
 - Retain peer presence across watch stream reconnections in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253
 
 ## [v0.7.0] - 2026-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.1] - 2026-06-15
+
+- Add tree-level schema validation and ProseMirror example in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253
+- Retain peer presence across watch stream reconnections in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253
+
 ## [v0.7.0] - 2026-06-15
 
 - Add undo/redo support for Tree.Edit operations (Phase 1) in https://github.com/yorkie-team/yorkie-ios-sdk/pull/252

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -358,7 +358,18 @@ extension Converter {
             case "array":
                 result.append(.array(.init(path: r.path)))
             case "yorkie.Text", "yorkie.Tree", "yorkie.Counter", "yorkie.Object", "yorkie.Array":
-                result.append(.yorkie(.init(path: r.path, type: .yorkie(.init(rawValue: r.type) ?? .text))))
+                // Mirror yorkie-js-sdk converter: keep `content` as the raw proto string (even ""),
+                // so the content check always runs for proto-sourced rules ("" = no children
+                // allowed). `marks`/`group` use truthy checks upstream, so treat "" as absent.
+                let treeNodes: [TreeNodeRule]? = r.treeNodes.isEmpty ? nil : r.treeNodes.map {
+                    TreeNodeRule(
+                        nodeType: $0.nodeType,
+                        content: $0.content,
+                        marks: $0.marks.isEmpty ? nil : $0.marks,
+                        group: $0.group.isEmpty ? nil : $0.group
+                    )
+                }
+                result.append(.yorkie(.init(path: r.path, type: .yorkie(.init(rawValue: r.type) ?? .text), treeNodes: treeNodes)))
             default:
                 break
             }

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -2465,6 +2465,24 @@ public struct Yorkie_V1_Schema: Sendable {
   fileprivate var _createdAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
+public struct Yorkie_V1_TreeNodeRule: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var nodeType: String = String()
+
+  public var content: String = String()
+
+  public var marks: String = String()
+
+  public var group: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Yorkie_V1_Rule: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -2473,6 +2491,8 @@ public struct Yorkie_V1_Rule: Sendable {
   public var path: String = String()
 
   public var type: String = String()
+
+  public var treeNodes: [Yorkie_V1_TreeNodeRule] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -6109,9 +6129,54 @@ extension Yorkie_V1_Schema: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
+extension Yorkie_V1_TreeNodeRule: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TreeNodeRule"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}node_type\0\u{1}content\0\u{1}marks\0\u{1}group\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.nodeType) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.content) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.marks) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.group) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.nodeType.isEmpty {
+      try visitor.visitSingularStringField(value: self.nodeType, fieldNumber: 1)
+    }
+    if !self.content.isEmpty {
+      try visitor.visitSingularStringField(value: self.content, fieldNumber: 2)
+    }
+    if !self.marks.isEmpty {
+      try visitor.visitSingularStringField(value: self.marks, fieldNumber: 3)
+    }
+    if !self.group.isEmpty {
+      try visitor.visitSingularStringField(value: self.group, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_TreeNodeRule, rhs: Yorkie_V1_TreeNodeRule) -> Bool {
+    if lhs.nodeType != rhs.nodeType {return false}
+    if lhs.content != rhs.content {return false}
+    if lhs.marks != rhs.marks {return false}
+    if lhs.group != rhs.group {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Yorkie_V1_Rule: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Rule"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}type\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}type\0\u{3}tree_nodes\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -6121,6 +6186,7 @@ extension Yorkie_V1_Rule: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.path) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.type) }()
+      case 3: try { try decoder.decodeRepeatedMessageField(value: &self.treeNodes) }()
       default: break
       }
     }
@@ -6133,12 +6199,16 @@ extension Yorkie_V1_Rule: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
     if !self.type.isEmpty {
       try visitor.visitSingularStringField(value: self.type, fieldNumber: 2)
     }
+    if !self.treeNodes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.treeNodes, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Yorkie_V1_Rule, rhs: Yorkie_V1_Rule) -> Bool {
     if lhs.path != rhs.path {return false}
     if lhs.type != rhs.type {return false}
+    if lhs.treeNodes != rhs.treeNodes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -481,9 +481,17 @@ message Schema {
   google.protobuf.Timestamp created_at = 6;
 }
 
+message TreeNodeRule {
+  string node_type = 1;
+  string content = 2;
+  string marks = 3;
+  string group = 4;
+}
+
 message Rule {
   string path = 1;
   string type = 2;
+  repeated TreeNodeRule tree_nodes = 3;
 }
 
 /////////////////////////////////////////

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -1297,8 +1297,8 @@ public class Client {
                 }
 
                 docAttachment.resource.setOnlineClients(onlineClients)
-                // Prune presences for clients no longer online (except self).
-                docAttachment.resource.prunePresences(keeping: onlineClients)
+                // NOTE: stale presences are intentionally retained (not pruned) so a peer whose
+                // watch stream reconnects becomes visible again — see `Document` presence handling.
                 docAttachment.resource.publishPresenceEvent(.initialized)
             }
         case .event(let watchEvent):

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -1064,16 +1064,12 @@ public class Document: Attachable {
         self.onlineClients.remove(clientID)
     }
 
-    /**
-     * `prunePresences` removes stored presences for clients that are no longer
-     * online, keeping only the given online clients and the current client.
-     */
-    func prunePresences(keeping onlineClients: Set<ActorID>) {
-        let myActorID = self.actorID
-        for clientID in self.presences.keys where clientID != myActorID && !onlineClients.contains(clientID) {
-            self.presences[clientID] = nil
-        }
-    }
+    // NOTE: stale presences for clients no longer in the online set are intentionally NOT pruned.
+    // The presences map retains them, but `getPresence`/`getPresences`/`getOthersPresences` already
+    // filter by `onlineClients`, so stale data is never exposed. Keeping them allows correct
+    // recovery when a client's watch stream reconnects: the server sends a `watched` event and,
+    // because the old presence is still in the map, the peer becomes visible again instead of being
+    // silently dropped.
 
     /**
      * `removePresence` removes the stored presence of the given client.
@@ -1140,6 +1136,13 @@ public class Document: Attachable {
      */
     public func getPresenceForTest(_ clientID: ActorID) -> [String: Any]? {
         self.presences[clientID]?.mapValues { $0.toJSONObject }
+    }
+
+    /**
+     * `setPresenceForTest` injects a stored presence for the given client. Test only.
+     */
+    func setPresenceForTest(_ clientID: ActorID, _ presence: StringValueTypeDictionary) {
+        self.presences[clientID] = presence
     }
 
     /**

--- a/Sources/Document/Ruleset/ContentExpression.swift
+++ b/Sources/Document/Ruleset/ContentExpression.swift
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// `ContentExpr` is a parsed ProseMirror-compatible content expression.
+///
+/// Content expressions define what children a node can contain, using the grammar:
+/// ```
+/// expr       -> sequence ('|' sequence)*     // alternatives
+/// sequence   -> element+                     // sequence
+/// element    -> atom quantifier?             // element + quantifier
+/// atom       -> name | '(' expr ')'          // node type or group
+/// quantifier -> '+' | '*' | '?'              // 1+, 0+, 0-1
+/// ```
+indirect enum ContentExpr {
+    case node(nodeType: String)
+    case sequence([ContentExpr])
+    case alternative([ContentExpr])
+    /// A repetition of an expression. `max == Int.max` represents an unbounded (`*`/`+`) upper bound.
+    case repeating(ContentExpr, min: Int, max: Int)
+}
+
+private enum Token: Equatable {
+    case name(String)
+    case plus
+    case star
+    case question
+    case pipe
+    case lparen
+    case rparen
+
+    var display: String {
+        switch self {
+        case .name(let value): return value
+        case .plus: return "+"
+        case .star: return "*"
+        case .question: return "?"
+        case .pipe: return "|"
+        case .lparen: return "("
+        case .rparen: return ")"
+        }
+    }
+}
+
+private extension Character {
+    /// Matches the JS tokenizer's `[a-zA-Z0-9_]` (ASCII only).
+    var isContentNameChar: Bool {
+        self == "_" || (self.isASCII && (self.isLetter || self.isNumber))
+    }
+}
+
+/// `tokenize` splits a content expression string into tokens.
+private func tokenize(_ expr: String) throws -> [Token] {
+    var tokens: [Token] = []
+    let chars = Array(expr)
+    var index = 0
+    while index < chars.count {
+        let char = chars[index]
+        if char.isWhitespace {
+            index += 1
+            continue
+        }
+        switch char {
+        case "+": tokens.append(.plus); index += 1
+        case "*": tokens.append(.star); index += 1
+        case "?": tokens.append(.question); index += 1
+        case "|": tokens.append(.pipe); index += 1
+        case "(": tokens.append(.lparen); index += 1
+        case ")": tokens.append(.rparen); index += 1
+        default:
+            var name = ""
+            while index < chars.count, chars[index].isContentNameChar {
+                name.append(chars[index])
+                index += 1
+            }
+            if name.isEmpty {
+                throw YorkieError(code: .errInvalidArgument, message: "Unexpected character '\(char)' at position \(index) in content expression")
+            }
+            tokens.append(.name(name))
+        }
+    }
+    return tokens
+}
+
+/// `parseAlternatives` parses alternatives separated by `|`.
+private func parseAlternatives(_ tokens: [Token], _ pos: Int) throws -> (expr: ContentExpr, pos: Int) {
+    var seqs: [ContentExpr] = []
+    var result = try parseSequence(tokens, pos)
+    seqs.append(result.expr)
+    while result.pos < tokens.count, tokens[result.pos] == .pipe {
+        result = try parseSequence(tokens, result.pos + 1)
+        seqs.append(result.expr)
+    }
+    if seqs.count == 1 {
+        return (seqs[0], result.pos)
+    }
+    return (.alternative(seqs), result.pos)
+}
+
+/// `parseSequence` parses a sequence of elements.
+private func parseSequence(_ tokens: [Token], _ pos: Int) throws -> (expr: ContentExpr, pos: Int) {
+    var pos = pos
+    var elements: [ContentExpr] = []
+    while pos < tokens.count, tokens[pos] != .pipe, tokens[pos] != .rparen {
+        let result = try parseElement(tokens, pos)
+        elements.append(result.expr)
+        pos = result.pos
+    }
+    if elements.count == 1 {
+        return (elements[0], pos)
+    }
+    return (.sequence(elements), pos)
+}
+
+/// `parseElement` parses an atom optionally followed by a quantifier.
+private func parseElement(_ tokens: [Token], _ pos: Int) throws -> (expr: ContentExpr, pos: Int) {
+    let result = try parseAtom(tokens, pos)
+    var expr = result.expr
+    var pos = result.pos
+    if pos < tokens.count {
+        switch tokens[pos] {
+        case .plus:
+            expr = .repeating(expr, min: 1, max: Int.max)
+            pos += 1
+        case .star:
+            expr = .repeating(expr, min: 0, max: Int.max)
+            pos += 1
+        case .question:
+            expr = .repeating(expr, min: 0, max: 1)
+            pos += 1
+        default:
+            break
+        }
+    }
+    return (expr, pos)
+}
+
+/// `parseAtom` parses a name or a parenthesized sub-expression.
+private func parseAtom(_ tokens: [Token], _ pos: Int) throws -> (expr: ContentExpr, pos: Int) {
+    guard pos < tokens.count else {
+        throw YorkieError(code: .errInvalidArgument, message: "Unexpected end of content expression")
+    }
+    if tokens[pos] == .lparen {
+        let result = try parseAlternatives(tokens, pos + 1)
+        guard result.pos < tokens.count, tokens[result.pos] == .rparen else {
+            throw YorkieError(code: .errInvalidArgument, message: "Unmatched parenthesis in content expression")
+        }
+        return (result.expr, result.pos + 1)
+    }
+    guard case .name(let name) = tokens[pos] else {
+        throw YorkieError(code: .errInvalidArgument, message: "Expected node type name but got '\(tokens[pos].display)' in content expression")
+    }
+    return (.node(nodeType: name), pos + 1)
+}
+
+/// `parseContentExpression` parses a ProseMirror-compatible content expression string into a
+/// ``ContentExpr``.
+///
+/// Examples:
+/// - `"paragraph+"` → 1+ paragraphs
+/// - `"text*"` → 0+ text nodes
+/// - `"heading paragraph+"` → one heading then 1+ paragraphs
+/// - `"paragraph | heading"` → one paragraph or one heading
+/// - `"(paragraph | heading)+"` → 1+ of paragraph or heading
+/// - `"block+"` → 1+ nodes from the "block" group (resolved via the group resolver)
+///
+/// - Parameter expr: The content expression string.
+/// - Returns: The parsed expression tree.
+/// - Throws: ``YorkieError`` when the expression is malformed.
+func parseContentExpression(_ expr: String) throws -> ContentExpr {
+    let trimmed = expr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        return .sequence([])
+    }
+    let tokens = try tokenize(trimmed)
+    let result = try parseAlternatives(tokens, 0)
+    if result.pos < tokens.count {
+        throw YorkieError(code: .errInvalidArgument, message: "Unexpected token '\(tokens[result.pos].display)' at position \(result.pos) in content expression")
+    }
+    return result.expr
+}
+
+/// `matchExpr` attempts to match child types starting at any of the given positions against the
+/// expression, returning the set of all reachable positions after matching (enabling backtracking
+/// for ambiguous expressions such as `a* a`).
+private func matchExpr(
+    _ expr: ContentExpr,
+    _ types: [String],
+    _ positions: Set<Int>,
+    _ resolver: (String) -> [String]
+) -> Set<Int> {
+    switch expr {
+    case .node(let nodeType):
+        let allowed = resolver(nodeType)
+        var result = Set<Int>()
+        for pos in positions where pos < types.count && allowed.contains(types[pos]) {
+            result.insert(pos + 1)
+        }
+        return result
+    case .sequence(let children):
+        var current = positions
+        for child in children {
+            current = matchExpr(child, types, current, resolver)
+            if current.isEmpty {
+                return current
+            }
+        }
+        return current
+    case .alternative(let children):
+        var result = Set<Int>()
+        for child in children {
+            for pos in matchExpr(child, types, positions, resolver) {
+                result.insert(pos)
+            }
+        }
+        return result
+    case .repeating(let child, let min, let max):
+        var current = positions
+        var reachable = Set<Int>()
+        if min == 0 {
+            for pos in current {
+                reachable.insert(pos)
+            }
+        }
+        var count = 1
+        while count <= max {
+            let next = matchExpr(child, types, current, resolver)
+            // Drop positions already seen (unless still below `min`) to avoid infinite loops.
+            var newPositions = Set<Int>()
+            for pos in next where !reachable.contains(pos) || count < min {
+                newPositions.insert(pos)
+            }
+            if newPositions.isEmpty {
+                break
+            }
+            current = newPositions
+            if count >= min {
+                for pos in current {
+                    reachable.insert(pos)
+                }
+            }
+            count += 1
+        }
+        return reachable
+    }
+}
+
+/// `matchContentExpression` matches an array of child type names against a parsed content
+/// expression, using `groupResolver` to resolve group names (like "block") to concrete node types.
+///
+/// - Parameters:
+///   - expr: The parsed content expression.
+///   - childTypes: The ordered child node type names.
+///   - groupResolver: Resolves a name to the node types in that group (or `[name]` if not a group).
+/// - Returns: `(valid: true, error: nil)` if the children match, otherwise a descriptive error.
+func matchContentExpression(
+    _ expr: ContentExpr,
+    _ childTypes: [String],
+    _ groupResolver: (String) -> [String]
+) -> (valid: Bool, error: String?) {
+    let positions = matchExpr(expr, childTypes, Set([0]), groupResolver)
+    if positions.contains(childTypes.count) {
+        return (true, nil)
+    }
+    if positions.isEmpty {
+        return (false, "Children do not match content expression")
+    }
+    return (false, "Unexpected child at position \(positions.max() ?? 0)")
+}

--- a/Sources/Document/Ruleset/Ruleset.swift
+++ b/Sources/Document/Ruleset/Ruleset.swift
@@ -89,6 +89,14 @@ enum Rule {
         default: return nil
         }
     }
+
+    /// Tree node rules, present only for a ``YorkieType/tree`` rule carrying schema constraints.
+    var treeNodes: [TreeNodeRule]? {
+        if case .yorkie(let yorkieTypeRule) = self {
+            return yorkieTypeRule.treeNodes
+        }
+        return nil
+    }
 }
 
 protocol RuleProtocol {
@@ -120,7 +128,21 @@ struct ArrayRule: RuleProtocol {
     let type: RuleType = .array
 }
 
+/// `TreeNodeRule` describes the schema constraints for a single tree node type.
+///
+/// It mirrors the `TreeNodeRule` proto message and the yorkie-js-sdk schema package: `content` is a
+/// ProseMirror-style content expression for allowed children, `marks` is the space-separated set of
+/// allowed text marks, and `group` is the space-separated set of groups the node belongs to.
+struct TreeNodeRule {
+    let nodeType: String
+    let content: String?
+    let marks: String?
+    let group: String?
+}
+
 struct YorkieTypeRule: RuleProtocol {
     let path: String
     let type: RuleType
+    /// Tree node rules for a ``YorkieType/tree`` rule, used for tree-level schema validation.
+    var treeNodes: [TreeNodeRule]?
 }

--- a/Sources/Document/Ruleset/RulesetValidator.swift
+++ b/Sources/Document/Ruleset/RulesetValidator.swift
@@ -80,10 +80,18 @@ enum RulesetValidator {
                     ])
                 }
             case .tree:
-                if !(value is CRDTTree) {
+                guard let tree = value as? CRDTTree else {
                     return ValidationResult(valid: false, errors: [
                         ValidationError(path: rule.path, message: "Expected yorkie.Tree at path \(rule.path)")
                     ])
+                }
+                if let treeNodes = rule.treeNodes, !treeNodes.isEmpty {
+                    let treeResult = validateTreeAgainstSchema(tree, treeNodes)
+                    if !treeResult.valid {
+                        return ValidationResult(valid: false, errors: [
+                            ValidationError(path: rule.path, message: treeResult.error ?? "")
+                        ])
+                    }
                 }
             case .counter:
                 // support Int32 and Int64 only

--- a/Sources/Document/Ruleset/TreeValidator.swift
+++ b/Sources/Document/Ruleset/TreeValidator.swift
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// `TreeValidationResult` is the result of validating a tree against its schema rules.
+struct TreeValidationResult {
+    let valid: Bool
+    let error: String?
+}
+
+/// `buildGroupResolver` builds a resolver that maps a name to the list of node types belonging to
+/// that group. If the name is not a group, it returns `[name]` (treating it as a concrete node type).
+func buildGroupResolver(_ treeNodes: [TreeNodeRule]) -> (String) -> [String] {
+    var groupMap: [String: [String]] = [:]
+    for node in treeNodes {
+        guard let group = node.group else {
+            continue
+        }
+        for groupName in group.split(whereSeparator: { $0.isWhitespace }).map(String.init) {
+            groupMap[groupName, default: []].append(node.nodeType)
+        }
+    }
+    return { name in groupMap[name] ?? [name] }
+}
+
+/// `validateTreeAgainstSchema` validates a ``CRDTTree``'s structure against the given tree node
+/// rules. It checks that each node's type exists in the rules, that children match the content
+/// expression (for non-text nodes), and that text-node marks are allowed by the parent's marks rule.
+///
+/// - Parameters:
+///   - tree: The tree to validate.
+///   - treeNodes: The tree node rules from the document schema.
+/// - Returns: A ``TreeValidationResult`` describing the first violation, if any.
+func validateTreeAgainstSchema(_ tree: CRDTTree, _ treeNodes: [TreeNodeRule]) -> TreeValidationResult {
+    var ruleMap: [String: TreeNodeRule] = [:]
+    for node in treeNodes {
+        ruleMap[node.nodeType] = node
+    }
+    let resolver = buildGroupResolver(treeNodes)
+    return validateNode(tree.root, ruleMap, resolver)
+}
+
+/// `validateNode` recursively validates a ``CRDTTreeNode`` against the rules.
+private func validateNode(
+    _ node: CRDTTreeNode,
+    _ ruleMap: [String: TreeNodeRule],
+    _ resolver: (String) -> [String]
+) -> TreeValidationResult {
+    // The node type must exist in the rules.
+    guard let rule = ruleMap[node.type] else {
+        return TreeValidationResult(valid: false, error: "Unknown node type: \"\(node.type)\"")
+    }
+
+    // Text nodes are leaves, validated by their parent's marks rule.
+    if node.isText {
+        return TreeValidationResult(valid: true, error: nil)
+    }
+
+    // Non-removed children.
+    let children = node.children
+
+    // All non-text children must have known types.
+    for child in children where !child.isText && ruleMap[child.type] == nil {
+        return TreeValidationResult(valid: false, error: "Unknown node type: \"\(child.type)\"")
+    }
+
+    // Validate the content expression (empty string means no children allowed).
+    if let content = rule.content {
+        let childTypes = children.map { $0.type }
+        do {
+            let expr = try parseContentExpression(content)
+            let result = matchContentExpression(expr, childTypes, resolver)
+            if !result.valid {
+                return TreeValidationResult(valid: false, error: "Node \"\(node.type)\": \(result.error ?? "")")
+            }
+        } catch {
+            let message = (error as? YorkieError)?.message ?? "\(error)"
+            return TreeValidationResult(valid: false, error: "Node \"\(node.type)\": \(message)")
+        }
+    }
+
+    // Validate marks on text children if the rule specifies allowed marks. An empty `marks` string
+    // is treated as "no marks rule" (matching the JS truthy check), not "allow no marks".
+    if let marks = rule.marks, !marks.isEmpty {
+        let allowedMarks = marks.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        let markResult = validateChildMarks(node, children, allowedMarks)
+        if !markResult.valid {
+            return markResult
+        }
+    }
+
+    // Recurse into non-text children.
+    for child in children where !child.isText {
+        let result = validateNode(child, ruleMap, resolver)
+        if !result.valid {
+            return result
+        }
+    }
+
+    return TreeValidationResult(valid: true, error: nil)
+}
+
+/// `validateChildMarks` checks that text children of a node only carry marks listed in
+/// `allowedMarks`.
+private func validateChildMarks(
+    _ parent: CRDTTreeNode,
+    _ children: [CRDTTreeNode],
+    _ allowedMarks: [String]
+) -> TreeValidationResult {
+    for child in children {
+        if !child.isText {
+            continue
+        }
+        guard let attrs = child.attrs else {
+            continue
+        }
+        for rhtNode in attrs {
+            if rhtNode.isRemoved {
+                continue
+            }
+            let markName = rhtNode.key
+            if !allowedMarks.contains(markName) {
+                return TreeValidationResult(
+                    valid: false,
+                    error: "Node \"\(parent.type)\": text child has disallowed mark \"\(markName)\". Allowed marks: \(allowedMarks.joined(separator: ", "))"
+                )
+            }
+        }
+    }
+    return TreeValidationResult(valid: true, error: nil)
+}

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.0"
+let yorkieVersion = "0.7.1"

--- a/Tests/Integration/DocumentSchemaTest.swift
+++ b/Tests/Integration/DocumentSchemaTest.swift
@@ -687,7 +687,12 @@ extension DocumentSchemaTest {
         schemaReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
         schemaReq.setValue("API-Key \(treeSecretKey)", forHTTPHeaderField: "Authorization")
         schemaReq.httpBody = try JSONSerialization.data(withJSONObject: schemaBody)
-        _ = try await URLSession.shared.data(for: schemaReq)
+        let (schemaRespData, schemaResp) = try await URLSession.shared.data(for: schemaReq)
+        let schemaStatus = (schemaResp as? HTTPURLResponse)?.statusCode ?? -1
+        XCTAssertTrue(
+            (200 ... 299).contains(schemaStatus),
+            "CreateSchema failed with status \(schemaStatus): \(String(data: schemaRespData, encoding: .utf8) ?? "")"
+        )
 
         let client = await Client.makeMock(apiKey: treeApiKey)
         try await client.activate()

--- a/Tests/Integration/DocumentSchemaTest.swift
+++ b/Tests/Integration/DocumentSchemaTest.swift
@@ -642,4 +642,108 @@ extension DocumentSchemaTest {
 
         try await client.deactivate()
     }
+
+    // should validate tree structure with tree node rules
+    // Mirrors: document_schema_test.ts "should validate tree structure with tree node rules"
+    @MainActor
+    func test_should_validate_tree_structure_with_tree_node_rules() async throws {
+        // given — create a dedicated project and a tree-schema
+        let adminToken = try await YorkieProjectHelper.logIn(
+            rpcAddress: ServerInfo.rpcAddress,
+            username: ServerInfo.testAPIID,
+            password: ServerInfo.testAPIPW
+        )
+
+        let time = "\(Date().timeIntervalSince1970)"
+        let treeProjectName = "tree-schema-\(time)"
+        let (_, treeApiKey, treeSecretKey) = try await YorkieProjectHelper.createProject(
+            rpcAddress: ServerInfo.rpcAddress,
+            token: adminToken,
+            name: treeProjectName
+        )
+
+        let treeSchemaName = "tree-schema-\(time)"
+        let schemaBody: [String: Any] = [
+            "schemaName": treeSchemaName,
+            "schemaVersion": 1,
+            "schemaBody": "type Document = {content: yorkie.Tree;};",
+            "rules": [
+                [
+                    "path": "$.content",
+                    "type": "yorkie.Tree",
+                    "tree_nodes": [
+                        ["node_type": "doc", "content": "block+", "marks": "", "group": ""],
+                        ["node_type": "paragraph", "content": "text*", "marks": "bold italic", "group": "block"],
+                        ["node_type": "heading", "content": "text*", "marks": "bold", "group": "block"],
+                        ["node_type": "text", "content": "", "marks": "", "group": ""]
+                    ]
+                ]
+            ]
+        ]
+
+        let schemaURL = URL(string: "\(ServerInfo.rpcAddress)/yorkie.v1.AdminService/CreateSchema")!
+        var schemaReq = URLRequest(url: schemaURL)
+        schemaReq.httpMethod = "POST"
+        schemaReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        schemaReq.setValue("API-Key \(treeSecretKey)", forHTTPHeaderField: "Authorization")
+        schemaReq.httpBody = try JSONSerialization.data(withJSONObject: schemaBody)
+        _ = try await URLSession.shared.data(for: schemaReq)
+
+        let client = await Client.makeMock(apiKey: treeApiKey)
+        try await client.activate()
+
+        let docKey = "\(#function)-\(time)".toDocKey
+        let doc = Document(key: docKey)
+
+        try await client.attach(doc, [:], .manual, "\(treeSchemaName)@1")
+
+        // when — valid: initialize tree with doc > paragraph > text
+        try await doc.update { root, _ in
+            root["content"] = JSONTree(initialRoot: JSONTreeElementNode(
+                type: "doc",
+                children: [
+                    JSONTreeElementNode(type: "paragraph", children: [
+                        JSONTreeTextNode(value: "Hello")
+                    ])
+                ]
+            ))
+        }
+
+        let docJSON = await doc.toSortedJSON()
+        XCTAssertTrue(docJSON.contains("content"))
+
+        // when — valid: add a heading (block group) at the start
+        try await doc.update { root, _ in
+            let tree = root["content"] as? JSONTree
+            try tree?.edit(0, 0, JSONTreeElementNode(type: "heading", children: [
+                JSONTreeTextNode(value: "Title")
+            ]))
+        }
+
+        // when — invalid: unknown node type "div"
+        do {
+            try await doc.update { root, _ in
+                let tree = root["content"] as? JSONTree
+                try tree?.edit(0, 0, JSONTreeElementNode(type: "div", children: [
+                    JSONTreeTextNode(value: "invalid")
+                ]))
+            }
+            XCTFail("Expected a YorkieError for unknown node type 'div'")
+        } catch let error as YorkieError {
+            XCTAssertFalse(error.message.isEmpty)
+        }
+
+        // when — invalid: text directly under doc (requires block+)
+        do {
+            try await doc.update { root, _ in
+                let tree = root["content"] as? JSONTree
+                try tree?.edit(0, 0, JSONTreeTextNode(value: "text under doc"))
+            }
+            XCTFail("Expected a YorkieError for text directly under doc")
+        } catch let error as YorkieError {
+            XCTAssertFalse(error.message.isEmpty)
+        }
+
+        try await client.deactivate()
+    }
 }

--- a/Tests/Unit/Document/DocumentPresenceTests.swift
+++ b/Tests/Unit/Document/DocumentPresenceTests.swift
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+final class DocumentPresenceTests: XCTestCase {
+    // Mirrors yorkie-js-sdk document_test.ts "should retain presence after watch stream
+    // reconnection" (#1186). Verifies the Document-level invariant the fix introduced: a stale
+    // presence is NOT pruned when its client leaves the online set, but `getPresences` /
+    // `getOthersPresences` filter it out — so when the peer re-watches, its retained presence
+    // resurfaces. The matching `.watched` event emission lives in the client watch-event handler,
+    // which relies on this retained presence to fire.
+    @MainActor
+    func test_should_retain_presence_after_watch_stream_reconnection() {
+        // given — a peer with injected presence, currently online
+        let doc = Document(key: "test-doc")
+        let peerID = "peer-client-id"
+        doc.setPresenceForTest(peerID, StringValueTypeDictionary.stringifyAttributes(["name": "Alice"]))
+        doc.addOnlineClient(peerID)
+
+        XCTAssertTrue(doc.hasPresence(peerID))
+        XCTAssertTrue(doc.getOthersPresences().contains { $0.clientID == peerID })
+
+        // when — the watch stream reconnects and the peer is momentarily absent from the online set
+        // (iOS equivalent of applyWatchInit([]); presences are intentionally NOT pruned)
+        doc.setOnlineClients([])
+
+        // then — the peer is hidden from the filtered API, but its presence is retained internally
+        XCTAssertFalse(doc.getOthersPresences().contains { $0.clientID == peerID })
+        XCTAssertTrue(doc.hasPresence(peerID))
+
+        // when — the peer's watch stream reconnects (re-added to the online set)
+        doc.addOnlineClient(peerID)
+
+        // then — the peer is visible again with its original presence intact
+        XCTAssertTrue(doc.getOthersPresences().contains { $0.clientID == peerID })
+        XCTAssertEqual(doc.getPresence(peerID)?["name"] as? String, "Alice")
+    }
+}

--- a/Tests/Unit/Schema/ContentExpressionTests.swift
+++ b/Tests/Unit/Schema/ContentExpressionTests.swift
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+final class ContentExpressionTests: XCTestCase {
+    // A resolver that treats every name as exactly that one type (no group expansion).
+    private let identity: (String) -> [String] = { [$0] }
+}
+
+// MARK: - Content Expression Parser
+
+extension ContentExpressionTests {
+    func test_should_match_simple_type() throws {
+        // given
+        let expr = try parseContentExpression("paragraph")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["heading"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, [], self.identity).valid)
+    }
+
+    func test_should_match_plus_quantifier_one_or_more() throws {
+        // given
+        let expr = try parseContentExpression("paragraph+")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph"], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph", "paragraph"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, [], self.identity).valid)
+    }
+
+    func test_should_match_star_quantifier_zero_or_more() throws {
+        // given
+        let expr = try parseContentExpression("text*")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, [], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["text", "text"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["paragraph"], self.identity).valid)
+    }
+
+    // Regression: the ambiguous `a* a` is the reason the matcher tracks a set of reachable
+    // positions (backtracking) rather than a single position. `a*` must be able to consume zero
+    // repetitions so the trailing `a` can match.
+    func test_should_match_ambiguous_star_followed_by_same_type() throws {
+        // given
+        let expr = try parseContentExpression("a* a")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["a"], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["a", "a"], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["a", "a", "a"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, [], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["b"], self.identity).valid)
+    }
+
+    func test_should_match_question_quantifier_zero_or_one() throws {
+        // given
+        let expr = try parseContentExpression("title?")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, [], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["title"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["title", "title"], self.identity).valid)
+    }
+
+    func test_should_match_sequence() throws {
+        // given
+        let expr = try parseContentExpression("heading paragraph+")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["heading", "paragraph"], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["heading", "paragraph", "paragraph"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["paragraph"], self.identity).valid)
+    }
+
+    func test_should_match_alternatives() throws {
+        // given
+        let expr = try parseContentExpression("paragraph | heading")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph"], self.identity).valid)
+        XCTAssertTrue(matchContentExpression(expr, ["heading"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["blockquote"], self.identity).valid)
+    }
+
+    func test_should_match_grouped_alternatives_with_quantifier() throws {
+        // given
+        let expr = try parseContentExpression("(paragraph | heading)+")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph", "heading", "paragraph"], self.identity).valid)
+        XCTAssertFalse(matchContentExpression(expr, [], self.identity).valid)
+    }
+
+    func test_should_resolve_groups() throws {
+        // given
+        let resolver: (String) -> [String] = { name in
+            name == "block" ? ["paragraph", "heading", "blockquote"] : [name]
+        }
+        let expr = try parseContentExpression("block+")
+
+        // then
+        XCTAssertTrue(matchContentExpression(expr, ["paragraph", "heading"], resolver).valid)
+        XCTAssertFalse(matchContentExpression(expr, ["inline"], resolver).valid)
+    }
+}

--- a/Tests/Unit/Schema/SchemaRulesConverterTests.swift
+++ b/Tests/Unit/Schema/SchemaRulesConverterTests.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+final class SchemaRulesConverterTests: XCTestCase {
+    // Guards the proto→model boundary for tree node rules: `content` must keep its raw value
+    // (including "" — which means "no children allowed"), while empty `marks`/`group` become nil
+    // (treated as "no rule"). Non-empty values pass through unchanged.
+    func test_fromSchemaRules_maps_tree_node_rule_empty_strings() {
+        // given — a yorkie.Tree rule with two tree nodes: one all-empty, one fully populated
+        var emptyNode = Yorkie_V1_TreeNodeRule()
+        emptyNode.nodeType = "doc"
+        emptyNode.content = ""
+        emptyNode.marks = ""
+        emptyNode.group = ""
+
+        var filledNode = Yorkie_V1_TreeNodeRule()
+        filledNode.nodeType = "paragraph"
+        filledNode.content = "text*"
+        filledNode.marks = "bold italic"
+        filledNode.group = "block"
+
+        var pbRule = Yorkie_V1_Rule()
+        pbRule.path = "$.tree"
+        pbRule.type = "yorkie.Tree"
+        pbRule.treeNodes = [emptyNode, filledNode]
+
+        // when
+        let rules = Converter.fromSchemaRules([pbRule])
+
+        // then
+        XCTAssertEqual(rules.count, 1)
+        guard let treeNodes = rules.first?.treeNodes else {
+            return XCTFail("expected treeNodes on the yorkie.Tree rule")
+        }
+        XCTAssertEqual(treeNodes.count, 2)
+
+        // content is retained even when empty ("" = no children allowed); marks/group → nil.
+        XCTAssertEqual(treeNodes[0].nodeType, "doc")
+        XCTAssertEqual(treeNodes[0].content, "")
+        XCTAssertNil(treeNodes[0].marks)
+        XCTAssertNil(treeNodes[0].group)
+
+        // non-empty values pass through unchanged.
+        XCTAssertEqual(treeNodes[1].nodeType, "paragraph")
+        XCTAssertEqual(treeNodes[1].content, "text*")
+        XCTAssertEqual(treeNodes[1].marks, "bold italic")
+        XCTAssertEqual(treeNodes[1].group, "block")
+    }
+
+    func test_fromSchemaRules_tree_rule_without_tree_nodes_has_nil_treeNodes() {
+        // given — a yorkie.Tree rule with no tree nodes
+        var pbRule = Yorkie_V1_Rule()
+        pbRule.path = "$.tree"
+        pbRule.type = "yorkie.Tree"
+
+        // when
+        let rules = Converter.fromSchemaRules([pbRule])
+
+        // then — treeNodes is nil (no tree-level schema), so validation is skipped
+        XCTAssertEqual(rules.count, 1)
+        XCTAssertNil(rules.first?.treeNodes)
+    }
+}

--- a/Tests/Unit/Schema/TreeSchemaValidationTests.swift
+++ b/Tests/Unit/Schema/TreeSchemaValidationTests.swift
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+// MARK: - Tree building helpers (file-private, used by both test classes below)
+
+private func schemaTextNode(_ value: String, attrs: RHT? = nil) -> CRDTTreeNode {
+    CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: value as NSString, attributes: attrs)
+}
+
+private func schemaElementNode(_ type: String, children: [CRDTTreeNode]) throws -> CRDTTreeNode {
+    let node = CRDTTreeNode(id: posT(), type: type, children: [])
+    try node.append(contentsOf: children)
+    return node
+}
+
+private func objectWithTree(key: String, tree: CRDTTree) -> CRDTObject {
+    let obj = CRDTObject(createdAt: timeT())
+    obj.set(key: key, value: tree)
+    return obj
+}
+
+// MARK: - Tree Schema Full-Pipeline Validation Tests
+
+// Mirrors: tree_schema_integration_test.ts "Tree Schema Integration (full pipeline)"
+// These tests exercise validateYorkieRuleset with CRDTTree constructed directly — no live server.
+
+final class TreeSchemaValidationTests: XCTestCase {
+    // Schema with: doc requires paragraph+; paragraph allows text* with marks "bold italic" in group block;
+    // heading allows text* with marks "bold" in group block; text is a leaf.
+    private let schemaRules: [Rule] = [
+        .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+        .yorkie(YorkieTypeRule(
+            path: "$.content",
+            type: .yorkie(.tree),
+            treeNodes: [
+                TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: nil, group: nil),
+                TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "bold italic", group: "block"),
+                TreeNodeRule(nodeType: "heading", content: "text*", marks: "bold", group: "block"),
+                TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+            ]
+        ))
+    ]
+
+    // MARK: valid tree structures through full pipeline
+
+    func test_should_validate_doc_paragraph_text() throws {
+        // given
+        let text = schemaTextNode("hello")
+        let para = try schemaElementNode("paragraph", children: [text])
+        let root = try schemaElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
+    func test_should_validate_doc_multiple_paragraphs_text() throws {
+        // given
+        let text1 = schemaTextNode("hello")
+        let text2 = schemaTextNode("world")
+        let para1 = try schemaElementNode("paragraph", children: [text1])
+        let para2 = try schemaElementNode("paragraph", children: [text2])
+        let root = try schemaElementNode("doc", children: [para1, para2])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_paragraph_with_no_text_children_star_allows_zero() throws {
+        // given
+        let para = try schemaElementNode("paragraph", children: [])
+        let root = try schemaElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_text_with_allowed_mark_bold_on_paragraph() throws {
+        // given
+        let attrs = RHT()
+        attrs.set(key: "bold", value: "\"true\"", executedAt: timeT())
+        let text = schemaTextNode("hello", attrs: attrs)
+        let para = try schemaElementNode("paragraph", children: [text])
+        let root = try schemaElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_text_with_multiple_allowed_marks_bold_italic() throws {
+        // given
+        let attrs = RHT()
+        attrs.set(key: "bold", value: "\"true\"", executedAt: timeT())
+        attrs.set(key: "italic", value: "\"true\"", executedAt: timeT())
+        let text = schemaTextNode("styled text", attrs: attrs)
+        let para = try schemaElementNode("paragraph", children: [text])
+        let root = try schemaElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    // MARK: invalid tree structures through full pipeline
+
+    func test_should_reject_doc_with_no_children_paragraph_plus_requires_at_least_one() throws {
+        // given
+        let root = try schemaElementNode("doc", children: [])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertEqual(result.errors[0].path, "$.content")
+        XCTAssertTrue(result.errors[0].message.contains("doc"))
+    }
+
+    func test_should_reject_unknown_node_types() throws {
+        // given
+        let text = schemaTextNode("hello")
+        let div = try schemaElementNode("div", children: [text])
+        let root = try schemaElementNode("doc", children: [div])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("Unknown node type"))
+        XCTAssertTrue(result.errors[0].message.contains("div"))
+    }
+
+    func test_should_reject_wrong_child_type_heading_under_doc_requires_paragraph_plus() throws {
+        // given — doc requires "paragraph+"; heading is not a paragraph
+        let text = schemaTextNode("title")
+        let heading = try schemaElementNode("heading", children: [text])
+        let root = try schemaElementNode("doc", children: [heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("doc"))
+    }
+
+    func test_should_reject_disallowed_marks_on_text_children() throws {
+        // given — paragraph allows "bold italic" → "underline" is not permitted
+        let attrs = RHT()
+        attrs.set(key: "underline", value: "\"true\"", executedAt: timeT())
+        let text = schemaTextNode("hello", attrs: attrs)
+        let para = try schemaElementNode("paragraph", children: [text])
+        let root = try schemaElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("disallowed mark"))
+        XCTAssertTrue(result.errors[0].message.contains("underline"))
+    }
+
+    // MARK: schema with groups through full pipeline
+
+    func test_should_validate_mixed_block_types_paragraph_and_heading() throws {
+        // given — doc content is "block+"; paragraph and heading belong to the "block" group
+        let groupRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: [
+                    TreeNodeRule(nodeType: "doc", content: "block+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "paragraph", content: "text*", marks: nil, group: "block"),
+                    TreeNodeRule(nodeType: "heading", content: "text*", marks: nil, group: "block"),
+                    TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+                ]
+            ))
+        ]
+
+        let text1 = schemaTextNode("hello")
+        let text2 = schemaTextNode("title")
+        let para = try schemaElementNode("paragraph", children: [text1])
+        let heading = try schemaElementNode("heading", children: [text2])
+        let root = try schemaElementNode("doc", children: [para, heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: groupRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_reject_non_block_types_under_doc_expects_block_plus() throws {
+        // given — text is not in the "block" group
+        let groupRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: [
+                    TreeNodeRule(nodeType: "doc", content: "block+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "paragraph", content: "text*", marks: nil, group: "block"),
+                    TreeNodeRule(nodeType: "heading", content: "text*", marks: nil, group: "block"),
+                    TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+                ]
+            ))
+        ]
+
+        let text = schemaTextNode("raw text")
+        let root = try schemaElementNode("doc", children: [text])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: groupRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("doc"))
+    }
+
+    // MARK: deeply nested schema through full pipeline
+
+    func test_should_validate_valid_deeply_nested_tree() throws {
+        // given
+        let nestedRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: [
+                    TreeNodeRule(nodeType: "doc", content: "section+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "section", content: "paragraph+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "paragraph", content: "text*", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+                ]
+            ))
+        ]
+
+        let text = schemaTextNode("hello")
+        let para = try schemaElementNode("paragraph", children: [text])
+        let section = try schemaElementNode("section", children: [para])
+        let root = try schemaElementNode("doc", children: [section])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: nestedRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_reject_errors_at_nested_level_section_with_no_paragraphs() throws {
+        // given — section requires paragraph+ but has no children
+        let nestedRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: [
+                    TreeNodeRule(nodeType: "doc", content: "section+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "section", content: "paragraph+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "paragraph", content: "text*", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+                ]
+            ))
+        ]
+
+        let section = try schemaElementNode("section", children: [])
+        let root = try schemaElementNode("doc", children: [section])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: nestedRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("section"))
+    }
+
+    // MARK: alternative content expression through full pipeline
+
+    func test_should_validate_mixed_paragraph_and_heading_under_doc() throws {
+        // given
+        let altRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: [
+                    TreeNodeRule(nodeType: "doc", content: "(paragraph | heading)+", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "paragraph", content: "text*", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "heading", content: "text*", marks: nil, group: nil),
+                    TreeNodeRule(nodeType: "text", content: nil, marks: nil, group: nil)
+                ]
+            ))
+        ]
+
+        let text1 = schemaTextNode("hello")
+        let text2 = schemaTextNode("title")
+        let text3 = schemaTextNode("more")
+        let para1 = try schemaElementNode("paragraph", children: [text1])
+        let heading = try schemaElementNode("heading", children: [text2])
+        let para2 = try schemaElementNode("paragraph", children: [text3])
+        let root = try schemaElementNode("doc", children: [para1, heading, para2])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: altRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    // MARK: non-tree type mismatch through full pipeline
+
+    func test_should_reject_when_value_at_path_is_not_a_CRDTTree() {
+        // given — "content" holds a nested CRDTObject instead of a CRDTTree
+        let innerObj = CRDTObject(createdAt: timeT())
+        let obj = CRDTObject(createdAt: timeT())
+        obj.set(key: "content", value: innerObj)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: self.schemaRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertGreaterThan(result.errors.count, 0)
+        XCTAssertTrue(result.errors[0].message.contains("yorkie.Tree"))
+    }
+
+    // MARK: tree without treeNodes (no schema constraint) through full pipeline
+
+    func test_should_pass_validation_for_yorkie_tree_rule_without_treeNodes() throws {
+        // given — nil treeNodes means any tree structure is valid
+        let noTreeNodesRules: [Rule] = [
+            .object(ObjectRule(path: "$", properties: ["content"], optional: nil)),
+            .yorkie(YorkieTypeRule(
+                path: "$.content",
+                type: .yorkie(.tree),
+                treeNodes: nil
+            ))
+        ]
+
+        let text = schemaTextNode("hello")
+        let customNode = try schemaElementNode("anything", children: [text])
+        let root = try schemaElementNode("root", children: [customNode])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+        let obj = objectWithTree(key: "content", tree: tree)
+
+        // when
+        let result = RulesetValidator.validateYorkieRuleset(data: obj, ruleset: noTreeNodesRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+}

--- a/Tests/Unit/Schema/TreeValidatorTests.swift
+++ b/Tests/Unit/Schema/TreeValidatorTests.swift
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+// MARK: - Tree building helpers
+
+/// Creates a `CRDTTreeNode` of type `"text"` with the given string value and optional attributes.
+private func makeTextNode(_ value: String, attrs: RHT? = nil) -> CRDTTreeNode {
+    CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: value as NSString, attributes: attrs)
+}
+
+/// Creates a `CRDTTreeNode` element of the given type and appends `children` into it.
+private func makeElementNode(_ type: String, children: [CRDTTreeNode]) throws -> CRDTTreeNode {
+    let node = CRDTTreeNode(id: posT(), type: type, children: [])
+    try node.append(contentsOf: children)
+    return node
+}
+
+// MARK: - buildGroupResolver tests
+
+final class BuildGroupResolverTests: XCTestCase {
+    func test_should_resolve_group_names_to_node_types() {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "block"),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "", group: "block"),
+            TreeNodeRule(nodeType: "blockquote", content: "block+", marks: "", group: "block")
+        ]
+
+        // when
+        let resolver = buildGroupResolver(rules)
+
+        // then
+        let resolved = resolver("block").sorted()
+        XCTAssertEqual(resolved, ["blockquote", "heading", "paragraph"])
+    }
+
+    func test_should_return_the_name_itself_if_not_a_group() {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "block")
+        ]
+
+        // when
+        let resolver = buildGroupResolver(rules)
+
+        // then
+        XCTAssertEqual(resolver("paragraph"), ["paragraph"])
+        XCTAssertEqual(resolver("unknown"), ["unknown"])
+    }
+
+    func test_should_handle_nodes_with_multiple_groups() {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "block flow")
+        ]
+
+        // when
+        let resolver = buildGroupResolver(rules)
+
+        // then
+        XCTAssertEqual(resolver("block"), ["paragraph"])
+        XCTAssertEqual(resolver("flow"), ["paragraph"])
+    }
+
+    func test_should_handle_empty_group() {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "")
+        ]
+
+        // when
+        let resolver = buildGroupResolver(rules)
+
+        // then
+        XCTAssertEqual(resolver("paragraph"), ["paragraph"])
+    }
+}
+
+// MARK: - validateTreeAgainstSchema tests
+
+final class ValidateTreeAgainstSchemaTests: XCTestCase {
+    private let docRules: [TreeNodeRule] = [
+        TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: "", group: ""),
+        TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "")
+    ]
+
+    func test_should_validate_a_valid_tree_doc_paragraph_text() throws {
+        // given
+        let text = makeTextNode("hello")
+        let para = try makeElementNode("paragraph", children: [text])
+        let root = try makeElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, docRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+        XCTAssertNil(result.error)
+    }
+
+    func test_should_validate_a_tree_with_multiple_paragraphs() throws {
+        // given
+        let text1 = makeTextNode("hello")
+        let text2 = makeTextNode("world")
+        let para1 = try makeElementNode("paragraph", children: [text1])
+        let para2 = try makeElementNode("paragraph", children: [text2])
+        let root = try makeElementNode("doc", children: [para1, para2])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, docRules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_reject_unknown_node_type() throws {
+        // given
+        let text = makeTextNode("hello")
+        let div = try makeElementNode("div", children: [text])
+        let root = try makeElementNode("doc", children: [div])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, docRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertTrue(result.error?.contains("Unknown node type") ?? false)
+        XCTAssertTrue(result.error?.contains("div") ?? false)
+    }
+
+    func test_should_reject_content_expression_violation_doc_requires_paragraph_plus_but_has_none() throws {
+        // given
+        let root = try makeElementNode("doc", children: [])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, docRules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertTrue(result.error?.contains("doc") ?? false)
+    }
+
+    func test_should_reject_content_expression_violation_wrong_child_type() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: ""),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "", group: "")
+        ]
+        let text = makeTextNode("hello")
+        let heading = try makeElementNode("heading", children: [text])
+        let root = try makeElementNode("doc", children: [heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertTrue(result.error?.contains("doc") ?? false)
+    }
+
+    func test_should_validate_with_group_resolver() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "block+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "block"),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "", group: "block")
+        ]
+        let text1 = makeTextNode("hello")
+        let text2 = makeTextNode("world")
+        let para = try makeElementNode("paragraph", children: [text1])
+        let heading = try makeElementNode("heading", children: [text2])
+        let root = try makeElementNode("doc", children: [para, heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_an_empty_content_expression_no_children_required() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "", marks: "", group: "")
+        ]
+        let para = try makeElementNode("paragraph", children: [])
+        let root = try makeElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_marks_on_text_children() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "heading+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "bold", group: "")
+        ]
+        let boldAttr = RHT()
+        boldAttr.set(key: "bold", value: "\"true\"", executedAt: timeT())
+        let text = makeTextNode("hello", attrs: boldAttr)
+        let heading = try makeElementNode("heading", children: [text])
+        let root = try makeElementNode("doc", children: [heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_reject_disallowed_marks_on_text_children() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "heading+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "bold", group: "")
+        ]
+        let italicAttr = RHT()
+        italicAttr.set(key: "italic", value: "\"true\"", executedAt: timeT())
+        let text = makeTextNode("hello", attrs: italicAttr)
+        let heading = try makeElementNode("heading", children: [text])
+        let root = try makeElementNode("doc", children: [heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertTrue(result.error?.contains("disallowed mark") ?? false)
+        XCTAssertTrue(result.error?.contains("italic") ?? false)
+    }
+
+    func test_should_allow_multiple_valid_marks() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "bold italic underline", group: "")
+        ]
+        let attrs = RHT()
+        attrs.set(key: "bold", value: "\"true\"", executedAt: timeT())
+        attrs.set(key: "italic", value: "\"true\"", executedAt: timeT())
+        let text = makeTextNode("hello", attrs: attrs)
+        let para = try makeElementNode("paragraph", children: [text])
+        let root = try makeElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_validate_deeply_nested_trees() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "section+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "section", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "")
+        ]
+        let text = makeTextNode("hello")
+        let para = try makeElementNode("paragraph", children: [text])
+        let section = try makeElementNode("section", children: [para])
+        let root = try makeElementNode("doc", children: [section])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_detect_errors_in_nested_children() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "section+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "section", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "")
+        ]
+        // section with no children (requires paragraph+)
+        let section = try makeElementNode("section", children: [])
+        let root = try makeElementNode("doc", children: [section])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertFalse(result.valid)
+        XCTAssertTrue(result.error?.contains("section") ?? false)
+    }
+
+    // Mirrors JS: "should skip mark validation when marks rule is empty".
+    // An empty `marks` string is treated as "no marks rule" (the validator skips it, matching the
+    // JS truthy check), so a text child with any mark passes.
+    func test_should_skip_mark_validation_when_marks_rule_is_empty() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "paragraph+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: "")
+        ]
+        // Text node with marks but paragraph has marks: "" — validation is skipped, so it passes.
+        let attrs = RHT()
+        attrs.set(key: "bold", value: "\"true\"", executedAt: timeT())
+        let text = makeTextNode("hello", attrs: attrs)
+        let para = try makeElementNode("paragraph", children: [text])
+        let root = try makeElementNode("doc", children: [para])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+
+    func test_should_handle_alternative_content_expressions() throws {
+        // given
+        let rules: [TreeNodeRule] = [
+            TreeNodeRule(nodeType: "doc", content: "(paragraph | heading)+", marks: "", group: ""),
+            TreeNodeRule(nodeType: "paragraph", content: "text*", marks: "", group: ""),
+            TreeNodeRule(nodeType: "heading", content: "text*", marks: "", group: "")
+        ]
+        let text1 = makeTextNode("hello")
+        let text2 = makeTextNode("title")
+        let para = try makeElementNode("paragraph", children: [text1])
+        let heading = try makeElementNode("heading", children: [text2])
+        let root = try makeElementNode("doc", children: [para, heading])
+        let tree = CRDTTree(root: root, createdAt: timeT())
+
+        // when
+        let result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        XCTAssertTrue(result.valid)
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.0'
+    image: 'yorkieteam/yorkie:0.7.1'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.0'
+    image: 'yorkieteam/yorkie:0.7.1'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Apply updates from yorkie-js-sdk `0.7.1` (`v0.7.0..v0.7.1`).

- **Add tree-level schema validation and ProseMirror example** — ports yorkie-js-sdk#1181. Adds a `TreeNodeRule` (`node_type`/`content`/`marks`/`group`) to the ruleset proto, a ProseMirror-compatible content-expression parser + matcher, and a tree validator wired into the `yorkie.Tree` ruleset check. The ProseMirror example and ANTLR schema grammar are JS-only / server-side (the iOS SDK consumes pre-parsed rulesets via proto) and are not ported.
- **Retain peer presence across watch stream reconnections** — ports yorkie-js-sdk#1186. Stale presences are no longer pruned when a client leaves the online set; the public presence APIs already filter by the online set, so a peer becomes visible again (instead of being silently dropped) when its watch stream reconnects.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Behaviour verified against yorkie-js-sdk `v0.7.1` (#1181, #1186); the upstream test suites were ported.
- The ruleset proto (`resources.proto`) was regenerated with the repo-pinned `buf` plugins — the regen is limited to the new `TreeNodeRule` message and `tree_nodes` field and is wire-compatible.
- Tree-level schema validation requires a yorkie `0.7.1` server (the schema, incl. `tree_nodes`, is returned by the server at attach). The CI server pin and docker-compose images are bumped to `0.7.1`; the schema integration test was verified locally against a `0.7.1` server.
- Gates: critic review passed (no High/Medium findings), SwiftFormat 0.55.6 + SwiftLint 0.58.2 `--strict` clean, `swift build` + 411 unit tests green.

**Does this PR introduce a user-facing change?**:

```release-note
Add tree-level schema validation; retain peer presence across watch stream reconnections
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tree-level schema validation for structured document content with node type rules, content expressions, and mark constraints
  * Peer presence now persists across watch stream reconnections

* **Chores**
  * Updated to version 0.7.1
  * Updated Docker images to v0.7.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->