### PR TITLE
Apply updates from yorkie-js-sdk 0.7.2

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.1
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/27896666c027da81b58f149db1575636d6c6544c/Formula/y/yorkie.rb"
+      # yorkie server v0.7.2
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/4e922a645a0a3cab278907d6b1f125017a0323a1/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.1
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/27896666c027da81b58f149db1575636d6c6544c/Formula/y/yorkie.rb"
+      # yorkie server v0.7.2
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/4e922a645a0a3cab278907d6b1f125017a0323a1/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.2] - 2026-06-16
+
+- Fix ElementRHT.set() producing duplicate ownKeys on timestamp reversal in https://github.com/yorkie-team/yorkie-ios-sdk/pull/254
+
 ## [v0.7.1] - 2026-06-15
 
 - Add tree-level schema validation in https://github.com/yorkie-team/yorkie-ios-sdk/pull/253

--- a/Examples/RichTextEditor/RichTextEditor/RTUITextField.swift
+++ b/Examples/RichTextEditor/RichTextEditor/RTUITextField.swift
@@ -47,7 +47,13 @@ struct RTUITextField: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context: Context) {
+        // Setting `attributedText` / `selectedRange` below fires the text view's delegate
+        // synchronously. Mark this as a programmatic update so the delegate does not publish the
+        // change back into the view model during this SwiftUI view-update pass (which triggers
+        // "Publishing changes from within view updates is not allowed").
+        context.coordinator.isProgrammaticUpdate = true
         defer {
+            context.coordinator.isProgrammaticUpdate = false
             // save style for checking latter after change style from local or remote
             // compare this style to make sure that is not local change
             context.coordinator.lastEditStyle = lastEditStyle
@@ -122,6 +128,7 @@ struct RTUITextField: UIViewRepresentable {
         var selectRange: UITextRange?
         var lastEditStyle: EditStyle?
         var isComposing: Bool = false // Track IME composition state
+        var isProgrammaticUpdate: Bool = false // True while `updateUIView` is setting the text view
         var textBeforeComposition: String = "" // Store text before composition started
         var compositionDebounceTimer: Timer?
 
@@ -131,9 +138,14 @@ struct RTUITextField: UIViewRepresentable {
 
         func textViewDidChangeSelection(_ textView: UITextView) {
             if let selectedTextRange = textView.selectedTextRange {
+                self.selectRange = selectedTextRange
+                // Ignore selection changes caused by our own programmatic update in `updateUIView`;
+                // only real user-driven selection changes should propagate to the view model.
+                guard !self.isProgrammaticUpdate else {
+                    return
+                }
                 let fromIndex = self.parent.textField.offset(from: textView.beginningOfDocument, to: selectedTextRange.start)
                 let toIndex = self.parent.textField.offset(from: textView.beginningOfDocument, to: selectedTextRange.end)
-                self.selectRange = selectedTextRange
                 self.parent.didChangeSelection(fromIndex, toIndex)
             }
         }

--- a/Sources/Document/CRDT/ElementRHT.swift
+++ b/Sources/Document/CRDT/ElementRHT.swift
@@ -74,6 +74,12 @@ class ElementRHT {
 
         if node == nil || value.createdAt.after(node!.value.createdAt) {
             self.nodeMapByKey[key] = newNode
+        } else if node!.isRemoved == false {
+            // The new node loses the LWW conflict — mark it as removed so it does not appear as a
+            // duplicate in `ownKeys` iteration over `nodeMapByCreatedAt`. The removal uses the same
+            // clock the winner test above uses (`createdAt`); upstream uses `getPositionedAt()`,
+            // which is equivalent here because `set` never assigns `movedAt`.
+            value.remove(node!.value.createdAt)
         }
 
         return removed

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.1"
+let yorkieVersion = "0.7.2"

--- a/Tests/Unit/Document/CRDT/ElementRHTTests.swift
+++ b/Tests/Unit/Document/CRDT/ElementRHTTests.swift
@@ -128,4 +128,82 @@ class ElementRHTTests: XCTestCase {
         XCTAssertTrue(target.has(key: "a1"))
         XCTAssertFalse(target.has(key: "a2"))
     }
+
+    // MARK: - Concurrent set / LWW conflict tests (ported from element_rht_test.ts, yorkie-js-sdk 0.7.2)
+
+    func test_should_not_produce_duplicate_keys_on_concurrent_set_with_earlier_timestamp() throws {
+        // given — two clients concurrently set the same key.
+        // Client A sets "color"="red" at T2 (lamport=2, actorA) — this arrives first and wins.
+        // Client B sets "color"="blue" at T1 (lamport=1, actorB) — this arrives later and loses.
+        let rht = ElementRHT()
+
+        let ticketA = TimeTicket(lamport: 2, delimiter: 0, actorID: "actorA")
+        let valueA = Primitive(value: .string("red"), createdAt: ticketA)
+        rht.set(key: "color", value: valueA)
+
+        let ticketB = TimeTicket(lamport: 1, delimiter: 0, actorID: "actorB")
+        let valueB = Primitive(value: .string("blue"), createdAt: ticketB)
+
+        // when — Client B's operation arrives with an earlier timestamp; it loses the LWW conflict.
+        rht.set(key: "color", value: valueB)
+
+        // then — the losing value must be marked removed so it does not appear as a live entry.
+        XCTAssertTrue(valueB.isRemoved, "the losing value must be marked removed by the fix")
+
+        // The object must expose exactly one "color" key and the winner's value.
+        let obj = CRDTObject(createdAt: TimeTicket.initial, memberNodes: rht)
+        let keys = obj.keys
+        XCTAssertEqual(keys.count, 1, "keys must not contain a duplicate")
+        XCTAssertEqual(keys, ["color"], "keys must contain only the single winning key")
+
+        // toJSON() iterates nodeMapByCreatedAt; without the fix the loser (earlier createdAt,
+        // sorted first) would surface here instead of the winner.
+        XCTAssertEqual(obj.toJSON(), "{\"color\":\"red\"}", "toJSON() must reflect the winner's value")
+
+        // get() via nodeMapByKey always returns the winner.
+        let winner = obj.get(key: "color") as? Primitive
+        XCTAssertNotNil(winner)
+        XCTAssertEqual(winner?.toJSON(), "\"red\"", "get(key:) must return the winner's value")
+    }
+
+    func test_should_handle_multiple_concurrent_sets_on_the_same_key() throws {
+        // given — three concurrent set operations targeting the same key, applied out of
+        // timestamp order to simulate late-arriving remote operations.
+        let rht = ElementRHT()
+
+        // Set "key"="first" at T3 (highest lamport) — this is the ultimate winner.
+        let ticket1 = TimeTicket(lamport: 3, delimiter: 0, actorID: "actor1")
+        let value1 = Primitive(value: .string("first"), createdAt: ticket1)
+        rht.set(key: "key", value: value1)
+
+        // Late-arriving "key"="second" at T1 — loses to T3.
+        let ticket2 = TimeTicket(lamport: 1, delimiter: 0, actorID: "actor2")
+        let value2 = Primitive(value: .string("second"), createdAt: ticket2)
+        rht.set(key: "key", value: value2)
+
+        // Late-arriving "key"="third" at T2 — loses to T3, beats T1, but still loses overall.
+        let ticket3 = TimeTicket(lamport: 2, delimiter: 0, actorID: "actor3")
+        let value3 = Primitive(value: .string("third"), createdAt: ticket3)
+
+        // when — all late-arriving operations have been applied.
+        rht.set(key: "key", value: value3)
+
+        // then — both losing values must be marked removed.
+        XCTAssertTrue(value2.isRemoved, "value at T1 must be marked removed")
+        XCTAssertTrue(value3.isRemoved, "value at T2 must be marked removed")
+
+        // Exactly one live key must remain.
+        let obj = CRDTObject(createdAt: TimeTicket.initial, memberNodes: rht)
+        let keys = obj.keys
+        XCTAssertEqual(keys.count, 1, "keys must have exactly one entry")
+        XCTAssertEqual(keys, ["key"], "keys must contain only the single winning key")
+
+        // toJSON() must surface the winner (T3 = "first"), not a loser.
+        XCTAssertEqual(obj.toJSON(), "{\"key\":\"first\"}", "toJSON() must reflect the winning value")
+
+        // get() must also resolve to the winner.
+        let winner = obj.get(key: "key") as? Primitive
+        XCTAssertNotNil(winner)
+        XCTAssertEqual(winner?.toJSON(), "\"first\"", "get(key:) must return the winner's value")
+    }
 }

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.1'
+    image: 'yorkieteam/yorkie:0.7.2'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.1'
+    image: 'yorkieteam/yorkie:0.7.2'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Apply updates from yorkie-js-sdk `0.7.2` (`v0.7.1..v0.7.2`).

- **Fix ElementRHT.set() producing duplicate ownKeys on timestamp reversal** — ports yorkie-js-sdk#1188. When a value loses the last-writer-wins conflict on `set` (its `createdAt` is not after the existing node's), the new value is now marked removed so it is not surfaced as a duplicate key during object iteration.

Also bundled (unrelated to the sync, separate commit `fix: stop RichTextEditor publishing @Published during SwiftUI view update`):

- **Example app fix** — `RichTextEditor` example: setting the `UITextView`'s `attributedText`/`selectedRange` inside `UIViewRepresentable.updateUIView` fired `textViewDidChangeSelection` synchronously, which published the view model's `@Published` state back during the SwiftUI view-update pass (the "Publishing changes from within view updates is not allowed" runtime warning). Guarded the delegate callback with an `isProgrammaticUpdate` flag so only real user-driven selection changes propagate to the model. Example-only; no SDK change.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Behaviour verified against yorkie-js-sdk `v0.7.2` (#1188); the upstream unit tests were ported.
- iOS note on the fix: iOS's `ElementRHT.set` resolves by `createdAt` (no `executedAt`/`positionedAt` parameter — a pre-existing divergence), so the port is the single LWW-loser tombstone branch, using the same `createdAt` clock as the existing winner check. The pre-existing undo-of-object-overwrite limitation (`test_undo_object_overwrite_is_a_known_limitation`) is unchanged and was verified to still pass as `XCTExpectFailure`.
- The iOS bug surfaced in `toJSON()` rather than as a literal duplicate key, because the object iterator already de-dups keys via a set; the tests assert on `isRemoved` + `toJSON()` accordingly.
- The example-app fix is not built by CI (CI builds the SwiftPM package, not the example `.xcodeproj`); it is SwiftFormat-clean and reviewed by inspection.
- Gates: critic review passed (no High/Medium), SwiftFormat 0.55.6 + SwiftLint 0.58.2 `--strict` clean, `swift build` + 413 unit tests green; CI server pin + docker images bumped to `0.7.2`.

**Does this PR introduce a user-facing change?**:

```release-note
Fix ElementRHT.set() producing duplicate ownKeys on timestamp reversal
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate keys issue when timestamps reverse in set operations
  * Improved text editor selection change handling to prevent unintended updates

* **Tests**
  * Added comprehensive tests for concurrent set operation conflicts

* **Chores**
  * Updated Yorkie server to latest version across CI/CD and Docker environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->