### PR TITLE
Apply updates from yorkie-js-sdk 0.7.4

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.3
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/bbda2dc5da3cc442d91fb6806e139cf630febd51/Formula/y/yorkie.rb"
+      # yorkie server v0.7.4
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5e33e48f8e8c04f80d8ab917256edf38d0a4109/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.3
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/bbda2dc5da3cc442d91fb6806e139cf630febd51/Formula/y/yorkie.rb"
+      # yorkie server v0.7.4
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5e33e48f8e8c04f80d8ab917256edf38d0a4109/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.4] - 2026-06-17
+
+- Fix tree style divergence on concurrent split via End-token guard in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Mirror tree merge snapshot encoding fix from Go SDK in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Fix SplitElement divergence on concurrent split inside merge range in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Fix split + delete divergence and splitElement tombstone handling in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Fix multi-level split + merge divergence via mergedFrom in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Fix split sibling convergence via position forwarding in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+- Fix convergence bugs in concurrent tree merge/split in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256
+
 ## [v0.7.3] - 2026-06-16
 
 - Add range-based styleByPath and removeStyleByPath for Tree in https://github.com/yorkie-team/yorkie-ios-sdk/pull/255

--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -253,7 +253,7 @@ extension ContentViewModel {
         guard self.document.canUndo else { return }
         do {
             try self.document.undo()
-            self.syncTextSnapShot()
+            self.syncTextSnapShot(force: true)
         } catch {
             Log.log("undo failed: \(error.localizedDescription)", level: .warning)
         }
@@ -265,7 +265,7 @@ extension ContentViewModel {
         guard self.document.canRedo else { return }
         do {
             try self.document.redo()
-            self.syncTextSnapShot()
+            self.syncTextSnapShot(force: true)
         } catch {
             Log.log("redo failed: \(error.localizedDescription)", level: .warning)
         }
@@ -642,19 +642,26 @@ extension NSMutableAttributedString {
 }
 
 extension ContentViewModel {
-    func syncTextSnapShot() {
-        Log.log("syncTextSnapShot", level: .debug)
+    /// Re-renders the editor from the document.
+    ///
+    /// - Parameter force: When true, always rebuilds the attributed string from the document and
+    ///   skips the unchanged-string shortcuts. Required after undo/redo: a style-only revert leaves
+    ///   the plain string unchanged, and a content revert can match the stale `content` cache, both
+    ///   of which would otherwise reuse the current on-screen text and drop the reverted state.
+    func syncTextSnapShot(force: Bool = false) {
+        Log.log("syncTextSnapShot force: \(force)", level: .debug)
         let content = self.document.getRoot().content as? JSONText
         guard let attributes = content?.values?.map({ $0.getAttributes() }) else { return }
+        let docString = content?.toString ?? ""
         let attributesString: NSMutableAttributedString
-        if self.content == (content?.toString ?? "") {
+        if !force, self.content == docString {
             attributesString = self.mutableAttributeString
         } else {
-            self.content = (content?.toString ?? "")
-            attributesString = NSMutableAttributedString(string: content!.toString)
+            self.content = docString
+            attributesString = NSMutableAttributedString(string: docString)
         }
-        if self.didFinishSync {
-            guard content?.toString != self.attributeString.string else {
+        if !force, self.didFinishSync {
+            guard docString != self.attributeString.string else {
                 print("nothing todo here!")
                 return
             }

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -987,6 +987,12 @@ extension Converter {
             if let id = node.insNextID {
                 pbTreeNode.insNextID = toTreeNodeID(id)
             }
+            if let mergedFrom = node.mergedFrom {
+                pbTreeNode.mergedFrom = toTreeNodeID(mergedFrom)
+            }
+            if let mergedAt = node.mergedAt {
+                pbTreeNode.mergedAt = toTimeTicket(mergedAt)
+            }
             if let ticket = node.removedAt {
                 pbTreeNode.removedAt = toTimeTicket(ticket)
             } else {
@@ -1082,6 +1088,8 @@ extension Converter {
         
         node.insPrevID = pbTreeNode.hasInsPrevID ? fromTreeNodeID(pbTreeNode.insPrevID) : nil
         node.insNextID = pbTreeNode.hasInsNextID ? fromTreeNodeID(pbTreeNode.insNextID) : nil
+        node.mergedFrom = pbTreeNode.hasMergedFrom ? fromTreeNodeID(pbTreeNode.mergedFrom) : nil
+        node.mergedAt = pbTreeNode.hasMergedAt ? fromTimeTicket(pbTreeNode.mergedAt) : nil
         node.removedAt = pbTreeNode.hasRemovedAt ? fromTimeTicket(pbTreeNode.removedAt) : nil
         
         return node

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -1535,6 +1535,30 @@ public struct Yorkie_V1_TreeNode: @unchecked Sendable {
     set {_uniqueStorage()._attributes = newValue}
   }
 
+  /// merged_from is set when this node was moved to a new parent by a
+  /// concurrent merge. It points to the source parent's ID.
+  public var mergedFrom: Yorkie_V1_TreeNodeID {
+    get {_storage._mergedFrom ?? Yorkie_V1_TreeNodeID()}
+    set {_uniqueStorage()._mergedFrom = newValue}
+  }
+  /// Returns true if `mergedFrom` has been explicitly set.
+  public var hasMergedFrom: Bool {_storage._mergedFrom != nil}
+  /// Clears the value of `mergedFrom`. Subsequent reads from it will return its default value.
+  public mutating func clearMergedFrom() {_uniqueStorage()._mergedFrom = nil}
+
+  /// merged_at records the immutable ticket of the merge operation.
+  /// Stored alongside merged_from because the source parent's removed_at
+  /// may be overwritten by later LWW tombstones and thus cannot serve as
+  /// the merge-time causal boundary for SplitElement.
+  public var mergedAt: Yorkie_V1_TimeTicket {
+    get {_storage._mergedAt ?? Yorkie_V1_TimeTicket()}
+    set {_uniqueStorage()._mergedAt = newValue}
+  }
+  /// Returns true if `mergedAt` has been explicitly set.
+  public var hasMergedAt: Bool {_storage._mergedAt != nil}
+  /// Clears the value of `mergedAt`. Subsequent reads from it will return its default value.
+  public mutating func clearMergedAt() {_uniqueStorage()._mergedAt = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -4625,7 +4649,7 @@ extension Yorkie_V1_TextNodeID: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TreeNode"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}type\0\u{1}value\0\u{3}removed_at\0\u{3}ins_prev_id\0\u{3}ins_next_id\0\u{1}depth\0\u{1}attributes\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}type\0\u{1}value\0\u{3}removed_at\0\u{3}ins_prev_id\0\u{3}ins_next_id\0\u{1}depth\0\u{1}attributes\0\u{3}merged_from\0\u{3}merged_at\0")
 
   fileprivate class _StorageClass {
     var _id: Yorkie_V1_TreeNodeID? = nil
@@ -4636,6 +4660,8 @@ extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     var _insNextID: Yorkie_V1_TreeNodeID? = nil
     var _depth: Int32 = 0
     var _attributes: Dictionary<String,Yorkie_V1_NodeAttr> = [:]
+    var _mergedFrom: Yorkie_V1_TreeNodeID? = nil
+    var _mergedAt: Yorkie_V1_TimeTicket? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -4654,6 +4680,8 @@ extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       _insNextID = source._insNextID
       _depth = source._depth
       _attributes = source._attributes
+      _mergedFrom = source._mergedFrom
+      _mergedAt = source._mergedAt
     }
   }
 
@@ -4680,6 +4708,8 @@ extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
         case 6: try { try decoder.decodeSingularMessageField(value: &_storage._insNextID) }()
         case 7: try { try decoder.decodeSingularInt32Field(value: &_storage._depth) }()
         case 8: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_NodeAttr>.self, value: &_storage._attributes) }()
+        case 9: try { try decoder.decodeSingularMessageField(value: &_storage._mergedFrom) }()
+        case 10: try { try decoder.decodeSingularMessageField(value: &_storage._mergedAt) }()
         default: break
         }
       }
@@ -4716,6 +4746,12 @@ extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       if !_storage._attributes.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_NodeAttr>.self, value: _storage._attributes, fieldNumber: 8)
       }
+      try { if let v = _storage._mergedFrom {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      } }()
+      try { if let v = _storage._mergedAt {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4733,6 +4769,8 @@ extension Yorkie_V1_TreeNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
         if _storage._insNextID != rhs_storage._insNextID {return false}
         if _storage._depth != rhs_storage._depth {return false}
         if _storage._attributes != rhs_storage._attributes {return false}
+        if _storage._mergedFrom != rhs_storage._mergedFrom {return false}
+        if _storage._mergedAt != rhs_storage._mergedAt {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -254,6 +254,14 @@ message TreeNode {
   TreeNodeID ins_next_id = 6;
   int32 depth = 7;
   map<string, NodeAttr> attributes = 8;
+  // merged_from is set when this node was moved to a new parent by a
+  // concurrent merge. It points to the source parent's ID.
+  TreeNodeID merged_from = 9;
+  // merged_at records the immutable ticket of the merge operation.
+  // Stored alongside merged_from because the source parent's removed_at
+  // may be overwritten by later LWW tombstones and thus cannot serve as
+  // the merge-time causal boundary for SplitElement.
+  TimeTicket merged_at = 10;
 }
 
 message TreeNodes {

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1059,7 +1059,7 @@ class CRDTTree: CRDTElement {
         var tokensToBeRemoved = [TreeToken<CRDTTreeNode>]()
         var toBeMovedToFromParents = [CRDTTreeNode]()
         var toBeMergedNodes = [CRDTTreeNode]()
-        try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { treeToken, ended in
+        try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft, includeRemoved: true) { treeToken, ended in
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
             let (node, tokenType) = treeToken
@@ -1460,12 +1460,12 @@ class CRDTTree: CRDTElement {
     /**
      * `toIndex` converts the given CRDTTreeNodeID to the index of the tree.
      */
-    func toIndex(_ parentNode: CRDTTreeNode, _ leftNode: CRDTTreeNode) throws -> Int {
-        guard let treePos = try self.toTreePos(parentNode, leftNode) else {
+    func toIndex(_ parentNode: CRDTTreeNode, _ leftNode: CRDTTreeNode, _ includeRemoved: Bool = false) throws -> Int {
+        guard let treePos = try self.toTreePos(parentNode, leftNode, includeRemoved) else {
             return -1
         }
 
-        return try self.indexTree.indexOf(treePos)
+        return try self.indexTree.indexOf(treePos, includeRemoved)
     }
 
     /**
@@ -1534,10 +1534,11 @@ class CRDTTree: CRDTElement {
                                     _ fromLeft: CRDTTreeNode,
                                     _ toParent: CRDTTreeNode,
                                     _ toLeft: CRDTTreeNode,
+                                    includeRemoved: Bool = false,
                                     callback: @escaping (TreeToken<CRDTTreeNode>, Bool) throws -> Void) throws
     {
-        let fromIdx = try self.toIndex(fromParent, fromLeft)
-        let toIdx = try self.toIndex(toParent, toLeft)
+        let fromIdx = try self.toIndex(fromParent, fromLeft, includeRemoved)
+        let toIdx = try self.toIndex(toParent, toLeft, includeRemoved)
 
         // When a concurrent merge redirects the to-position into an earlier part
         // of the tree, the range becomes empty (prior merge handled it).
@@ -1545,23 +1546,23 @@ class CRDTTree: CRDTElement {
             return
         }
 
-        return try self.indexTree.tokensBetween(fromIdx, toIdx, callback)
+        return try self.indexTree.tokensBetween(fromIdx, toIdx, includeRemoved, callback)
     }
 
     /**
      * `toTreePos` converts the given CRDTTreePos to local TreePos<CRDTTreeNode>.
      */
-    private func toTreePos(_ parentNode: CRDTTreeNode, _ leftNode: CRDTTreeNode) throws -> TreePos<CRDTTreeNode>? {
+    private func toTreePos(_ parentNode: CRDTTreeNode, _ leftNode: CRDTTreeNode, _ includeRemoved: Bool = false) throws -> TreePos<CRDTTreeNode>? {
         var parentNode = parentNode
 
-        if parentNode.isRemoved {
+        if !includeRemoved, parentNode.isRemoved {
             var childNode = parentNode
             while parentNode.isRemoved {
                 childNode = parentNode
                 parentNode = childNode.parent!
             }
 
-            let childOffset = try parentNode.findOffset(node: childNode)
+            let childOffset = try parentNode.findOffset(node: childNode, includeRemoved: includeRemoved)
 
             return TreePos(node: parentNode, offset: Int32(childOffset))
         }
@@ -1570,11 +1571,11 @@ class CRDTTree: CRDTElement {
             return TreePos(node: parentNode, offset: 0)
         }
 
-        var offset = try parentNode.findOffset(node: leftNode)
+        var offset = try parentNode.findOffset(node: leftNode, includeRemoved: includeRemoved)
 
-        if leftNode.isRemoved == false {
+        if includeRemoved || leftNode.isRemoved == false {
             if leftNode.isText {
-                return TreePos(node: leftNode, offset: Int32(leftNode.paddedSize))
+                return TreePos(node: leftNode, offset: Int32(leftNode.paddedLength(includeRemoved: includeRemoved)))
             }
 
             offset += 1

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1097,22 +1097,7 @@ class CRDTTree: CRDTElement {
                     // Cascade delete to split siblings created by concurrent
                     // SplitElement. Only for element nodes.
                     if !node.isText, node.insNextID != nil, !toBeMergedNodes.contains(where: { $0 === node }) {
-                        var nextID = node.insNextID
-                        while let id = nextID, let next = self.findFloorNode(id) {
-                            if !ticketKnown(versionVector, next.id.createdAt) {
-                                nodesToBeRemoved.append(next)
-                                // Cascade through the full subtree, not just immediate children.
-                                traverseAll(node: next) { descendant, _ in
-                                    if descendant !== next {
-                                        nodesToBeRemoved.append(descendant)
-                                    }
-                                }
-                            }
-                            if next.insNextID == nil {
-                                break
-                            }
-                            nextID = next.insNextID
-                        }
+                        nodesToBeRemoved.append(contentsOf: self.collectUnknownSplitSiblings(of: node, versionVector))
                     }
                 }
                 tokensToBeRemoved.append((node, tokenType))
@@ -1126,71 +1111,20 @@ class CRDTTree: CRDTElement {
         // 02. Delete: delete the nodes that are marked as removed.
         var pairs = [GCPair]()
         for node in nodesToBeRemoved {
-            if node.remove(editedAt) {
+            let didRemove = node.remove(editedAt)
+            if didRemove {
                 pairs.append(GCPair(parent: self, child: node))
             }
         }
 
-        // 03. Merge: move the nodes that are marked as moved. Only `mergedFrom`
-        // and `mergedAt` are written on the moved child — both are persisted in
-        // the snapshot encoding. `mergedAt` must be captured explicitly here
-        // (not read from source.removedAt at use time) because the source's
-        // `removedAt` is mutated by LWW when a later concurrent tombstone
-        // targets the same node.
-        for node in toBeMovedToFromParents where node.removedAt == nil {
-            if let parent = node.parent {
-                node.mergedFrom = parent.id
-                node.mergedAt = editedAt
-                // Detach from old parent to prevent ghost references. The child
-                // may already have been detached by a concurrent operation
-                // (e.g., cascade delete of split sibling), so ignore the error.
-                try? parent.detachChild(child: node)
-            }
-            try fromParent.append(contentsOf: [node])
-        }
-
-        // Set forwarding pointer on merge-source nodes. This is a runtime cache
-        // rebuilt from `mergedFrom` on snapshot load.
-        for src in toBeMergedNodes {
-            src.mergedInto = fromParent.id
-        }
+        // 03. Merge: move the nodes that are marked as moved, then set the
+        // forwarding pointer on merge-source nodes.
+        try self.applyMergeMoves(toBeMovedToFromParents, fromParent, toBeMergedNodes, editedAt)
 
         // 03-1. Propagate deletes to children moved by prior merges. When a
         // merge-source node is fully deleted (not a merge boundary), its former
-        // children in the merge target should also be deleted. Skip when
-        // `mergedInto` points to `fromParent` (concurrent merge). The list of
-        // moved children is recomputed on the fly from the merge target's
-        // children filtered by `mergedFrom`.
-        for node in nodesToBeRemoved {
-            guard let mergedInto = node.mergedInto,
-                  !toBeMergedNodes.contains(where: { $0 === node }),
-                  mergedInto != fromParent.id
-            else {
-                continue
-            }
-            guard let mergeTarget = self.findFloorNode(mergedInto) else {
-                continue
-            }
-            for targetChild in mergeTarget.innerChildren {
-                guard let childMergedFrom = targetChild.mergedFrom, childMergedFrom == node.id else {
-                    continue
-                }
-                if targetChild.removedAt != nil {
-                    continue
-                }
-                if targetChild.remove(editedAt) {
-                    pairs.append(GCPair(parent: self, child: targetChild))
-                }
-                // Also tombstone descendants if the moved child is an element.
-                traverseAll(node: targetChild) { descendant, _ in
-                    if descendant !== targetChild, descendant.removedAt == nil {
-                        if descendant.remove(editedAt) {
-                            pairs.append(GCPair(parent: self, child: descendant))
-                        }
-                    }
-                }
-            }
-        }
+        // children in the merge target should also be deleted.
+        pairs.append(contentsOf: self.propagateDeletesToMergedChildren(nodesToBeRemoved, fromParent, toBeMergedNodes, editedAt))
 
         // 04. Split: split the element nodes for the given split level.
         if splitLevel > 0 {
@@ -1273,6 +1207,98 @@ class CRDTTree: CRDTElement {
             }
         }
         return (changes, pairs, diff, nodesToBeRemoved, fromIdx)
+    }
+
+    /**
+     * `applyMergeMoves` moves each alive node marked for merge into `fromParent`,
+     * recording `mergedFrom`/`mergedAt` (both persisted in the snapshot encoding;
+     * `mergedAt` is captured here because the source's `removedAt` may be
+     * overwritten by a later LWW tombstone) and detaching it from its old parent.
+     * It then sets the `mergedInto` forwarding cache on the merge-source nodes.
+     */
+    private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) throws {
+        for node in toBeMovedToFromParents where node.removedAt == nil {
+            if let parent = node.parent {
+                node.mergedFrom = parent.id
+                node.mergedAt = editedAt
+                // Detach from old parent to prevent ghost references. The child
+                // may already have been detached by a concurrent operation
+                // (e.g., cascade delete of split sibling), so ignore the error.
+                try? parent.detachChild(child: node)
+            }
+            try fromParent.append(contentsOf: [node])
+        }
+
+        // Forwarding pointer rebuilt from `mergedFrom` on snapshot load.
+        for src in toBeMergedNodes {
+            src.mergedInto = fromParent.id
+        }
+    }
+
+    /**
+     * `collectUnknownSplitSiblings` walks the `insNextID` chain from the given
+     * node and collects the split siblings (and their subtrees) whose creation
+     * the editor did not know about, so they can be cascade-deleted alongside
+     * the node being removed.
+     */
+    private func collectUnknownSplitSiblings(of node: CRDTTreeNode, _ versionVector: VersionVector?) -> [CRDTTreeNode] {
+        var result = [CRDTTreeNode]()
+        var nextID = node.insNextID
+        while let id = nextID, let next = self.findFloorNode(id) {
+            if !ticketKnown(versionVector, next.id.createdAt) {
+                result.append(next)
+                // Cascade through the full subtree, not just immediate children.
+                traverseAll(node: next) { descendant, _ in
+                    if descendant !== next {
+                        result.append(descendant)
+                    }
+                }
+            }
+            if next.insNextID == nil {
+                break
+            }
+            nextID = next.insNextID
+        }
+        return result
+    }
+
+    /**
+     * `propagateDeletesToMergedChildren` tombstones the children (and their
+     * descendants) that a prior merge moved out of each fully-deleted
+     * merge-source node into its merge target. Skips merge boundaries and the
+     * concurrent-merge case where `mergedInto` points back at `fromParent`. The
+     * moved children are recomputed from the merge target's children filtered by
+     * `mergedFrom`. Returns the GC pairs for the newly tombstoned nodes.
+     */
+    private func propagateDeletesToMergedChildren(_ nodesToBeRemoved: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) -> [GCPair] {
+        var pairs = [GCPair]()
+        for node in nodesToBeRemoved {
+            guard let mergedInto = node.mergedInto,
+                  !toBeMergedNodes.contains(where: { $0 === node }),
+                  mergedInto != fromParent.id,
+                  let mergeTarget = self.findFloorNode(mergedInto)
+            else {
+                continue
+            }
+            for targetChild in mergeTarget.innerChildren {
+                guard let childMergedFrom = targetChild.mergedFrom,
+                      childMergedFrom == node.id,
+                      targetChild.removedAt == nil
+                else {
+                    continue
+                }
+                if targetChild.remove(editedAt) {
+                    pairs.append(GCPair(parent: self, child: targetChild))
+                }
+                // Also tombstone descendants if the moved child is an element.
+                traverseAll(node: targetChild) { descendant, _ in
+                    if descendant !== targetChild, descendant.removedAt == nil, descendant.remove(editedAt) {
+                        pairs.append(GCPair(parent: self, child: descendant))
+                    }
+                }
+            }
+        }
+        return pairs
     }
 
     /**

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -289,6 +289,29 @@ final class CRDTTreeNode: IndexTreeNode {
      */
     var insNextID: CRDTTreeNodeID?
 
+    /**
+     * `mergedFrom` records the source parent's ID when this node was moved by a
+     * concurrent merge. Persisted in the snapshot encoding as the witness of the
+     * merge relationship.
+     */
+    var mergedFrom: CRDTTreeNodeID?
+
+    /**
+     * `mergedAt` records the immutable ticket of the merge operation. Persisted
+     * alongside ``mergedFrom`` because the source parent's ``removedAt`` may be
+     * overwritten by later LWW tombstones and thus cannot serve as the
+     * merge-time causal boundary for the split's Fix 8 version-vector check.
+     */
+    var mergedAt: TimeTicket?
+
+    /**
+     * `mergedInto` is a runtime cache set on the source parent pointing at the
+     * merge target. Set locally during merge execution and rebuilt from
+     * ``mergedFrom`` on snapshot load. Used for the fast "is this tombstoned
+     * parent a merge source?" check when resolving insertion positions.
+     */
+    var mergedInto: CRDTTreeNodeID?
+
     init(id: CRDTTreeNodeID, type: TreeNodeType, value: NSString? = nil, children: [CRDTTreeNode]? = nil, attributes: RHT? = nil, removedAt: TimeTicket? = nil) {
         self.size = 0
         self.innerValue = ""
@@ -329,6 +352,9 @@ final class CRDTTreeNode: IndexTreeNode {
         }
         clone.insPrevID = self.insPrevID
         clone.insNextID = self.insNextID
+        clone.mergedFrom = self.mergedFrom
+        clone.mergedAt = self.mergedAt
+        clone.mergedInto = self.mergedInto
 
         return clone
     }
@@ -341,9 +367,12 @@ final class CRDTTreeNode: IndexTreeNode {
     }
 
     /**
-     * `remove` marks the node as removed.
+     * `remove` marks the node as removed. Returns true when this call
+     * transitions a previously-alive node to removed, so the caller can register
+     * a GC pair; a tombstone overwrite by LWW returns false.
      */
-    func remove(_ removedAt: TimeTicket) {
+    @discardableResult
+    func remove(_ removedAt: TimeTicket) -> Bool {
         let alived = !self.isRemoved
 
         if self.removedAt == nil || removedAt <= self.removedAt! {
@@ -352,16 +381,22 @@ final class CRDTTreeNode: IndexTreeNode {
 
         if alived {
             self.updateAncestorsSize()
+            return true
         }
+
+        return false
     }
 
     /**
      * `cloneText` clones this text node with the given offset.
      */
     func cloneText(offset: Int32) -> CRDTTreeNode {
-        CRDTTreeNode(id: CRDTTreeNodeID(createdAt: self.id.createdAt, offset: offset),
-                     type: self.type,
-                     removedAt: self.removedAt)
+        let clone = CRDTTreeNode(id: CRDTTreeNodeID(createdAt: self.id.createdAt, offset: offset),
+                                 type: self.type,
+                                 removedAt: self.removedAt)
+        clone.mergedFrom = self.mergedFrom
+        clone.mergedAt = self.mergedAt
+        return clone
     }
 
     /**
@@ -374,19 +409,36 @@ final class CRDTTreeNode: IndexTreeNode {
     }
 
     /**
+     * `shouldStayLeftOnSplit` keeps a concurrent merge-moved child in the
+     * original (left) node during a split when the merge is unknown to the
+     * editor and the merge source is local to this node (one of `siblings`).
+     */
+    func shouldStayLeftOnSplit(_ child: CRDTTreeNode, siblings: [CRDTTreeNode], versionVector: VersionVector?) -> Bool {
+        guard let mergedFrom = child.mergedFrom, let mergedAt = child.mergedAt else {
+            return false
+        }
+        guard let versionVector, !versionVector.afterOrEqual(other: mergedAt) else {
+            return false
+        }
+
+        return siblings.contains { $0.id == mergedFrom }
+    }
+
+    /**
      * `split` splits the given offset of this node.
      */
     @discardableResult
     func split(
         _ tree: CRDTTree,
         _ offset: Int32,
-        _ issueTimeTicket: TimeTicket? = nil
+        _ issueTimeTicket: TimeTicket? = nil,
+        _ versionVector: VersionVector? = nil
     ) throws -> (CRDTTreeNode?, DataSize) {
         if self.isText == false, issueTimeTicket == nil {
             throw YorkieError(code: .errInvalidArgument, message: "The issueTimeTicket for Text Node have to nil!")
         }
 
-        let (split, diff) = self.isText ? try self.splitText(offset, self.id.offset) : try self.splitElement(offset, issueTimeTicket!)
+        let (split, diff) = self.isText ? try self.splitText(offset, self.id.offset) : try self.splitElement(offset, issueTimeTicket!, versionVector)
 
         if split != nil {
             split?.insPrevID = self.id
@@ -602,6 +654,22 @@ extension CRDTTreeNode: GCChild {
 }
 
 /**
+ * `ticketKnown` returns true if the given ticket is causally known to the
+ * editor, i.e. the editor's version vector covers the ticket's lamport clock
+ * for the same actor. For local operations (no version vector), all tickets are
+ * considered known.
+ */
+private func ticketKnown(_ versionVector: VersionVector?, _ ticket: TimeTicket) -> Bool {
+    guard let versionVector else {
+        return true
+    }
+    guard let lamport = versionVector.get(ticket.actorID) else {
+        return false
+    }
+    return lamport >= ticket.lamport
+}
+
+/**
  * `CRDTTree` is a CRDT implementation of a tree.
  */
 class CRDTTree: CRDTElement {
@@ -620,6 +688,41 @@ class CRDTTree: CRDTElement {
         self.indexTree.traverseAll { node, _ in
             self.nodeMapByID.put(node.id, node)
         }
+
+        // Rebuild runtime merge state from the persisted `mergedFrom` field.
+        // Only `mergedFrom` and `mergedAt` are written to the snapshot encoding;
+        // `mergedInto` is a cache reconstructed here so replicas loaded from a
+        // snapshot can still handle concurrent ops that target merged-away
+        // parents (redirect, propagation, split skip).
+        self.rebuildMergeState()
+    }
+
+    /**
+     * `rebuildMergeState` reconstructs the `mergedInto` cache on source parents
+     * from the persisted ``CRDTTreeNode/mergedFrom`` field on moved children.
+     * For snapshots written before `mergedAt` was added to the proto, it also
+     * falls back to the source's `removedAt` — an approximation that may be
+     * wrong if the source was later overwritten by a concurrent delete, but it
+     * is the best available without the persisted merge ticket.
+     */
+    private func rebuildMergeState() {
+        self.indexTree.traverseAll { node, _ in
+            guard let mergedFrom = node.mergedFrom, let parent = node.parent else {
+                return
+            }
+            guard let src = self.findFloorNode(mergedFrom) else {
+                return
+            }
+
+            // Back-compat: older snapshots lack mergedAt on moved children.
+            if node.mergedAt == nil, let removedAt = src.removedAt {
+                node.mergedAt = removedAt
+            }
+
+            if src.mergedInto == nil {
+                src.mergedInto = parent.id
+            }
+        }
     }
 
     /**
@@ -631,6 +734,67 @@ class CRDTTree: CRDTElement {
         }
 
         return entry.value
+    }
+
+    /**
+     * `advancePastUnknownSplitSiblings` follows the `insNextID` chain of the
+     * given node, advancing past element-type split siblings that the editing
+     * client did not know about (not in `versionVector`).
+     */
+    private func advancePastUnknownSplitSiblings(_ node: CRDTTreeNode, _ versionVector: VersionVector?) -> CRDTTreeNode {
+        guard let versionVector else {
+            return node
+        }
+
+        var current = node
+        while let insNextID = current.insNextID {
+            guard let next = self.findFloorNode(insNextID), !next.isText else {
+                break
+            }
+
+            // Stop if the sibling has been moved to a different parent
+            // (e.g., by a higher-level concurrent split).
+            if next.parent !== current.parent {
+                break
+            }
+
+            let actorID = next.id.createdAt.actorID
+            if let knownLamport = versionVector.get(actorID), knownLamport >= next.id.createdAt.lamport {
+                break
+            }
+
+            current = next
+        }
+
+        return current
+    }
+
+    /**
+     * `hasUnknownSplitSibling` checks whether the given element node has a split
+     * sibling (via `insNextID`) whose creation the editor did not know about.
+     * Used to prevent styling via End tokens when a concurrent split extended
+     * the range into the split sibling.
+     */
+    private func hasUnknownSplitSibling(_ node: CRDTTreeNode, _ versionVector: VersionVector) -> Bool {
+        guard let insNextID = node.insNextID else {
+            return false
+        }
+
+        guard let next = self.findFloorNode(insNextID), !next.isText else {
+            return false
+        }
+
+        // NOTE: Unlike advancePastUnknownSplitSiblings, the parent-equality
+        // check is intentionally omitted. In multi-level splits (splitLevel>=2),
+        // the split sibling may have been moved to a different parent by the
+        // recursive ancestor split. The End-token guard must still fire because
+        // the node WAS split — insNextID is only set by SplitElement.
+        let actorID = next.id.createdAt.actorID
+        guard let knownLamport = versionVector.get(actorID) else {
+            return true
+        }
+
+        return knownLamport < next.id.createdAt.lamport
     }
 
     /**
@@ -661,6 +825,28 @@ class CRDTTree: CRDTElement {
         // in the current tree.
         let isLeftMost = parent === leftNode
         let realParent = leftNode.parent != nil && !isLeftMost ? leftNode.parent! : parent
+
+        // 02-1. If the parent has been tombstoned by a merge, redirect to the
+        // merge destination using the forwarding pointer. The insertion boundary
+        // is the first child in the target whose `mergedFrom` points back at the
+        // tombstoned parent (i.e. the first child moved by the merge, in target
+        // child order).
+        if realParent.isRemoved, isLeftMost, let mergedInto = realParent.mergedInto {
+            if let mergeTarget = self.findFloorNode(mergedInto), !mergeTarget.isRemoved {
+                let allChildren = mergeTarget.innerChildren
+                for (index, targetChild) in allChildren.enumerated() {
+                    guard let childMergedFrom = targetChild.mergedFrom, childMergedFrom == realParent.id else {
+                        continue
+                    }
+                    if index == 0 {
+                        return ((mergeTarget, mergeTarget), diff)
+                    }
+                    return ((mergeTarget, allChildren[index - 1]), diff)
+                }
+                // Fallback: insert at leftmost of merge target.
+                return ((mergeTarget, mergeTarget), diff)
+            }
+        }
 
         // 03. Split text node if the left node is a text node.
         if leftNode.isText {
@@ -698,9 +884,14 @@ class CRDTTree: CRDTElement {
         _ versionVector: VersionVector?
     ) throws -> ([GCPair], [TreeChange], DataSize) {
         var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeft), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
-        let ((toParent, toLeft), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
         diff.addDataSizes(others: fromDiff, toDiff)
+
+        // Advance past split siblings unknown to the editing client so the range
+        // covers all concurrent split products. Skip when leftNode == parent.
+        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
+        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
@@ -716,6 +907,13 @@ class CRDTTree: CRDTElement {
                 editedAt,
                 clientLamportAtChange
             ), !node.isText, let attributes {
+                // Skip styling via End token when the node has an unknown split
+                // sibling. The End token is in the range only because a
+                // concurrent split extended the range into the sibling.
+                if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
+                    return
+                }
+
                 let updatedAttrPairs = node.setAttrs(attributes, editedAt)
                 var affectedAttrs = [String: String]()
                 for (_, curr) in updatedAttrPairs {
@@ -766,15 +964,21 @@ class CRDTTree: CRDTElement {
         _ versionVector: VersionVector? = nil
     ) throws -> ([GCPair], [TreeChange], DataSize) {
         var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeft), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
-        let ((toParent, toLeft), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
         diff.addDataSizes(others: fromDiff, toDiff)
+
+        // Advance past split siblings unknown to the editing client so the range
+        // covers all concurrent split products. Skip when leftNode == parent.
+        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
+        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
+
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
         let value = TreeChangeValue.attributesToRemove(attributesToRemove)
 
         try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { token, _ in
-            let (node, _) = token
+            let (node, tokenType) = token
             let actorID = node.createdAt.actorID
             var clientLamportAtChange: Int64 = .max
 
@@ -785,6 +989,13 @@ class CRDTTree: CRDTElement {
                 editedAt,
                 clientLamportAtChange
             ), !attributesToRemove.isEmpty {
+                // Skip styling via End token when the node has an unknown split
+                // sibling. The End token is in the range only because a
+                // concurrent split extended the range into the sibling.
+                if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
+                    return
+                }
+
                 if node.attrs == nil {
                     node.attrs = RHT()
                 }
@@ -828,9 +1039,18 @@ class CRDTTree: CRDTElement {
     ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeft), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
-        let ((toParent, toLeft), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
         diff.addDataSizes(others: fromDiff, toDiff)
+
+        // 01-1. Advance past split siblings unknown to the editing client.
+        // When a concurrent SplitElement created siblings linked via insNextID,
+        // the editor's position was computed against the unsplit tree. Advance
+        // past siblings the editor could not have seen so that the range
+        // starts/ends after all concurrent split products. Skip when
+        // leftNode == parent (leftmost child position).
+        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
+        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
         let fromIdx = try self.toIndex(fromParent, fromLeft)
         let fromPath = try self.toPath(fromParent, fromLeft)
@@ -838,45 +1058,62 @@ class CRDTTree: CRDTElement {
         var nodesToBeRemoved = [CRDTTreeNode]()
         var tokensToBeRemoved = [TreeToken<CRDTTreeNode>]()
         var toBeMovedToFromParents = [CRDTTreeNode]()
+        var toBeMergedNodes = [CRDTTreeNode]()
         try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { treeToken, ended in
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
             let (node, tokenType) = treeToken
             if tokenType == .start, !ended {
-                // TODO(hackerwins): Define more clearly merge-able rules
-                // between two parents. For now, we only merge two parents are
-                // both element nodes having text children.
-                // e.g. <p>a|b</p><p>c|d</p> -> <p>a|d</p>
-                // if (!fromParent.hasTextChild() || !toParent.hasTextChild()) {
-                //   return;
-                // }
-
-                toBeMovedToFromParents.append(contentsOf: node.children)
+                // Fix 9: Skip merge for elements created by concurrent
+                // operations. The editor didn't know about this element, so
+                // crossing into it is an artifact of a concurrent split, not an
+                // intentional merge.
+                if ticketKnown(versionVector, node.createdAt) {
+                    toBeMergedNodes.append(node)
+                    toBeMovedToFromParents.append(contentsOf: node.children)
+                }
             }
 
-            let actorID = node.createdAt.actorID
+            // NOTE(sigmaith): Determine if the node's creation event was visible.
+            let creationKnown = ticketKnown(versionVector, node.createdAt)
+
+            // NOTE(sigmaith): Determine if existing tombstone was already causally known.
+            let tombstoneKnown = node.removedAt != nil && ticketKnown(versionVector, node.removedAt!)
+
             // NOTE(sejongk): If the node is removable or its parent is going to
-            // be removed, then this node should be removed.
-
-            let isLocal = versionVector == nil
-            var creationKnown = isLocal
-            var tombstoneKnown = false
-
-            if let versionVector {
-                let clientLamportAtChange = versionVector.get(actorID) ?? 0
-                creationKnown = node.createdAt.lamport <= clientLamportAtChange
-                tombstoneKnown = node.isRemoved && (isLocal || versionVector.afterOrEqual(other: node.removedAt!))
-            }
-
+            // be removed, then this node should be removed. Do not cascade-delete
+            // children of merge-boundary nodes (toBeMergedNodes), because those
+            // children are moved rather than deleted.
             if node.canDelete(
                 editedAt,
                 creationKnown,
                 tombstoneKnown
-            ) || nodesToBeRemoved.contains(where: { $0 === node.parent }) {
+            ) || (nodesToBeRemoved.contains(where: { $0 === node.parent }) && !toBeMergedNodes.contains(where: { $0 === node.parent })) {
                 // NOTE(hackerwins): If the node overlaps as an end token with the
                 // range then we need to keep the node.
                 if tokenType == .text || tokenType == .start {
                     nodesToBeRemoved.append(node)
+
+                    // Cascade delete to split siblings created by concurrent
+                    // SplitElement. Only for element nodes.
+                    if !node.isText, node.insNextID != nil, !toBeMergedNodes.contains(where: { $0 === node }) {
+                        var nextID = node.insNextID
+                        while let id = nextID, let next = self.findFloorNode(id) {
+                            if !ticketKnown(versionVector, next.id.createdAt) {
+                                nodesToBeRemoved.append(next)
+                                // Cascade through the full subtree, not just immediate children.
+                                traverseAll(node: next) { descendant, _ in
+                                    if descendant !== next {
+                                        nodesToBeRemoved.append(descendant)
+                                    }
+                                }
+                            }
+                            if next.insNextID == nil {
+                                break
+                            }
+                            nextID = next.insNextID
+                        }
+                    }
                 }
                 tokensToBeRemoved.append((node, tokenType))
             }
@@ -889,15 +1126,71 @@ class CRDTTree: CRDTElement {
         // 02. Delete: delete the nodes that are marked as removed.
         var pairs = [GCPair]()
         for node in nodesToBeRemoved {
-            node.remove(editedAt)
-
-            if node.isRemoved {
+            if node.remove(editedAt) {
                 pairs.append(GCPair(parent: self, child: node))
             }
         }
 
-        // 03. Merge: move the nodes that are marked as moved.
-        try fromParent.append(contentsOf: toBeMovedToFromParents.filter { $0.removedAt == nil })
+        // 03. Merge: move the nodes that are marked as moved. Only `mergedFrom`
+        // and `mergedAt` are written on the moved child — both are persisted in
+        // the snapshot encoding. `mergedAt` must be captured explicitly here
+        // (not read from source.removedAt at use time) because the source's
+        // `removedAt` is mutated by LWW when a later concurrent tombstone
+        // targets the same node.
+        for node in toBeMovedToFromParents where node.removedAt == nil {
+            if let parent = node.parent {
+                node.mergedFrom = parent.id
+                node.mergedAt = editedAt
+                // Detach from old parent to prevent ghost references. The child
+                // may already have been detached by a concurrent operation
+                // (e.g., cascade delete of split sibling), so ignore the error.
+                try? parent.detachChild(child: node)
+            }
+            try fromParent.append(contentsOf: [node])
+        }
+
+        // Set forwarding pointer on merge-source nodes. This is a runtime cache
+        // rebuilt from `mergedFrom` on snapshot load.
+        for src in toBeMergedNodes {
+            src.mergedInto = fromParent.id
+        }
+
+        // 03-1. Propagate deletes to children moved by prior merges. When a
+        // merge-source node is fully deleted (not a merge boundary), its former
+        // children in the merge target should also be deleted. Skip when
+        // `mergedInto` points to `fromParent` (concurrent merge). The list of
+        // moved children is recomputed on the fly from the merge target's
+        // children filtered by `mergedFrom`.
+        for node in nodesToBeRemoved {
+            guard let mergedInto = node.mergedInto,
+                  !toBeMergedNodes.contains(where: { $0 === node }),
+                  mergedInto != fromParent.id
+            else {
+                continue
+            }
+            guard let mergeTarget = self.findFloorNode(mergedInto) else {
+                continue
+            }
+            for targetChild in mergeTarget.innerChildren {
+                guard let childMergedFrom = targetChild.mergedFrom, childMergedFrom == node.id else {
+                    continue
+                }
+                if targetChild.removedAt != nil {
+                    continue
+                }
+                if targetChild.remove(editedAt) {
+                    pairs.append(GCPair(parent: self, child: targetChild))
+                }
+                // Also tombstone descendants if the moved child is an element.
+                traverseAll(node: targetChild) { descendant, _ in
+                    if descendant !== targetChild, descendant.removedAt == nil {
+                        if descendant.remove(editedAt) {
+                            pairs.append(GCPair(parent: self, child: descendant))
+                        }
+                    }
+                }
+            }
+        }
 
         // 04. Split: split the element nodes for the given split level.
         if splitLevel > 0 {
@@ -905,7 +1198,7 @@ class CRDTTree: CRDTElement {
             var parent = fromParent
             var left = fromLeft
             while splitCount < splitLevel {
-                try parent.split(self, Int32(parent.findOffset(node: left) + 1), issueTimeTicket())
+                try parent.split(self, Int32(parent.findOffset(node: left) + 1), issueTimeTicket(), versionVector)
                 left = parent
                 parent = parent.parent!
                 splitCount += 1
@@ -1219,6 +1512,12 @@ class CRDTTree: CRDTElement {
     {
         let fromIdx = try self.toIndex(fromParent, fromLeft)
         let toIdx = try self.toIndex(toParent, toLeft)
+
+        // When a concurrent merge redirects the to-position into an earlier part
+        // of the tree, the range becomes empty (prior merge handled it).
+        if fromIdx > toIdx {
+            return
+        }
 
         return try self.indexTree.tokensBetween(fromIdx, toIdx, callback)
     }

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -88,17 +88,17 @@ enum DefaultTreeNodeType: String {
 /**
  * `addSizeOfLeftSiblings` returns the size of left siblings of the given offset.
  */
-func addSizeOfLeftSiblings<T: IndexTreeNode>(parent: T, offset: Int) -> Int {
+func addSizeOfLeftSiblings<T: IndexTreeNode>(parent: T, offset: Int, includeRemoved: Bool = false) -> Int {
     var acc = 0
 
-    let siblings = parent.children
+    let siblings = includeRemoved ? parent.innerChildren : parent.children
 
     for leftSibling in siblings.prefix(upTo: offset) {
-        if leftSibling.isRemoved {
+        if !includeRemoved, leftSibling.isRemoved {
             continue
         }
 
-        acc += leftSibling.paddedSize
+        acc += leftSibling.paddedLength(includeRemoved: includeRemoved)
     }
 
     return acc
@@ -187,6 +187,26 @@ extension IndexTreeNode {
      */
     var paddedSize: Int {
         self.size + (self.isText ? 0 : elementPaddingSize)
+    }
+
+    /**
+     * `nodeLength` returns the node's size under the given tombstone policy.
+     * Visible (`false`) uses the maintained `size`; total (`true`) sums the raw
+     * children, mirroring yorkie-js-sdk's `totalSize` — iOS keeps only a single
+     * (visible) `size`, so the total is computed on the fly.
+     */
+    func nodeLength(includeRemoved: Bool) -> Int {
+        if !includeRemoved || self.isText {
+            return self.size
+        }
+        return self.innerChildren.reduce(0) { $0 + $1.paddedLength(includeRemoved: true) }
+    }
+
+    /**
+     * `paddedLength` returns ``nodeLength(includeRemoved:)`` plus element padding.
+     */
+    func paddedLength(includeRemoved: Bool) -> Int {
+        self.nodeLength(includeRemoved: includeRemoved) + (self.isText ? 0 : elementPaddingSize)
     }
 
     /**
@@ -518,8 +538,16 @@ extension IndexTreeNode {
      * It excludes the removed nodes.
      */
     func findOffset(node: Self) throws -> Int {
+        try self.findOffset(node: node, includeRemoved: false)
+    }
+
+    func findOffset(node: Self, includeRemoved: Bool) throws -> Int {
         guard self.isText == false else {
             throw YorkieError(code: .errRefused, message: "Text node cannot have children")
+        }
+
+        if includeRemoved {
+            return self.innerChildren.firstIndex(where: { $0 === node }) ?? -1
         }
 
         if node.isRemoved {
@@ -654,18 +682,20 @@ typealias TreeToken<T> = (T, TokenType)
 func tokensBetween<T: IndexTreeNode>(root: T,
                                      from: Int,
                                      to: Int,
+                                     includeRemoved: Bool = false,
                                      callback: @escaping (TreeToken<T>, Bool) throws -> Void) throws
 {
     if from > to {
         throw YorkieError(code: .errInvalidArgument, message: "from is greater than to: \(from) > \(to)")
     }
 
-    if from > root.size {
-        throw YorkieError(code: .errInvalidArgument, message: "from is out of range: \(from) > \(root.size)")
+    let rootSize = root.nodeLength(includeRemoved: includeRemoved)
+    if from > rootSize {
+        throw YorkieError(code: .errInvalidArgument, message: "from is out of range: \(from) > \(rootSize)")
     }
 
-    if to > root.size {
-        throw YorkieError(code: .errInvalidArgument, message: "to is out of range: \(to) > \(root.size)")
+    if to > rootSize {
+        throw YorkieError(code: .errInvalidArgument, message: "to is out of range: \(to) > \(rootSize)")
     }
 
     if from == to {
@@ -673,9 +703,11 @@ func tokensBetween<T: IndexTreeNode>(root: T,
     }
 
     var pos = 0
-    for child in root.children {
+    let children = includeRemoved ? root.innerChildren : root.children
+    for child in children {
+        let childPaddedSize = child.paddedLength(includeRemoved: includeRemoved)
         // If the child is an element node, the size of the child.
-        if from - child.paddedSize < pos, pos < to {
+        if from - childPaddedSize < pos, pos < to {
             // If the child is an element node, the range of the child
             // is from - 1 to to - 1. Because the range of the element node is from
             // the open tag to the close tag.
@@ -684,15 +716,17 @@ func tokensBetween<T: IndexTreeNode>(root: T,
 
             // If the range spans outside the child,
             // the callback is called with the child.
+            let childSize = child.nodeLength(includeRemoved: includeRemoved)
             let startContained = !child.isText && fromChild < 0
-            let endContained = !child.isText && toChild > child.size
+            let endContained = !child.isText && toChild > childSize
             if child.isText || startContained {
                 try callback((child, child.isText ? .text : .start), endContained)
             }
 
             try tokensBetween(root: child,
                               from: max(0, fromChild),
-                              to: min(toChild, child.size),
+                              to: min(toChild, childSize),
+                              includeRemoved: includeRemoved,
                               callback: callback)
 
             if endContained {
@@ -700,7 +734,7 @@ func tokensBetween<T: IndexTreeNode>(root: T,
             }
         }
 
-        pos += child.paddedSize
+        pos += childPaddedSize
     }
 }
 
@@ -866,8 +900,8 @@ class IndexTree<T: IndexTreeNode> {
     /**
      * `tokensBetween` returns the nodes between the given range.
      */
-    func tokensBetween(_ from: Int, _ to: Int, _ callback: @escaping (TreeToken<T>, Bool) throws -> Void) throws {
-        try Yorkie.tokensBetween(root: self.root, from: from, to: to, callback: callback)
+    func tokensBetween(_ from: Int, _ to: Int, _ includeRemoved: Bool = false, _ callback: @escaping (TreeToken<T>, Bool) throws -> Void) throws {
+        try Yorkie.tokensBetween(root: self.root, from: from, to: to, includeRemoved: includeRemoved, callback: callback)
     }
 
     /**
@@ -1002,7 +1036,7 @@ class IndexTree<T: IndexTreeNode> {
     /**
      * `indexOf` returns the index of the given tree position.
      */
-    func indexOf(_ pos: TreePos<T>) throws -> Int {
+    func indexOf(_ pos: TreePos<T>, _ includeRemoved: Bool = false) throws -> Int {
         var node = pos.node
         let offset = Int(pos.offset)
 
@@ -1012,26 +1046,26 @@ class IndexTree<T: IndexTreeNode> {
             size += offset
 
             let parent = node.parent!
-            let offsetOfNode = try parent.findOffset(node: node)
+            let offsetOfNode = try parent.findOffset(node: node, includeRemoved: includeRemoved)
             if offsetOfNode == -1 {
                 throw YorkieError(code: .errInvalidArgument, message: "invalid pos")
             }
 
-            size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode)
+            size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode, includeRemoved: includeRemoved)
 
             node = node.parent!
         } else {
-            size += addSizeOfLeftSiblings(parent: node, offset: offset)
+            size += addSizeOfLeftSiblings(parent: node, offset: offset, includeRemoved: includeRemoved)
         }
 
         while node.parent != nil {
             let parent = node.parent!
-            let offsetOfNode = try parent.findOffset(node: node)
+            let offsetOfNode = try parent.findOffset(node: node, includeRemoved: includeRemoved)
             if offsetOfNode == -1 {
                 throw YorkieError(code: .errInvalidArgument, message: "invalid pos")
             }
 
-            size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode)
+            size += addSizeOfLeftSiblings(parent: parent, offset: offsetOfNode, includeRemoved: includeRemoved)
             depth += 1
             node = node.parent!
         }

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -131,6 +131,7 @@ protocol IndexTreeNode: AnyObject {
     func cloneText(offset: Int32) -> Self
     func cloneElement(issueTimeTicket: TimeTicket) -> Self
     func getDataSize() -> DataSize
+    func shouldStayLeftOnSplit(_ child: Self, siblings: [Self], versionVector: VersionVector?) -> Bool
 }
 
 extension IndexTreeNode {
@@ -373,7 +374,10 @@ extension IndexTreeNode {
         }
 
         guard let offset = self.innerChildren.firstIndex(where: { $0 === child }) else {
-            throw YorkieError(code: .errInvalidArgument, message: "child not found")
+            // When a child has been detached by a prior merge operation,
+            // removeChild during GC purge may not find it. This is safe to
+            // skip since the child is already physically removed.
+            return
         }
 
         self.innerChildren.splice(offset, 1, with: [])
@@ -381,9 +385,53 @@ extension IndexTreeNode {
     }
 
     /**
+     * `detachChild` removes the given child from this node's children list and
+     * updates the ancestors' size. Unlike ``removeChild(child:)`` which purges a
+     * tombstoned node during GC, `detachChild` moves an alive node between
+     * parents during a merge, so it subtracts the child's size from the
+     * ancestors.
+     */
+    func detachChild(child: Self) throws {
+        guard self.isText == false else {
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
+        }
+
+        guard let offset = self.innerChildren.firstIndex(where: { $0 === child }) else {
+            throw YorkieError(code: .errInvalidArgument, message: "child not found")
+        }
+
+        self.innerChildren.splice(offset, 1, with: [])
+
+        // The child is alive (merge moves only non-removed nodes), so its
+        // paddedSize is currently counted in this node's ancestor chain.
+        // Subtract it before re-appending the child to a new parent.
+        var ancestor = child.parent
+        while ancestor != nil {
+            ancestor?.size -= child.paddedSize
+            if ancestor!.isRemoved {
+                break
+            }
+            ancestor = ancestor?.parent
+        }
+
+        child.parent = nil
+    }
+
+    /**
+     * `shouldStayLeftOnSplit` returns true when `child` was moved here by a
+     * concurrent merge whose source is one of `siblings`, and that merge is
+     * unknown to `versionVector`. Such a child must remain in the original
+     * (left) node during a split instead of flowing to the split (right) node.
+     * Index trees without merge semantics return false.
+     */
+    func shouldStayLeftOnSplit(_ child: Self, siblings: [Self], versionVector: VersionVector?) -> Bool {
+        false
+    }
+
+    /**
      * `splitElement` splits the given element at the given offset.
      */
-    func splitElement(_ offset: Int32, _ issuedTimeTicket: TimeTicket) throws -> (Self?, DataSize) {
+    func splitElement(_ offset: Int32, _ issuedTimeTicket: TimeTicket, _ versionVector: VersionVector? = nil) throws -> (Self?, DataSize) {
         /**
          * TODO(hackerwins): Define ID of split node for concurrent editing.
          * Text has fixed content and its split nodes could have limited offset
@@ -400,8 +448,24 @@ extension IndexTreeNode {
         try self.parent?.insertAfterInternal(newNode: clone, referenceNode: self)
         clone.updateAncestorsSize()
 
-        let leftChildren = Array(self.children[0 ..< Int(offset)])
-        let rightChildren = Array(self.children[Int(offset)...])
+        let left = Array(self.innerChildren[0 ..< Int(offset)])
+        let right = Array(self.innerChildren[Int(offset)...])
+
+        // Fix 8: handle concurrent merge-moved children during split.
+        // When a child was merge-moved from a source local to this node, the
+        // content should stay in the original (left) node. When the source is
+        // external, the content flows naturally to the split (right) node.
+        let allChildren = left + right
+        var leftChildren = left
+        var rightChildren = [Self]()
+        for child in right {
+            if self.shouldStayLeftOnSplit(child, siblings: allChildren, versionVector: versionVector) {
+                leftChildren.append(child)
+            } else {
+                rightChildren.append(child)
+            }
+        }
+
         self.innerChildren = leftChildren
         clone.innerChildren = rightChildren
         self.size = self.innerChildren.reduce(0) { acc, child in

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.3"
+let yorkieVersion = "0.7.4"

--- a/Tests/Integration/TreeMergeConvergenceTests.swift
+++ b/Tests/Integration/TreeMergeConvergenceTests.swift
@@ -1,0 +1,715 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Integration tests for Tree merge/split convergence fixes ported from
+// yorkie-js-sdk v0.7.4 (PRs #1202-1206, #1210, #1211).
+// These tests require a running yorkie server at http://localhost:8080.
+
+import XCTest
+@testable @preconcurrency import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Overlapping range
+
+final class TreeOverlappingMergeConvergenceTests: XCTestCase {
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent overlapping range)
+    // — overlapping-merge-and-merge (was skipped in v0.7.3).
+    @MainActor
+    func test_overlapping_merge_and_merge() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+
+            // when — d1 merges p1+p2, d2 merges p2+p3 concurrently
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(5, 7) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bc</p></r>")
+
+            // then — both converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abc</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abc</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent overlapping range)
+    // — overlapping-merge-and-delete-element-node (was skipped in v0.7.3).
+    @MainActor
+    func test_overlapping_merge_and_delete_element_node() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+
+            // when — d1 merges p1+p2, d2 deletes content of p2 and its closing tag
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 6) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent overlapping range)
+    // — overlapping-merge-and-delete-text-nodes (was skipped in v0.7.3).
+    @MainActor
+    func test_overlapping_merge_and_delete_text_nodes() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "bcde")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bcde</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bcde</p></r>")
+
+            // when — d1 merges p1+p2, d2 deletes "bc" in p2
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(4, 6) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcde</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>de</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ade</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ade</p></r>")
+        }
+    }
+}
+
+// MARK: - Contained range
+
+final class TreeContainedMergeConvergenceTests: XCTestCase {
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-split-and-split-at-different-levels (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_split_and_split_at_different_levels() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <r><p><p>ab</p><p>c</p></p></r>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")])
+                    ])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>ab</p><p>c</p></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>ab</p><p>c</p></p></r>")
+
+            // when — d1 splits inner p at a|b (level 1), d2 splits outer p at level 1
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, nil, 1) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(5, 5, nil, 1) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>a</p><p>b</p><p>c</p></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>ab</p></p><p><p>c</p></p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>a</p><p>b</p></p><p><p>c</p></p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-split-and-delete-contents-in-split-node (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_split_and_delete_contents_in_split_node() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+
+            // when — d1 splits at a|b, d2 deletes "b"
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 2, nil, 1) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(2, 3) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p></p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-split-and-delete-the-whole-original-and-split-nodes (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_split_and_delete_the_whole_original_and_split_nodes() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+
+            // when — d1 splits at a|b, d2 deletes the whole tree content
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 2, nil, 1) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(0, 4) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-merge-and-merge-at-the-same-level (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_merge_and_merge_at_the_same_level() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+
+            // when — d1 merges all three paragraphs, d2 merges only p2+p3
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 7) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(5, 7) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ac</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bc</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ac</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ac</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-merge-and-insert (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_merge_and_insert() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+
+            // when — d1 merges p1+p2, d2 inserts "c" before "b" in p2
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(4, 4, JSONTreeTextNode(value: "c")) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>cb</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>acb</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>acb</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-merge-and-delete-contents-in-merged-node (was skipped in v0.7.3).
+    @MainActor
+    func test_contained_merge_and_delete_contents_in_merged_node() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "bc")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bc</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>bc</p></r>")
+
+            // when — d1 merges p1+p2, d2 deletes "b" from p2
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(4, 5) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abc</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>c</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ac</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ac</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, contained range)
+    // — contained-split-and-merge-same-block (new in v0.7.4; regression for #1726).
+    // When one client splits inside a block that the other client merges, replicas must converge.
+    @MainActor
+    func test_contained_split_and_merge_same_block() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+
+            // when — d1 splits first paragraph at a|b, d2 merges both paragraphs
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 2, nil, 1) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>cd</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            // then — both replicas converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+        }
+    }
+}
+
+// MARK: - Side by side range
+
+final class TreeSideBySideMergeConvergenceTests: XCTestCase {
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — side-by-side-split-and-insert (was skipped in v0.7.3).
+    @MainActor
+    func test_side_by_side_split_and_insert() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+
+            // when — d1 splits at a|b, d2 inserts a new paragraph after the current one
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 2, nil, 1) }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(4, 4, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")]))
+            }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>c</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — side-by-side-split-and-delete (was skipped in v0.7.3).
+    @MainActor
+    func test_side_by_side_split_and_delete() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>c</p></r>")
+
+            // when — d1 splits at a|b, d2 deletes p2 entirely
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 2, nil, 1) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(4, 7) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — cascade-delete-across-parent-after-multi-level-split (new in v0.7.4).
+    @MainActor
+    func test_cascade_delete_across_parent_after_multi_level_split() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — nested structure <r><p><p>ab</p><p>cd</p></p></r>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                    ])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 splits at level 2, d2 deletes a wide range
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, nil, 2) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(1, 6) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><p>a</p></p><p><p>b</p><p>cd</p></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>cd</p></r>")
+
+            // then — both replicas converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>cd</p><p></p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — sequential-merge-then-split (new in v0.7.4).
+    @MainActor
+    func test_sequential_merge_then_split() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 merges both paragraphs (sequential, no concurrency)
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            // d2 splits the merged content at ab|cd (sequential, knows about merge)
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, nil, 1) }
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+
+            // then — both replicas converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — multi-level-split-with-concurrent-merge-and-text-split (new in v0.7.4).
+    @MainActor
+    func test_multi_level_split_with_concurrent_merge_and_text_split() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — nested structure
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                    ])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — concurrent split at level 2 and wide delete
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, nil, 2) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(1, 6) }
+
+            // then — both replicas converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — split-with-concurrent-delete-overlapping-content (new in v0.7.4).
+    // Fixed by Fix 9: skip merge for concurrent elements in collectBetween.
+    @MainActor
+    func test_split_with_concurrent_delete_overlapping_content() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "abcd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            // when — d1 deletes "bc", d2 splits <p> at position 3 (b|c)
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 3, nil, 1) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ad</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>d</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — merge-with-concurrent-content-delete (new in v0.7.4).
+    @MainActor
+    func test_merge_with_concurrent_content_delete() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 deletes "b" (boundary only), d2 merges both paragraphs
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 3) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>cd</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>acd</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — merge-with-concurrent-full-content-delete-in-source (new in v0.7.4).
+    @MainActor
+    func test_merge_with_concurrent_full_content_delete_in_source() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 deletes "cd" from p2, d2 merges both paragraphs
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(5, 7) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>abcd</p></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), (d2.getRoot().t as? JSONTree)?.toXML())
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — side-by-side-merge-and-merge (second instance added in v0.7.4, with 4 paragraphs).
+    @MainActor
+    func test_side_by_side_merge_and_merge_four_paragraphs() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — 4 paragraphs
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "d")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p><p>d</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>c</p><p>d</p></r>")
+
+            // when — d1 merges p1+p2, d2 merges p3+p4 concurrently
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(2, 4) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(8, 10) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>c</p><p>d</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>a</p><p>b</p><p>cd</p></r>")
+
+            // then — both converge
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p>ab</p><p>cd</p></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — concurrent-delete-after-merge-with-nested-content (new in v0.7.4).
+    @MainActor
+    func test_concurrent_delete_after_merge_with_nested_content() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — <r><p><b>a</b></p><p><b>b</b></p></r>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeElementNode(type: "b", children: [JSONTreeTextNode(value: "a")])
+                    ]),
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeElementNode(type: "b", children: [JSONTreeTextNode(value: "b")])
+                    ])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><b>a</b></p><p><b>b</b></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><b>a</b></p><p><b>b</b></p></r>")
+
+            // when — d1 merges p1+p2, d2 deletes everything
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(4, 6) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(0, 10) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r><p><b>a</b><b>b</b></p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+
+            // then
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), /* html */ "<r></r>")
+        }
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
+    // — delete-starting-inside-merge-target (new in v0.7.4).
+    // After sync: merged children (text_c) should be deleted because C2's delete range covers them.
+    @MainActor
+    func test_delete_starting_inside_merge_target() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "c")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), "<r><p>ab</p><p>c</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), "<r><p>ab</p><p>c</p></r>")
+
+            // when — d1 merges p1+p2, d2 deletes from after "b" through end of tree
+            try d1.update { root, _ in try (root.t as? JSONTree)?.edit(3, 5) }
+            try d2.update { root, _ in try (root.t as? JSONTree)?.edit(3, 7) }
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), "<r><p>abc</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), "<r><p>ab</p></r>")
+
+            // then — merged children (text_c) are deleted because C2's range covers them
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+            XCTAssertEqual((d1.getRoot().t as? JSONTree)?.toXML(), "<r><p>ab</p></r>")
+            XCTAssertEqual((d2.getRoot().t as? JSONTree)?.toXML(), "<r><p>ab</p></r>")
+        }
+    }
+}

--- a/Tests/Integration/TreeMergeConvergenceTests.swift
+++ b/Tests/Integration/TreeMergeConvergenceTests.swift
@@ -492,6 +492,15 @@ final class TreeSideBySideMergeConvergenceTests: XCTestCase {
 
     // Ported from yorkie-js-sdk v0.7.4: Tree.edit(concurrent, side by side range)
     // — multi-level-split-with-concurrent-merge-and-text-split (new in v0.7.4).
+    //
+    // NOTE: Upstream intentionally shares the exact setup and operations with
+    // `cascade-delete-across-parent-after-multi-level-split` above. The two
+    // upstream tests differ only in their assertions: the cascade test pins the
+    // deterministic intermediate/final XML, while THIS variant asserts ONLY that
+    // the two replicas converge (d1 == d2) without pinning a specific XML — a
+    // looser guard that must hold regardless of the exact converged shape. This
+    // port mirrors that upstream pair 1:1; the shared operations are deliberate,
+    // not an accidental copy.
     @MainActor
     func test_multi_level_split_with_concurrent_merge_and_text_split() async throws {
         try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in

--- a/Tests/Unit/API/V1/ConverterTests.swift
+++ b/Tests/Unit/API/V1/ConverterTests.swift
@@ -408,4 +408,50 @@ class ConverterTests: XCTestCase {
 
         XCTAssertEqual(size1, size2)
     }
+
+    // Ported from yorkie-js-sdk v0.7.4: Converter — should persist merge state across bytes roundtrip.
+    //
+    // Regression test for the snapshot-roundtrip convergence bug fixed by persisting `mergedFrom`
+    // and `mergedAt` on moved children. A tree that undergoes a merge and is then serialized via
+    // objectToBytes must deserialize with mergedFrom/mergedAt preserved on moved children and
+    // mergedInto reconstructed on the source parent by rebuildMergeState.
+    func test_should_persist_merge_state_across_bytes_roundtrip() async throws {
+        // given — build <root><p>a</p><p>b</p></root> then merge into <root><p>ab</p></root>
+        let doc = Document(key: "test-doc")
+
+        try await doc.update { root, _ in
+            root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "root", children: [
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "a")]),
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "b")])
+            ]))
+            // merge the two paragraphs: delete the boundary between them
+            try (root.t as? JSONTree)?.edit(2, 4)
+        }
+
+        let xmlBeforeRoundtrip = await(doc.getRoot().t as? JSONTree)?.toXML()
+        XCTAssertEqual(xmlBeforeRoundtrip, "<root><p>ab</p></root>")
+
+        // when — snapshot via objectToBytes then restore via bytesToObject
+        let bytes = try await Converter.objectToBytes(obj: doc.getRootObject())
+        let clonedObj = try Converter.bytesToObject(bytes: bytes)
+
+        // then — XML is preserved after roundtrip
+        let clonedTree = clonedObj.get(key: "t") as? CRDTTree
+        XCTAssertNotNil(clonedTree)
+        XCTAssertEqual(clonedTree?.toXML(), "<root><p>ab</p></root>")
+
+        // and — mergedFrom/mergedAt on the moved child survive serialization
+        let rootNode = clonedTree?.root
+        let firstP = rootNode?.children.first
+        XCTAssertNotNil(firstP)
+
+        let movedChild = firstP?.innerChildren.first { $0.mergedFrom != nil }
+        XCTAssertNotNil(movedChild, "moved child should carry mergedFrom after roundtrip")
+        XCTAssertNotNil(movedChild?.mergedAt, "moved child should carry mergedAt after roundtrip")
+
+        // and — rebuildMergeState restores mergedInto on the tombstoned source parent
+        let sourceParent = rootNode?.innerChildren.first { $0.isRemoved }
+        XCTAssertNotNil(sourceParent, "source parent should be tombstoned")
+        XCTAssertNotNil(sourceParent?.mergedInto, "rebuildMergeState should set mergedInto on tombstoned source")
+    }
 }

--- a/Tests/Unit/API/V1/ConverterTests.swift
+++ b/Tests/Unit/API/V1/ConverterTests.swift
@@ -453,5 +453,11 @@ class ConverterTests: XCTestCase {
         let sourceParent = rootNode?.innerChildren.first { $0.isRemoved }
         XCTAssertNotNil(sourceParent, "source parent should be tombstoned")
         XCTAssertNotNil(sourceParent?.mergedInto, "rebuildMergeState should set mergedInto on tombstoned source")
+
+        // and — the merge links point at the right nodes, not merely non-nil:
+        // the moved child's mergedFrom is the tombstoned source parent, and that
+        // source parent's mergedInto forwards to the surviving merge target.
+        XCTAssertEqual(movedChild?.mergedFrom, sourceParent?.id, "movedChild.mergedFrom should reference the tombstoned source parent")
+        XCTAssertEqual(sourceParent?.mergedInto, firstP?.id, "sourceParent.mergedInto should reference the surviving merge target")
     }
 }

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -61,6 +61,59 @@ final class CRDTTreeNodeTests: XCTestCase {
 
         XCTAssertEqual(node.toJSONString, "{\"type\":\"text\",\"value\":\"\\n\"}")
     }
+
+    // Ported from yorkie-js-sdk v0.7.4: CRDTTreeNode — splitText preserves mergedFrom and mergedAt.
+    func test_splitText_preserves_mergedFrom_and_mergedAt() throws {
+        // given
+        let para = CRDTTreeNode(id: posT(), type: "p", children: [])
+        let text = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "abcd")
+        try para.append(contentsOf: [text])
+
+        let sourceID = CRDTTreeNodeID(createdAt: timeT(), offset: 0)
+        let mergeTicket = timeT()
+        text.mergedFrom = sourceID
+        text.mergedAt = mergeTicket
+
+        // when — split "abcd" at offset 2 into "ab" | "cd"
+        let right = try text.splitText(2, 0).0
+
+        // then — left node retains original value; right inherits merge metadata
+        XCTAssertEqual(text.value, "ab")
+        XCTAssertNotNil(right)
+        XCTAssertEqual(right?.value, "cd")
+
+        XCTAssertEqual(right?.mergedFrom, sourceID)
+        XCTAssertEqual(right?.mergedAt, mergeTicket)
+    }
+
+    // Ported from yorkie-js-sdk v0.7.4: CRDTTreeNode — deepcopy preserves merge metadata.
+    func test_deepcopy_preserves_merge_metadata() throws {
+        // given
+        let para = CRDTTreeNode(id: posT(), type: "p", children: [])
+        let text = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "hello")
+        try para.append(contentsOf: [text])
+
+        let targetID = CRDTTreeNodeID(createdAt: timeT(), offset: 0)
+        let sourceID = CRDTTreeNodeID(createdAt: timeT(), offset: 0)
+        let mergeTicket = timeT()
+
+        para.mergedInto = targetID
+        text.mergedFrom = sourceID
+        text.mergedAt = mergeTicket
+
+        // when
+        let clone = para.deepcopy()
+
+        // then — element-level mergedInto is preserved
+        XCTAssertNotNil(clone)
+        XCTAssertEqual(clone?.mergedInto, targetID)
+
+        // and the text child's mergedFrom / mergedAt survive the copy
+        let clonedText = clone?.children.first
+        XCTAssertNotNil(clonedText)
+        XCTAssertEqual(clonedText?.mergedFrom, sourceID)
+        XCTAssertEqual(clonedText?.mergedAt, mergeTicket)
+    }
 }
 
 final class CRDTTreeEditTests: XCTestCase {

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.3'
+    image: 'yorkieteam/yorkie:0.7.4'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.3'
+    image: 'yorkieteam/yorkie:0.7.4'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk 0.7.4. The release is a set of Tree (`JSONTree`) merge/split **convergence** fixes plus the proto change that backs them. Ported upstream PRs:

- Fix convergence bugs in concurrent tree merge/split (#1202)
- Fix split sibling convergence via position forwarding (#1203)
- Fix multi-level split + merge divergence via mergedFrom (#1204)
- Fix split + delete divergence and splitElement tombstone handling (#1205)
- Fix SplitElement divergence on concurrent split inside merge range (#1206)
- Mirror tree merge snapshot encoding fix from Go SDK (#1210)
- Fix tree style divergence on concurrent split via End-token guard (#1211)

Proto: `TreeNode` gains `merged_from` (9) and `merged_at` (10) to carry the merge witness and merge-time causal boundary in the snapshot encoding; `Converter` round-trips them and `CRDTTree` rebuilds the `mergedInto` runtime cache on snapshot load. Skipped upstream: #1207 (ProseMirror binding, no iOS) and #1208 (release commit).

Also bundles an unrelated example fix: RichTextEditor undo/redo did not re-render after a revert.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Pre-PR gate green: critic-reviewer (approved, no High/Medium), SwiftFormat 0.55.6 and SwiftLint 0.58.2 `--strict` (0 violations), `swift build` + unit tests pass. Integration convergence tests (`TreeMergeConvergenceTests`, 21 cases) require a live yorkie server v0.7.4 — exercised by CI.
- `edit()` was split into private helpers (`applyMergeMoves`, `collectUnknownSplitSiblings`, `propagateDeletesToMergedChildren`) to satisfy SwiftLint complexity/length — no behaviour change.
- Two **pre-existing** iOS/JS divergences (not introduced here) left as follow-ups: `CRDTTreeNode.remove()` keeps the earlier tombstone vs JS's newer (only the `Bool` return was added); `traverseInPosRange`/`toIndex` lack JS's `includeRemoved` parameter. The write-only `preTombstoned` set from the JS source was intentionally omitted (dead code).

**Does this PR introduce a user-facing change?**:
```release-note
Fix Tree (JSONTree) convergence under concurrent merge/split editing; fix RichTextEditor example undo/redo not re-rendering.
```

**Additional documentation**:
```docs
- CHANGELOG.md updated for v0.7.4
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.4

* **New Features**
  * Enhanced undo/redo functionality in the rich text editor to properly restore editing state.

* **Bug Fixes**
  * Improved concurrent tree merge and split convergence behavior.
  * Fixed merge metadata persistence across serialization/deserialization operations.
  * Resolved tree node handling during complex concurrent edits.

* **Tests**
  * Added comprehensive integration tests for tree merge/split scenarios.

* **Chores**
  * Updated dependencies and container images to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->