### PR TITLE
Apply updates from yorkie-js-sdk 0.7.3

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.2
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/4e922a645a0a3cab278907d6b1f125017a0323a1/Formula/y/yorkie.rb"
+      # yorkie server v0.7.3
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/bbda2dc5da3cc442d91fb6806e139cf630febd51/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.2
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/4e922a645a0a3cab278907d6b1f125017a0323a1/Formula/y/yorkie.rb"
+      # yorkie server v0.7.3
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/bbda2dc5da3cc442d91fb6806e139cf630febd51/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.3] - 2026-06-16
+
+- Add range-based styleByPath and removeStyleByPath for Tree in https://github.com/yorkie-team/yorkie-ios-sdk/pull/255
+- Add epoch mismatch event for compaction recovery in https://github.com/yorkie-team/yorkie-ios-sdk/pull/255
+
 ## [v0.7.2] - 2026-06-16
 
 - Fix ElementRHT.set() producing duplicate ownKeys on timestamp reversal in https://github.com/yorkie-team/yorkie-ios-sdk/pull/254

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -1455,6 +1455,7 @@ public class Client {
         } catch {
             doc.publishSyncEvent(.syncFailed)
             publishAuthErrorIfNeeded(error: error as? ConnectError, attachment: attachment, method: .pushPull)
+            publishEpochMismatchIfNeeded(error: error as? ConnectError, attachment: attachment)
 
             Logger.error("[PP] c:\"\(self.key)\" err : \(error)")
 
@@ -1493,6 +1494,13 @@ public class Client {
             let reason = errorMetadataOf(error: connectError)["reason"]
             try? await injectAuthTokenAfterGet(with: authTokenInjector, reason: reason)
             return true
+        }
+
+        // NOTE(hackerwins): If the error is `ErrEpochMismatch`, the document has been compacted and
+        // the client's checkpoint is stale. The sync loop should stop, and the user must detach and
+        // reattach the document to recover.
+        if yorkieErrorCode == .errEpochMismatch {
+            return false
         }
 
         // The client has reached the maximum number of allowed attachments.
@@ -1606,6 +1614,16 @@ public extension Client {
 
         let reason = errorMetadataOf(error: connectError)["reason"] ?? ""
         attachment.resource.publishAuthErrorEvent(reason: reason, method: method)
+    }
+
+    private func publishEpochMismatchIfNeeded(error: ConnectError?, attachment: Attachment<Document>?) {
+        guard let connectError = error, let attachment else { return }
+        let rawValue = errorCodeOf(error: connectError)
+        guard let code = YorkieError.Code(rawValue: rawValue), code == .errEpochMismatch else {
+            return
+        }
+
+        attachment.resource.publishEpochMismatchEvent(method: "PushPull")
     }
 }
 

--- a/Sources/Document/DocEvent.swift
+++ b/Sources/Document/DocEvent.swift
@@ -75,6 +75,12 @@ public enum DocEventType: String {
      * `authError` indicates an authorization failure in syncLoop or watchLoop.
      */
     case authError = "auth-error"
+
+    /**
+     * `epochMismatch` indicates the document was compacted on the server and
+     * this client must detach and reattach to recover.
+     */
+    case epochMismatch = "epoch-mismatch"
 }
 
 /**
@@ -320,4 +326,16 @@ public struct AuthErrorEvent: DocEvent {
      * AuthErrorEvent type
      */
     public let value: AuthErrorValue
+}
+
+public struct EpochMismatchValue: Equatable {
+    /// The API method whose response surfaced the epoch mismatch. Currently always `"PushPull"`.
+    public let method: String
+}
+
+/// `EpochMismatchEvent` is published when the server reports that the document was compacted and the
+/// client's epoch is stale. The client must detach and reattach the document to recover.
+public struct EpochMismatchEvent: DocEvent {
+    public let type: DocEventType = .epochMismatch
+    public let value: EpochMismatchValue
 }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -99,6 +99,7 @@ public class Document: Attachable {
     private var statusSubscribeCallback: SubscribeCallback?
     private var syncSubscribeCallback: SubscribeCallback?
     private var authErrorSubscribeCallback: SubscribeCallback?
+    private var epochMismatchSubscribeCallback: SubscribeCallback?
 
     /**
      * `onlineClients` is a set of client IDs that are currently online.
@@ -416,6 +417,15 @@ public class Document: Attachable {
     }
 
     /**
+     * `subscribeEpochMismatch` registers a callback to subscribe to events on the document.
+     * The callback will be called when an epoch mismatch error occurs (the document was compacted
+     * on the server); the client must detach and reattach the document to recover.
+     */
+    public func subscribeEpochMismatch(_ callback: @escaping SubscribeCallback) {
+        self.epochMismatchSubscribeCallback = callback
+    }
+
+    /**
      * `unsubscribe` unregisters a callback to subscribe to events on the document.
      */
     public func unsubscribe(_ targetPath: String? = nil) {
@@ -452,6 +462,13 @@ public class Document: Attachable {
      */
     public func unsubscribeAuthError() {
         self.authErrorSubscribeCallback = nil
+    }
+
+    /**
+     * `unsubscribeEpochMismatch` unregisters the epoch-mismatch callback.
+     */
+    public func unsubscribeEpochMismatch() {
+        self.epochMismatchSubscribeCallback = nil
     }
 
     /**
@@ -921,6 +938,10 @@ public class Document: Attachable {
         self.publish(authErrorEvent)
     }
 
+    func publishEpochMismatchEvent(method: String) {
+        self.publish(EpochMismatchEvent(value: EpochMismatchValue(method: method)))
+    }
+
     /**
      * `publish` triggers an event in this document, which can be received by
      * callback functions from document.subscribe().
@@ -973,6 +994,8 @@ public class Document: Attachable {
             self.subscribeCallbacks["$"]?(event, self)
         } else if let authErrorEvent = event as? AuthErrorEvent {
             self.authErrorSubscribeCallback?(authErrorEvent, self)
+        } else if let epochMismatchEvent = event as? EpochMismatchEvent {
+            self.epochMismatchSubscribeCallback?(epochMismatchEvent, self)
         } else if let event = event as? ChangeEvent {
             var operations = [String: [any OperationInfo]]()
 

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -584,6 +584,40 @@ public class JSONTree {
     }
 
     /**
+     * `styleByPath` sets the attributes to the elements in the given path range.
+     *
+     * The range form takes three arguments: `(fromPath, toPath, attributes)`. Calling
+     * ``styleByPath(_:_:)-`` with two arrays (e.g. `styleByPath([0], [1])`) resolves to the
+     * single-path overload (since `[Int]` is `Codable`) and styles `[0]` with `[1]` as attributes —
+     * to style a range, always pass the attributes as the third argument.
+     */
+    public func styleByPath(_ fromPath: [Int], _ toPath: [Int], _ attributes: Codable) throws {
+        try self.styleByPathRangeInternal(fromPath, toPath, StringValueTypeDictionary.stringifyAttributes(attributes))
+    }
+
+    public func styleByPath(_ fromPath: [Int], _ toPath: [Int], _ attributes: [String: Any]) throws {
+        try self.styleByPathRangeInternal(fromPath, toPath, attributes.stringValueTypeDictionary)
+    }
+
+    func styleByPathRangeInternal(_ fromPath: [Int], _ toPath: [Int], _ stringAttrs: [String: String]) throws {
+        guard let tree else {
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
+        }
+
+        if fromPath.count != toPath.count {
+            throw YorkieError(code: .errInvalidArgument, message: "path length should be equal")
+        }
+        if fromPath.isEmpty || toPath.isEmpty {
+            throw YorkieError(code: .errInvalidArgument, message: "path should not be empty")
+        }
+
+        let fromPos = try tree.pathToPos(fromPath)
+        let toPos = try tree.pathToPos(toPath)
+
+        try self.styleInternal(fromPos, toPos, stringAttrs)
+    }
+
+    /**
      * `style` sets the attributes to the elements of the given range.
      */
     public func style(_ fromIdx: Int, _ toIdx: Int, _ attributes: Codable) throws {
@@ -648,6 +682,27 @@ public class JSONTree {
         }
 
         let (fromPos, toPos) = try tree.pathToPosRange(path)
+
+        try self.removeStyleInternal(fromPos, toPos, attributesToRemove)
+    }
+
+    /**
+     * `removeStyleByPath` removes the attributes of the elements in the given path range.
+     */
+    public func removeStyleByPath(_ fromPath: [Int], _ toPath: [Int], _ attributesToRemove: [String]) throws {
+        guard let tree else {
+            throw YorkieError(code: .errNotInitialized, message: "\(type(of: self)) is not initialized yet")
+        }
+
+        if fromPath.count != toPath.count {
+            throw YorkieError(code: .errInvalidArgument, message: "path length should be equal")
+        }
+        if fromPath.isEmpty || toPath.isEmpty {
+            throw YorkieError(code: .errInvalidArgument, message: "path should not be empty")
+        }
+
+        let fromPos = try tree.pathToPos(fromPath)
+        let toPos = try tree.pathToPos(toPath)
 
         try self.removeStyleInternal(fromPos, toPos, attributesToRemove)
     }

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -89,6 +89,9 @@ struct YorkieError: Error, CustomStringConvertible {
         // ErrUnauthenticated is returned when the request does not have valid authentication credentials.
         case errUnauthenticated = "ErrUnauthenticated"
 
+        // ErrEpochMismatch is returned when the document has been compacted and the client's epoch no longer matches the server's epoch.
+        case errEpochMismatch = "ErrEpochMismatch"
+
         // ErrTooManyAttachments is returned when the number of attachments exceeds the limit.
         case errTooManyAttachments = "ErrTooManyAttachments"
 

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.2"
+let yorkieVersion = "0.7.3"

--- a/Tests/Unit/Document/EpochMismatchEventTests.swift
+++ b/Tests/Unit/Document/EpochMismatchEventTests.swift
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ports the epoch-mismatch event wiring from yorkie-js-sdk 0.7.3 (#1193):
+//   .doc/js-0.7.3/tests/epoch_mismatch_test.ts
+//
+// The JS test requires a running Yorkie server with admin CompactDocumentByAdmin
+// support (yorkie-team/yorkie#1714) to trigger an actual epoch mismatch over the
+// network. That server-compaction scenario cannot be reproduced in a unit test.
+// These tests instead verify the iOS event-subscription wiring deterministically:
+//   - subscribeEpochMismatch registers a callback
+//   - publishEpochMismatchEvent fires it with the correct EpochMismatchEvent
+//   - unsubscribeEpochMismatch de-registers the callback
+//   - EpochMismatchValue and EpochMismatchEvent carry the expected field values
+//
+// The full integration scenario (push-pull → server returns ErrEpochMismatch →
+// client emits the event → caller detaches and reattaches) requires a live server
+// and is not covered here.
+
+import XCTest
+@testable import Yorkie
+
+final class EpochMismatchEventTests: XCTestCase {
+    // MARK: - Event wiring
+
+    /// Verifies that subscribing to epoch-mismatch and publishing the event
+    /// invokes the callback exactly once with the correct event type and method.
+    ///
+    /// Mirrors JS assertion:
+    ///   `expect(event.type).toBe(DocEventType.EpochMismatch)`
+    ///   `expect(event.value.method).toBe("PushPull")`
+    @MainActor
+    func test_subscribe_epoch_mismatch_fires_callback_with_correct_event() {
+        // given
+        let doc = Document(key: "epoch-mismatch-wiring")
+        var receivedEvent: EpochMismatchEvent?
+        var callCount = 0
+
+        doc.subscribeEpochMismatch { event, _ in
+            receivedEvent = event as? EpochMismatchEvent
+            callCount += 1
+        }
+
+        // when
+        doc.publishEpochMismatchEvent(method: "PushPull")
+
+        // then
+        XCTAssertEqual(callCount, 1)
+        XCTAssertNotNil(receivedEvent)
+        XCTAssertEqual(receivedEvent?.type, .epochMismatch)
+        XCTAssertEqual(receivedEvent?.value.method, "PushPull")
+    }
+
+    /// Verifies that unsubscribeEpochMismatch prevents further callbacks.
+    @MainActor
+    func test_unsubscribe_epoch_mismatch_stops_callback() {
+        // given
+        let doc = Document(key: "epoch-mismatch-unsub")
+        var callCount = 0
+
+        doc.subscribeEpochMismatch { _, _ in
+            callCount += 1
+        }
+
+        // when — first publish reaches the subscriber
+        doc.publishEpochMismatchEvent(method: "PushPull")
+        XCTAssertEqual(callCount, 1)
+
+        // when — unsubscribe, then publish again
+        doc.unsubscribeEpochMismatch()
+        doc.publishEpochMismatchEvent(method: "PushPull")
+
+        // then — second publish is not delivered
+        XCTAssertEqual(callCount, 1)
+    }
+
+    /// Verifies that publishing without any subscriber does not crash.
+    @MainActor
+    func test_publish_epoch_mismatch_without_subscriber_does_not_crash() {
+        // given
+        let doc = Document(key: "epoch-mismatch-no-sub")
+
+        // when / then — must not crash
+        doc.publishEpochMismatchEvent(method: "PushPull")
+    }
+
+    // MARK: - Value types
+
+    /// Verifies EpochMismatchValue carries the method string correctly.
+    func test_epoch_mismatch_value_holds_method() {
+        // given / when
+        let value = EpochMismatchValue(method: "PushPull")
+
+        // then
+        XCTAssertEqual(value.method, "PushPull")
+    }
+
+    /// Verifies EpochMismatchEvent exposes the correct DocEventType.
+    func test_epoch_mismatch_event_has_correct_type() {
+        // given / when
+        let event = EpochMismatchEvent(value: EpochMismatchValue(method: "PushPull"))
+
+        // then
+        XCTAssertEqual(event.type, DocEventType.epochMismatch)
+    }
+
+    /// Verifies the DocEventType raw value matches the JS string "epoch-mismatch".
+    func test_epoch_mismatch_doc_event_type_raw_value() {
+        XCTAssertEqual(DocEventType.epochMismatch.rawValue, "epoch-mismatch")
+    }
+
+    /// Verifies the YorkieError.Code for epoch mismatch matches the expected raw value.
+    func test_err_epoch_mismatch_error_code_raw_value() {
+        XCTAssertEqual(YorkieError.Code.errEpochMismatch.rawValue, "ErrEpochMismatch")
+    }
+
+    /// Verifies the callback receives the method string injected via publishEpochMismatchEvent.
+    @MainActor
+    func test_epoch_mismatch_callback_receives_injected_method() {
+        // given
+        let doc = Document(key: "epoch-mismatch-method-check")
+        var capturedMethod: String?
+
+        doc.subscribeEpochMismatch { event, _ in
+            capturedMethod = (event as? EpochMismatchEvent)?.value.method
+        }
+
+        // when
+        doc.publishEpochMismatchEvent(method: "WatchDocuments")
+
+        // then
+        XCTAssertEqual(capturedMethod, "WatchDocuments")
+    }
+}

--- a/Tests/Unit/Document/Json/TreeStyleByPathTests.swift
+++ b/Tests/Unit/Document/Json/TreeStyleByPathTests.swift
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ports the range-based styleByPath / removeStyleByPath test cases from
+// yorkie-js-sdk 0.7.3 (#1198):
+//   .doc/js-0.7.3/tests/tree_test_styleByPath_additions.ts
+//
+// All tests run locally without a server because they use a single Document
+// whose changes stay in-process (no client attach / sync needed).
+
+import XCTest
+@testable import Yorkie
+
+final class TreeStyleByPathTests: XCTestCase {
+    // MARK: - styleByPath range
+
+    /// Mirrors JS: "Can style a range by path"
+    ///
+    /// styleByPath([0], [2], { color: "red" }) styles both paragraph elements.
+    @MainActor
+    func test_can_style_a_range_by_path() throws {
+        // given
+        let doc = Document(key: "tree-style-range-1")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")],
+                                        attributes: ["weight": "bold"]),
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "b")])
+                ])
+            )
+        }
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.styleByPath([0], [2], ["color": "red"])
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p color=\"red\" weight=\"bold\">a</p><p color=\"red\">b</p></doc>")
+    }
+
+    /// Mirrors JS: "Can style multiple elements across a range by path"
+    ///
+    /// styleByPath([0], [2], { bold: "true" }) applies to both paragraphs.
+    @MainActor
+    func test_can_style_multiple_elements_across_a_range_by_path() throws {
+        // given
+        let doc = Document(key: "tree-style-range-2")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "cd")])
+                ])
+            )
+        }
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.styleByPath([0], [2], ["bold": "true"])
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p bold=\"true\">ab</p><p bold=\"true\">cd</p></doc>")
+    }
+
+    /// Mirrors JS: "Can style single element by path (backward compat)"
+    ///
+    /// The single-path overload styleByPath([0], { bold: "true" }) still works.
+    @MainActor
+    func test_can_style_single_element_by_path_backward_compat() throws {
+        // given
+        let doc = Document(key: "tree-style-single-compat")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "hello")])
+                ])
+            )
+        }
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.styleByPath([0], ["bold": "true"])
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p bold=\"true\">hello</p></doc>")
+    }
+
+    // MARK: - removeStyleByPath range
+
+    /// Mirrors JS: "Can remove style by path"
+    ///
+    /// removeStyleByPath([0], [2], ["italic"]) removes italic from both paragraphs.
+    @MainActor
+    func test_can_remove_style_by_path() throws {
+        // given
+        let doc = Document(key: "tree-remove-style-range-1")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")],
+                                        attributes: ["bold": "true", "italic": "true"]),
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "b")],
+                                        attributes: ["bold": "true", "italic": "true"])
+                ])
+            )
+        }
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.removeStyleByPath([0], [2], ["italic"])
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p bold=\"true\">a</p><p bold=\"true\">b</p></doc>")
+    }
+
+    /// Mirrors JS: "Can remove style from multiple elements across a range by path"
+    ///
+    /// removeStyleByPath([0], [2], ["bold"]) strips bold from both paragraphs.
+    @MainActor
+    func test_can_remove_style_from_multiple_elements_across_a_range_by_path() throws {
+        // given
+        let doc = Document(key: "tree-remove-style-range-2")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "ab")],
+                                        attributes: ["bold": "true"]),
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "cd")],
+                                        attributes: ["bold": "true"])
+                ])
+            )
+        }
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.removeStyleByPath([0], [2], ["bold"])
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p>ab</p><p>cd</p></doc>")
+    }
+
+    // MARK: - Validation errors — styleByPath
+
+    /// Mirrors JS: "Should throw on mismatched path lengths for range styleByPath"
+    ///
+    /// styleByPath([0], [0, 0], ...) must throw because the path lengths differ (1 vs 2).
+    @MainActor
+    func test_should_throw_on_mismatched_path_lengths_for_range_style_by_path() throws {
+        // given
+        let doc = Document(key: "tree-style-path-length-mismatch")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")])
+                ])
+            )
+        }
+
+        // when / then
+        XCTAssertThrowsError(
+            try doc.update { root, _ in
+                try (root.t as? JSONTree)?.styleByPath([0], [0, 0], ["bold": "true"])
+            }
+        ) { error in
+            let yorkieError = error as? YorkieError
+            XCTAssertEqual(yorkieError?.code, .errInvalidArgument)
+        }
+    }
+
+    /// Mirrors JS: "Should throw on empty paths for styleByPath"
+    ///
+    /// styleByPath([], [], ...) must throw because paths are empty.
+    @MainActor
+    func test_should_throw_on_empty_paths_for_style_by_path() throws {
+        // given
+        let doc = Document(key: "tree-style-empty-paths")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")])
+                ])
+            )
+        }
+
+        // when / then
+        XCTAssertThrowsError(
+            try doc.update { root, _ in
+                try (root.t as? JSONTree)?.styleByPath([], [], ["bold": "true"])
+            }
+        ) { error in
+            let yorkieError = error as? YorkieError
+            XCTAssertEqual(yorkieError?.code, .errInvalidArgument)
+        }
+    }
+
+    // MARK: - Validation errors — removeStyleByPath
+
+    /// Mirrors JS: "Should throw on mismatched path lengths for removeStyleByPath"
+    ///
+    /// removeStyleByPath([0], [0, 0], ...) must throw because the path lengths differ.
+    @MainActor
+    func test_should_throw_on_mismatched_path_lengths_for_remove_style_by_path() throws {
+        // given
+        let doc = Document(key: "tree-remove-style-path-length-mismatch")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")],
+                                        attributes: ["bold": "true"])
+                ])
+            )
+        }
+
+        // when / then
+        XCTAssertThrowsError(
+            try doc.update { root, _ in
+                try (root.t as? JSONTree)?.removeStyleByPath([0], [0, 0], ["bold"])
+            }
+        ) { error in
+            let yorkieError = error as? YorkieError
+            XCTAssertEqual(yorkieError?.code, .errInvalidArgument)
+        }
+    }
+
+    /// Mirrors JS: "Should throw on empty paths for removeStyleByPath"
+    ///
+    /// removeStyleByPath([], [], ...) must throw because paths are empty.
+    @MainActor
+    func test_should_throw_on_empty_paths_for_remove_style_by_path() throws {
+        // given
+        let doc = Document(key: "tree-remove-style-empty-paths")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p",
+                                        children: [JSONTreeTextNode(value: "a")],
+                                        attributes: ["bold": "true"])
+                ])
+            )
+        }
+
+        // when / then
+        XCTAssertThrowsError(
+            try doc.update { root, _ in
+                try (root.t as? JSONTree)?.removeStyleByPath([], [], ["bold"])
+            }
+        ) { error in
+            let yorkieError = error as? YorkieError
+            XCTAssertEqual(yorkieError?.code, .errInvalidArgument)
+        }
+    }
+
+    /// Exercises the `[String: Any]` range overload (the dictionary-literal tests above resolve to
+    /// the `Codable` overload). An explicitly-typed `[String: Any]` routes through
+    /// `styleByPathRangeInternal` via `stringValueTypeDictionary`.
+    @MainActor
+    func test_can_style_a_range_by_path_with_string_any_attributes() throws {
+        // given
+        let doc = Document(key: "tree-style-range-stringany")
+
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")])
+                ])
+            )
+        }
+
+        // when
+        let attributes: [String: Any] = ["color": "red"]
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.styleByPath([0], [2], attributes)
+        }
+
+        // then
+        let xml = (doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xml, "<doc><p color=\"red\">a</p><p color=\"red\">b</p></doc>")
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.2'
+    image: 'yorkieteam/yorkie:0.7.3'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.2'
+    image: 'yorkieteam/yorkie:0.7.3'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Apply updates from yorkie-js-sdk `0.7.3` (`v0.7.2..v0.7.3`).

- **Add range-based styleByPath and removeStyleByPath for Tree** — ports yorkie-js-sdk#1198. Adds range overloads `styleByPath(fromPath, toPath, attributes)` and `removeStyleByPath(fromPath, toPath, attributesToRemove)` on `JSONTree`, styling/un-styling the element range between two equal-length, non-empty paths. The single-path forms are unchanged; the range forms delegate to the existing CRDT `style`/`removeStyle` via `pathToPos`.
- **Add epoch mismatch event for compaction recovery** — ports yorkie-js-sdk#1193. Adds `DocEventType.epochMismatch` / `EpochMismatchEvent`, `Document.subscribeEpochMismatch`, and a `YorkieError.Code.errEpochMismatch`. When a sync (PushPull) fails with that code, the client publishes the event and stops the retry loop; the app should detach and reattach the document to recover.

Upstream `0.7.3` also included yorkie-js-sdk#1190 (*Export Tree, Text and Counter from @yorkie-js/react*), which is React-package-only and has no iOS counterpart — not ported.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Behaviour verified against yorkie-js-sdk `v0.7.3` (#1198, #1193); no proto/wire changes.
- 431 unit tests pass, incl. 10 range-style tests and 8 epoch-mismatch event-wiring tests.
- Critic review passed (no High; two Medium addressed):
  - `styleByPath` overload note: because `[Int]` is `Codable`, a two-array call like `styleByPath([0], [1])` resolves to the single-path overload (styles `[0]` with `[1]` as attributes) rather than a range. The range form always requires the three-argument `(fromPath, toPath, attributes)` shape — documented in a doc comment to avoid the footgun (kept the JS-parity overload naming rather than a breaking rename).
  - The Client-side epoch-mismatch path (`publishEpochMismatchIfNeeded` / `handleConnectError`) is mirrored 1:1 from the existing, server-verified `AuthError` path. A full end-to-end test needs server-side document compaction (`CompactDocumentByAdmin`), which the local/CI test server does not yet support — the same way auth-error detection is covered only by `WebhookIntegrationTests` against a real server. Left as a documented integration gap to add once the server fixture exists.
- Gates: SwiftFormat 0.55.6 + SwiftLint 0.58.2 `--strict` clean, `swift build` green; CI server pin + docker images bumped to `0.7.3`.

**Does this PR introduce a user-facing change?**:

```release-note
Add range-based styleByPath and removeStyleByPath for Tree; add epoch mismatch event for compaction recovery
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.3

* **New Features**
  * Added range-based styling and style removal capabilities for Tree documents.
  * Added epoch mismatch event notification for handling document compaction recovery.

* **Tests**
  * Added comprehensive test coverage for epoch mismatch event handling and range-based styling operations.

* **Documentation**
  * Updated changelog for v0.7.3 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->