### PR TITLE
Apply updates from yorkie-js-sdk 0.7.5

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.4
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5e33e48f8e8c04f80d8ab917256edf38d0a4109/Formula/y/yorkie.rb"
+      # yorkie server v0.7.5
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/9fe7c7f4b22fe5a7a113588e29d2f9fd190d67af/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.4
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5e33e48f8e8c04f80d8ab917256edf38d0a4109/Formula/y/yorkie.rb"
+      # yorkie server v0.7.5
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/9fe7c7f4b22fe5a7a113588e29d2f9fd190d67af/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.5] - 2026-06-17
+
+- Add Counter dedup mode with HyperLogLog for UV measurement in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257
+- Enable splitLevel=1 concurrent tests and add split undo/redo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257
+- Add undo/redo support for TreeStyleOperation in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257
+- Add content correctness tests for overlapping undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257
+- Simplify Counter interface and replace long with bigint in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257
+
 ## [v0.7.4] - 2026-06-17
 
 - Fix tree style divergence on concurrent split via End-token guard in https://github.com/yorkie-team/yorkie-ios-sdk/pull/256

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -53,7 +53,7 @@ enum Converter {
 
     static func countValueFrom(_ valueType: PbValueType, data: Data) throws -> any YorkieCountable {
         switch valueType {
-        case .integerCnt:
+        case .integerCnt, .integerDedupCnt:
             return Int32(littleEndian: data.withUnsafeBytes { $0.load(as: Int32.self) })
         case .longCnt:
             return Int64(littleEndian: data.withUnsafeBytes { $0.load(as: Int64.self) })
@@ -252,15 +252,16 @@ extension Converter {
 
 // MARK: CounterType
 extension Converter {
-    /**
-     * `toCounterType` converts the given model to Protobuf format.
-     */
-    static func toCounterType(_ valueType: any YorkieCountable) -> PbValueType {
-        if valueType is Int32 {
-            return .integer
-        } else {
-            return .long
+    /// Returns the Protobuf value type for a ``CRDTCounter``, preserving
+    /// dedup mode as `.integerDedupCnt`.
+    static func toCounterTypeForCounter<T: YorkieCountable>(_ counter: CRDTCounter<T>) -> PbValueType {
+        if counter.isDedup {
+            return .integerDedupCnt
         }
+        if counter.value is Int32 {
+            return .integerCnt
+        }
+        return .longCnt
     }
 }
 
@@ -283,7 +284,7 @@ extension Converter {
             pbElementSimple.type = toValueType(primitive)
             pbElementSimple.value = element.toBytes()
         } else if let counter = element as? CRDTCounter<Int32> {
-            pbElementSimple.type = .integerCnt
+            pbElementSimple.type = counter.isDedup ? .integerDedupCnt : .integerCnt
             pbElementSimple.value = counter.toBytes()
         } else if let counter = element as? CRDTCounter<Int64> {
             pbElementSimple.type = .longCnt
@@ -324,6 +325,11 @@ extension Converter {
             return CRDTText(rgaTreeSplit: RGATreeSplit(), createdAt: fromTimeTicket(pbElementSimple.createdAt))
         case .null, .boolean, .integer, .long, .double, .string, .bytes, .date:
             return Primitive(value: try valueFrom(pbElementSimple.type, data: pbElementSimple.value), createdAt: fromTimeTicket(pbElementSimple.createdAt))
+        case .integerDedupCnt:
+            let counter = CRDTCounter<Int32>(dedupWithCreatedAt: fromTimeTicket(pbElementSimple.createdAt))
+            // value bytes encode the last-known cardinality; HLL registers are
+            // restored via fromCounter — not available in the simple form.
+            return counter
         case .integerCnt:
             guard let value = try countValueFrom(pbElementSimple.type, data: pbElementSimple.value) as? Int32 else {
                 throw YorkieError(code: .errInvalidType, message: "unexpected counter value type")
@@ -480,6 +486,7 @@ extension Converter {
             pbIncreaseOperation.parentCreatedAt = toTimeTicket(increaseOperation.parentCreatedAt)
             pbIncreaseOperation.value = toElementSimple(increaseOperation.value)
             pbIncreaseOperation.executedAt = toTimeTicket(increaseOperation.executedAt)
+            pbIncreaseOperation.actor = increaseOperation.actor
             pbOperation.increase = pbIncreaseOperation
         } else if let treeEditOperation = operation as? TreeEditOperation {
             var pbTreeEditOperation = PbOperation.TreeEdit()
@@ -564,7 +571,8 @@ extension Converter {
             } else if case let .increase(pbIncreaseOperation) = pbOperation.body {
                 return IncreaseOperation(parentCreatedAt: fromTimeTicket(pbIncreaseOperation.parentCreatedAt),
                                          value: try fromElementSimple(pbElementSimple: pbIncreaseOperation.value),
-                                         executedAt: fromTimeTicket(pbIncreaseOperation.executedAt))
+                                         executedAt: fromTimeTicket(pbIncreaseOperation.executedAt),
+                                         actor: pbIncreaseOperation.actor)
             } else if case let .treeEdit(pbTreeEditOperation) = pbOperation.body {
                 return TreeEditOperation(parentCreatedAt: fromTimeTicket(pbTreeEditOperation.parentCreatedAt),
                                          fromPos: fromTreePos(pbTreeEditOperation.from),
@@ -798,8 +806,11 @@ extension Converter {
      */
     static func toCounter<T: YorkieCountable>(_ counter: CRDTCounter<T>) -> PbJSONElement {
         var pbCounter = PbJSONElement.Counter()
-        pbCounter.type = toCounterType(counter.value)
+        pbCounter.type = toCounterTypeForCounter(counter)
         pbCounter.value = counter.toBytes()
+        if let hllData = counter.hllBytes() {
+            pbCounter.hllRegisters = hllData
+        }
         pbCounter.createdAt = toTimeTicket(counter.createdAt)
         if let ticket = counter.movedAt {
             pbCounter.movedAt = toTimeTicket(ticket)
@@ -821,26 +832,32 @@ extension Converter {
      * `fromCounter` converts the given Protobuf format to model format.
      */
     static func fromCounter(_ pbCounter: PbJSONElement.Counter) throws -> CRDTElement {
-        let value = try countValueFrom(pbCounter.type, data: pbCounter.value)
-
         switch pbCounter.type {
+        case .integerDedupCnt:
+            let counter = CRDTCounter<Int32>(dedupWithCreatedAt: fromTimeTicket(pbCounter.createdAt))
+            counter.movedAt = pbCounter.hasMovedAt ? fromTimeTicket(pbCounter.movedAt) : nil
+            counter.removedAt = pbCounter.hasRemovedAt ? fromTimeTicket(pbCounter.removedAt) : nil
+            if !pbCounter.hllRegisters.isEmpty {
+                try counter.restoreHLL(pbCounter.hllRegisters)
+            }
+            return counter
         case .integerCnt:
+            let value = try countValueFrom(pbCounter.type, data: pbCounter.value)
             guard let value = value as? Int32 else {
                 throw YorkieError(code: .errInvalidType, message: "[\(pbCounter.type)] value is not Int32.")
             }
             let counter = CRDTCounter<Int32>(value: value, createdAt: fromTimeTicket(pbCounter.createdAt))
             counter.movedAt = pbCounter.hasMovedAt ? fromTimeTicket(pbCounter.movedAt) : nil
             counter.removedAt = pbCounter.hasRemovedAt ? fromTimeTicket(pbCounter.removedAt) : nil
-
             return counter
         case .longCnt:
+            let value = try countValueFrom(pbCounter.type, data: pbCounter.value)
             guard let value = value as? Int64 else {
                 throw YorkieError(code: .errInvalidType, message: "[\(pbCounter.type)] value is not Int64.")
             }
             let counter = CRDTCounter<Int64>(value: value, createdAt: fromTimeTicket(pbCounter.createdAt))
             counter.movedAt = pbCounter.hasMovedAt ? fromTimeTicket(pbCounter.movedAt) : nil
             counter.removedAt = pbCounter.hasRemovedAt ? fromTimeTicket(pbCounter.removedAt) : nil
-
             return counter
         default:
             throw YorkieError(code: .errUnimplemented, message: "\(pbCounter.type) is not implemented.")

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -56,6 +56,7 @@ public enum Yorkie_V1_ValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
   case integerCnt // = 11
   case longCnt // = 12
   case tree // = 13
+  case integerDedupCnt // = 14
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -78,6 +79,7 @@ public enum Yorkie_V1_ValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 11: self = .integerCnt
     case 12: self = .longCnt
     case 13: self = .tree
+    case 14: self = .integerDedupCnt
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -98,6 +100,7 @@ public enum Yorkie_V1_ValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .integerCnt: return 11
     case .longCnt: return 12
     case .tree: return 13
+    case .integerDedupCnt: return 14
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -118,6 +121,7 @@ public enum Yorkie_V1_ValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
     .integerCnt,
     .longCnt,
     .tree,
+    .integerDedupCnt,
   ]
 
 }
@@ -765,6 +769,11 @@ public struct Yorkie_V1_Operation: Sendable {
     /// Clears the value of `executedAt`. Subsequent reads from it will return its default value.
     public mutating func clearExecutedAt() {_uniqueStorage()._executedAt = nil}
 
+    public var actor: String {
+      get {_storage._actor}
+      set {_uniqueStorage()._actor = newValue}
+    }
+
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     public init() {}
@@ -1272,6 +1281,8 @@ public struct Yorkie_V1_JSONElement: Sendable {
     public var hasRemovedAt: Bool {self._removedAt != nil}
     /// Clears the value of `removedAt`. Subsequent reads from it will return its default value.
     public mutating func clearRemovedAt() {self._removedAt = nil}
+
+    public var hllRegisters: Data = Data()
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2557,7 +2568,7 @@ public struct Yorkie_V1_RevisionSummary: Sendable {
 fileprivate let _protobuf_package = "yorkie.v1"
 
 extension Yorkie_V1_ValueType: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0VALUE_TYPE_NULL\0\u{1}VALUE_TYPE_BOOLEAN\0\u{1}VALUE_TYPE_INTEGER\0\u{1}VALUE_TYPE_LONG\0\u{1}VALUE_TYPE_DOUBLE\0\u{1}VALUE_TYPE_STRING\0\u{1}VALUE_TYPE_BYTES\0\u{1}VALUE_TYPE_DATE\0\u{1}VALUE_TYPE_JSON_OBJECT\0\u{1}VALUE_TYPE_JSON_ARRAY\0\u{1}VALUE_TYPE_TEXT\0\u{1}VALUE_TYPE_INTEGER_CNT\0\u{1}VALUE_TYPE_LONG_CNT\0\u{1}VALUE_TYPE_TREE\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0VALUE_TYPE_NULL\0\u{1}VALUE_TYPE_BOOLEAN\0\u{1}VALUE_TYPE_INTEGER\0\u{1}VALUE_TYPE_LONG\0\u{1}VALUE_TYPE_DOUBLE\0\u{1}VALUE_TYPE_STRING\0\u{1}VALUE_TYPE_BYTES\0\u{1}VALUE_TYPE_DATE\0\u{1}VALUE_TYPE_JSON_OBJECT\0\u{1}VALUE_TYPE_JSON_ARRAY\0\u{1}VALUE_TYPE_TEXT\0\u{1}VALUE_TYPE_INTEGER_CNT\0\u{1}VALUE_TYPE_LONG_CNT\0\u{1}VALUE_TYPE_TREE\0\u{1}VALUE_TYPE_INTEGER_DEDUP_CNT\0")
 }
 
 extension Yorkie_V1_DocEventType: SwiftProtobuf._ProtoNameProviding {
@@ -3504,12 +3515,13 @@ extension Yorkie_V1_Operation.Style: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Yorkie_V1_Operation.protoMessageName + ".Increase"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}value\0\u{3}executed_at\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}value\0\u{3}executed_at\0\u{1}actor\0")
 
   fileprivate class _StorageClass {
     var _parentCreatedAt: Yorkie_V1_TimeTicket? = nil
     var _value: Yorkie_V1_JSONElementSimple? = nil
     var _executedAt: Yorkie_V1_TimeTicket? = nil
+    var _actor: String = String()
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -3523,6 +3535,7 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
       _parentCreatedAt = source._parentCreatedAt
       _value = source._value
       _executedAt = source._executedAt
+      _actor = source._actor
     }
   }
 
@@ -3544,6 +3557,7 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
         case 1: try { try decoder.decodeSingularMessageField(value: &_storage._parentCreatedAt) }()
         case 2: try { try decoder.decodeSingularMessageField(value: &_storage._value) }()
         case 3: try { try decoder.decodeSingularMessageField(value: &_storage._executedAt) }()
+        case 4: try { try decoder.decodeSingularStringField(value: &_storage._actor) }()
         default: break
         }
       }
@@ -3565,6 +3579,9 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
       try { if let v = _storage._executedAt {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
       } }()
+      if !_storage._actor.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._actor, fieldNumber: 4)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3577,6 +3594,7 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
         if _storage._parentCreatedAt != rhs_storage._parentCreatedAt {return false}
         if _storage._value != rhs_storage._value {return false}
         if _storage._executedAt != rhs_storage._executedAt {return false}
+        if _storage._actor != rhs_storage._actor {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -4293,7 +4311,7 @@ extension Yorkie_V1_JSONElement.Text: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Yorkie_V1_JSONElement.Counter: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Yorkie_V1_JSONElement.protoMessageName + ".Counter"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}value\0\u{3}created_at\0\u{3}moved_at\0\u{3}removed_at\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}value\0\u{3}created_at\0\u{3}moved_at\0\u{3}removed_at\0\u{4}\u{2}hll_registers\0\u{c}\u{6}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -4306,6 +4324,7 @@ extension Yorkie_V1_JSONElement.Counter: SwiftProtobuf.Message, SwiftProtobuf._M
       case 3: try { try decoder.decodeSingularMessageField(value: &self._createdAt) }()
       case 4: try { try decoder.decodeSingularMessageField(value: &self._movedAt) }()
       case 5: try { try decoder.decodeSingularMessageField(value: &self._removedAt) }()
+      case 7: try { try decoder.decodeSingularBytesField(value: &self.hllRegisters) }()
       default: break
       }
     }
@@ -4331,6 +4350,9 @@ extension Yorkie_V1_JSONElement.Counter: SwiftProtobuf.Message, SwiftProtobuf._M
     try { if let v = self._removedAt {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
     } }()
+    if !self.hllRegisters.isEmpty {
+      try visitor.visitSingularBytesField(value: self.hllRegisters, fieldNumber: 7)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -4340,6 +4362,7 @@ extension Yorkie_V1_JSONElement.Counter: SwiftProtobuf.Message, SwiftProtobuf._M
     if lhs._createdAt != rhs._createdAt {return false}
     if lhs._movedAt != rhs._movedAt {return false}
     if lhs._removedAt != rhs._removedAt {return false}
+    if lhs.hllRegisters != rhs.hllRegisters {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -114,6 +114,7 @@ message Operation {
     TimeTicket parent_created_at = 1;
     JSONElementSimple value = 2;
     TimeTicket executed_at = 3;
+    string actor = 4;
   }
   message TreeEdit {
     TimeTicket parent_created_at = 1;
@@ -198,6 +199,8 @@ message JSONElement {
     TimeTicket created_at = 3;
     TimeTicket moved_at = 4;
     TimeTicket removed_at = 5;
+    reserved 6;
+    bytes hll_registers = 7;
   }
   message Tree {
     repeated TreeNode nodes = 1;
@@ -435,6 +438,8 @@ enum ValueType {
   VALUE_TYPE_INTEGER_CNT = 11;
   VALUE_TYPE_LONG_CNT = 12;
   VALUE_TYPE_TREE = 13;
+  VALUE_TYPE_INTEGER_DEDUP_CNT = 14;
+  reserved 15;
 }
 
 enum DocEventType {

--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -75,7 +75,14 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
             copy.movedAt = self.movedAt
             copy.removedAt = self.removedAt
             if let bytes = counter.hllBytes() {
-                try? copy.restoreHLL(bytes)
+                do {
+                    try copy.restoreHLL(bytes)
+                } catch {
+                    // hllBytes() always returns a valid 16384-byte payload, so this
+                    // should never happen; log loudly rather than silently dropping
+                    // the HLL state and producing an inconsistent copy.
+                    Logger.error("failed to restore HLL on deepcopy", error: error)
+                }
             }
             return copy
         }

--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -18,29 +18,48 @@ import Foundation
 
 /**
  * `CRDTCounter` represents changeable number data type.
+ *
+ * When `isDedup` is `true` the counter is a HyperLogLog-backed dedup counter
+ * (equivalent to JS `CounterType.IntDedup`). Its `value` is always derived
+ * from the HLL cardinality estimate and its type parameter is always `Int32`.
  */
 class CRDTCounter<T: YorkieCountable>: CRDTElement {
-    /**
-     * `getDataSize` returns the data usage of this element.
-     */
-    func getDataSize() -> DataSize {
-        let data = self.value is Int32 ? 4 : 8
-        return DataSize(
-            data: data,
-            meta: self.getMetaUsage()
-        )
-    }
-
     var createdAt: TimeTicket
     var movedAt: TimeTicket?
     var removedAt: TimeTicket?
 
     private(set) var value: T
 
+    /// Whether this counter uses HyperLogLog-based actor deduplication.
+    private(set) var isDedup: Bool
+
+    /// HLL state; non-nil exactly when `isDedup == true`.
+    private var hll: HLL?
+
+    // MARK: – Initializers
+
+    /// Creates a regular (non-dedup) counter.
     init(value: T, createdAt: TimeTicket) {
         self.createdAt = createdAt
         self.value = value
+        self.isDedup = false
+        self.hll = nil
     }
+
+    /// Creates a dedup counter.  `T` must be `Int32`; `value` is ignored —
+    /// the counter value is always derived from the HLL cardinality.
+    ///
+    /// - Parameters:
+    ///   - dedup: Pass `true` to create a dedup counter.
+    ///   - createdAt: Creation timestamp.
+    init(dedupWithCreatedAt createdAt: TimeTicket) where T == Int32 {
+        self.createdAt = createdAt
+        self.value = 0
+        self.isDedup = true
+        self.hll = HLL()
+    }
+
+    // MARK: – CRDTElement
 
     func toJSON() -> String {
         "\(self.value)"
@@ -51,24 +70,61 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
     }
 
     func deepcopy() -> CRDTElement {
+        if self.isDedup, let counter = self as? CRDTCounter<Int32> {
+            let copy = CRDTCounter<Int32>(dedupWithCreatedAt: self.createdAt)
+            copy.movedAt = self.movedAt
+            copy.removedAt = self.removedAt
+            if let bytes = counter.hllBytes() {
+                try? copy.restoreHLL(bytes)
+            }
+            return copy
+        }
+
         let counter = CRDTCounter(value: self.value, createdAt: self.createdAt)
         counter.movedAt = self.movedAt
-
+        counter.removedAt = self.removedAt
         return counter
     }
 
-    /**
-     * `toBytes` creates an array representing the value.
-     */
+    // MARK: – DataSize
+
+    /// Returns the data usage of this element.
+    func getDataSize() -> DataSize {
+        var data = self.value is Int32 ? 4 : 8
+        if self.isDedup, let hll {
+            data += hll.toBytes().count
+        }
+        return DataSize(data: data, meta: self.getMetaUsage())
+    }
+
+    // MARK: – Serialisation
+
+    /// Creates a byte array representing the value (little-endian).
     func toBytes() -> Data {
         return withUnsafeBytes(of: self.value.littleEndian) { Data($0) }
     }
 
-    /**
-     * `increase` increases numeric data.
-     */
+    /// Returns the serialised HLL register bytes, or `nil` when not in dedup mode.
+    func hllBytes() -> Data? {
+        guard self.isDedup, let hll else { return nil }
+        return Data(hll.toBytes())
+    }
+
+    // MARK: – Mutations
+
+    /// Increases the counter by the given primitive value.
+    ///
+    /// - Throws: ``YorkieError`` when called on a dedup counter; use
+    ///   ``increaseDedup(_:actor:)`` instead.
     @discardableResult
     func increase(_ primitive: Primitive) throws -> CRDTCounter {
+        if self.isDedup {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "dedup counter requires actor, use increaseDedup(_:actor:)"
+            )
+        }
+
         switch primitive.value {
         case .integer(let int32Value):
             self.value &+= T(int32Value)
@@ -79,5 +135,66 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
         }
 
         return self
+    }
+
+    /// Increases the dedup counter by recording the given actor in the HLL.
+    ///
+    /// Only the `Int32` specialisation supports dedup. The primitive value
+    /// must be 1 (integer or long).
+    ///
+    /// - Parameters:
+    ///   - primitive: The increment value (must be 1).
+    ///   - actor: The actor identifier to record in the HLL.
+    /// - Throws: ``YorkieError`` when not in dedup mode, when `actor` is
+    ///   empty, or when `primitive` is not 1.
+    @discardableResult
+    func increaseDedup(_ primitive: Primitive, actor: String) throws -> CRDTCounter where T == Int32 {
+        guard self.isDedup, let hll else {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "increaseDedup called on a non-dedup counter"
+            )
+        }
+        guard !actor.isEmpty else {
+            throw YorkieError(code: .errInvalidArgument, message: "dedup counter requires actor")
+        }
+
+        // Only increment-by-1 is supported (mirrors JS reference).
+        let isUnit: Bool
+        switch primitive.value {
+        case .integer(let val): isUnit = (val == 1)
+        case .long(let val): isUnit = (val == 1)
+        default: isUnit = false
+        }
+        guard isUnit else {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "dedup counter only supports increment by 1"
+            )
+        }
+
+        if hll.add(value: actor) {
+            self.value = Int32(hll.count())
+        }
+
+        return self
+    }
+
+    /// Restores the HLL state from the given serialised bytes and recomputes
+    /// the counter value.
+    ///
+    /// - Parameter data: Serialised register bytes from ``hllBytes()``.
+    /// - Throws: ``YorkieError`` when not in dedup mode, or when the byte
+    ///   count does not match the expected register count.
+    func restoreHLL(_ data: Data) throws where T == Int32 {
+        guard self.isDedup else {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "restoreHLL called on a non-dedup counter"
+            )
+        }
+        if self.hll == nil { self.hll = HLL() }
+        try self.hll!.restore([UInt8](data))
+        self.value = Int32(self.hll!.count())
     }
 }

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -875,6 +875,10 @@ class CRDTTree: CRDTElement {
 
     /**
      * `style` applies the given attributes of the given range.
+     *
+     * - Returns: A tuple of GC pairs, tree changes, data size delta, previous attribute values
+     *   captured from the first styled node (for undo reverse op), and keys of attributes that
+     *   did not previously exist on the first styled node (for undo reverse op).
      */
     @discardableResult
     func style(
@@ -882,7 +886,7 @@ class CRDTTree: CRDTElement {
         _ attributes: [String: String]?,
         _ editedAt: TimeTicket,
         _ versionVector: VersionVector?
-    ) throws -> ([GCPair], [TreeChange], DataSize) {
+    ) throws -> ([GCPair], [TreeChange], DataSize, [String: String], [String]) {
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
         let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
@@ -895,6 +899,9 @@ class CRDTTree: CRDTElement {
 
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
+        var prevAttributes = [String: String]()
+        var newAttrKeys = [String]()
+        var capturedPrev = false
         try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { token, _ in
             let (node, tokenType) = token
             let actorID = node.createdAt.actorID
@@ -912,6 +919,19 @@ class CRDTTree: CRDTElement {
                 // concurrent split extended the range into the sibling.
                 if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
                     return
+                }
+
+                // Capture previous attribute values from the first styled node
+                // for the reverse operation (undo).
+                if !capturedPrev {
+                    for key in attributes.keys {
+                        if let existing = node.attrs?.getNodeByKey(key)?.value {
+                            prevAttributes[key] = existing
+                        } else {
+                            newAttrKeys.append(key)
+                        }
+                    }
+                    capturedPrev = true
                 }
 
                 let updatedAttrPairs = node.setAttrs(attributes, editedAt)
@@ -951,18 +971,21 @@ class CRDTTree: CRDTElement {
             }
         }
 
-        return (pairs, changes, diff)
+        return (pairs, changes, diff, prevAttributes, newAttrKeys)
     }
 
     /**
      * `removeStyle` removes the given attributes of the given range.
+     *
+     * - Returns: A tuple of GC pairs, tree changes, data size delta, and previous attribute values
+     *   captured from the first styled node (for undo reverse op).
      */
     func removeStyle(
         _ range: TreePosRange,
         _ attributesToRemove: [String],
         _ editedAt: TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([GCPair], [TreeChange], DataSize) {
+    ) throws -> ([GCPair], [TreeChange], DataSize, [String: String]) {
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
         let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
@@ -976,6 +999,8 @@ class CRDTTree: CRDTElement {
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
         let value = TreeChangeValue.attributesToRemove(attributesToRemove)
+        var prevAttributes = [String: String]()
+        var capturedPrev = false
 
         try self.traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { token, _ in
             let (node, tokenType) = token
@@ -994,6 +1019,17 @@ class CRDTTree: CRDTElement {
                 // concurrent split extended the range into the sibling.
                 if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
                     return
+                }
+
+                // Capture previous attribute values from the first styled node
+                // for the reverse operation (undo).
+                if !capturedPrev {
+                    for key in attributesToRemove {
+                        if let existing = node.attrs?.getNodeByKey(key)?.value {
+                            prevAttributes[key] = existing
+                        }
+                    }
+                    capturedPrev = true
                 }
 
                 if node.attrs == nil {
@@ -1021,7 +1057,7 @@ class CRDTTree: CRDTElement {
             }
         }
 
-        return (pairs, changes, diff)
+        return (pairs, changes, diff, prevAttributes)
     }
 
     /**
@@ -1132,7 +1168,7 @@ class CRDTTree: CRDTElement {
             var parent = fromParent
             var left = fromLeft
             while splitCount < splitLevel {
-                try parent.split(self, Int32(parent.findOffset(node: left) + 1), issueTimeTicket(), versionVector)
+                try parent.split(self, Int32(parent.findOffset(node: left, includeRemoved: true) + 1), issueTimeTicket(), versionVector)
                 left = parent
                 parent = parent.parent!
                 splitCount += 1

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -925,7 +925,9 @@ class CRDTTree: CRDTElement {
                 // for the reverse operation (undo).
                 if !capturedPrev {
                     for key in attributes.keys {
-                        if let existing = node.attrs?.getNodeByKey(key)?.value {
+                        // A tombstoned (removed) attribute counts as absent, so the
+                        // reverse op removes the key rather than restoring a stale value.
+                        if node.attrs?.has(key: key) == true, let existing = node.attrs?.getNodeByKey(key)?.value {
                             prevAttributes[key] = existing
                         } else {
                             newAttrKeys.append(key)
@@ -1024,7 +1026,7 @@ class CRDTTree: CRDTElement {
                 // Capture previous attribute values from the first styled node
                 // for the reverse operation (undo).
                 if !capturedPrev {
-                    for key in attributesToRemove {
+                    for key in attributesToRemove where node.attrs?.has(key: key) == true {
                         if let existing = node.attrs?.getNodeByKey(key)?.value {
                             prevAttributes[key] = existing
                         }

--- a/Sources/Document/CRDT/HLL.swift
+++ b/Sources/Document/CRDT/HLL.swift
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// HyperLogLog precision and register count.
+private let hllPrecision = 14
+private let hllRegisterCount = 1 << hllPrecision // 16384
+
+// xxhash64 constants (64-bit, matching Go's cespare/xxhash/v2 and JS implementation).
+private let prime64x1: UInt64 = 0x9E37_79B1_85EB_CA87
+private let prime64x2: UInt64 = 0xC2B2_AE3D_27D4_EB4F
+private let prime64x3: UInt64 = 0x1656_67B1_9E37_79F9
+private let prime64x4: UInt64 = 0x85EB_CA77_C2B2_AE63
+private let prime64x5: UInt64 = 0x27D4_EB2F_1656_67C5
+
+/**
+ * `HLL` is a HyperLogLog implementation used for approximate cardinality
+ * estimation in Counter dedup mode. It uses xxhash64 hashing (matching the
+ * Go server) and precision 14 (16384 registers, ~16KB, ~2% error).
+ */
+class HLL {
+    private var registers: [UInt8]
+
+    init() {
+        self.registers = [UInt8](repeating: 0, count: hllRegisterCount)
+    }
+
+    /// Adds a value to the HLL and returns true if the register was updated.
+    @discardableResult
+    func add(value: String) -> Bool {
+        let hash = xxhash64(input: value)
+        let idx = Int(hash >> UInt64(64 - hllPrecision))
+        // Shift the hash left by precision bits to get the remaining bits,
+        // then OR in a sentinel 1 at bit (precision-1) so countLeadingZeros64
+        // terminates correctly even when all remaining bits are zero.
+        let remaining = (hash &<< UInt64(hllPrecision)) | (1 << UInt64(hllPrecision - 1))
+        let rho = countLeadingZeros64(remaining) + 1
+        if rho > self.registers[idx] {
+            self.registers[idx] = rho
+            return true
+        }
+        return false
+    }
+
+    /// Returns the approximate cardinality estimate.
+    func count() -> Int {
+        let registerCount = hllRegisterCount
+        let alpha = 0.7213 / (1.0 + 1.079 / Double(registerCount))
+        var sum = 0.0
+        var zeros = 0
+        for idx in 0 ..< registerCount {
+            sum += pow(2.0, -Double(self.registers[idx]))
+            if self.registers[idx] == 0 { zeros += 1 }
+        }
+        var estimate = (alpha * Double(registerCount) * Double(registerCount)) / sum
+        if estimate <= 2.5 * Double(registerCount), zeros > 0 {
+            estimate = Double(registerCount) * log(Double(registerCount) / Double(zeros))
+        }
+        return Int(estimate.rounded())
+    }
+
+    /// Merges another HLL into this one by taking the max of each register.
+    ///
+    /// This operation is commutative, associative, and idempotent.
+    func merge(_ other: HLL) {
+        for idx in 0 ..< hllRegisterCount where other.registers[idx] > self.registers[idx] {
+            self.registers[idx] = other.registers[idx]
+        }
+    }
+
+    /// Serializes the HLL registers to a byte array.
+    func toBytes() -> [UInt8] {
+        return self.registers
+    }
+
+    /// Restores the HLL registers from a byte array.
+    ///
+    /// - Parameter data: The byte array to restore from.
+    /// - Throws: ``YorkieError`` with code ``YorkieErrorCode/errInvalidArgument``
+    ///   when the data length does not match the register count.
+    func restore(_ data: [UInt8]) throws {
+        guard data.count == hllRegisterCount else {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "invalid HLL register payload: got \(data.count) bytes, want \(hllRegisterCount)"
+            )
+        }
+        self.registers = data
+    }
+}
+
+// MARK: - xxhash64
+
+/// Computes a 64-bit xxHash of the given string with seed 0.
+///
+/// Produces identical output to Go's cespare/xxhash/v2.
+/// All multi-byte reads are little-endian, matching the JS reference implementation.
+private func xxhash64(input: String) -> UInt64 {
+    let buf = Array(input.utf8)
+    let len = buf.count
+    var h64: UInt64
+    var offset = 0
+
+    if len >= 32 {
+        var v1: UInt64 = 0 &+ prime64x1 &+ prime64x2
+        var v2: UInt64 = 0 &+ prime64x2
+        var v3: UInt64 = 0
+        var v4: UInt64 = 0 &- prime64x1
+
+        while offset <= len - 32 {
+            v1 = xxRound(v1, readU64LE(buf, offset)); offset += 8
+            v2 = xxRound(v2, readU64LE(buf, offset)); offset += 8
+            v3 = xxRound(v3, readU64LE(buf, offset)); offset += 8
+            v4 = xxRound(v4, readU64LE(buf, offset)); offset += 8
+        }
+
+        h64 = rotl64(v1, 1) &+ rotl64(v2, 7) &+ rotl64(v3, 12) &+ rotl64(v4, 18)
+        h64 = xxMergeRound(h64, v1)
+        h64 = xxMergeRound(h64, v2)
+        h64 = xxMergeRound(h64, v3)
+        h64 = xxMergeRound(h64, v4)
+    } else {
+        h64 = 0 &+ prime64x5
+    }
+
+    h64 = h64 &+ UInt64(len)
+
+    while offset + 8 <= len {
+        let k1 = xxRound(0, readU64LE(buf, offset))
+        h64 = rotl64(h64 ^ k1, 27) &* prime64x1 &+ prime64x4
+        offset += 8
+    }
+
+    if offset + 4 <= len {
+        h64 = h64 ^ (UInt64(readU32LE(buf, offset)) &* prime64x1)
+        h64 = rotl64(h64, 23) &* prime64x2 &+ prime64x3
+        offset += 4
+    }
+
+    while offset < len {
+        h64 = h64 ^ (UInt64(buf[offset]) &* prime64x5)
+        h64 = rotl64(h64, 11) &* prime64x1
+        offset += 1
+    }
+
+    h64 = (h64 ^ (h64 >> 33)) &* prime64x2
+    h64 = (h64 ^ (h64 >> 29)) &* prime64x3
+    h64 = h64 ^ (h64 >> 32)
+
+    return h64
+}
+
+/// Rotates a 64-bit value left by `shift` bits.
+private func rotl64(_ value: UInt64, _ shift: UInt64) -> UInt64 {
+    return (value &<< shift) | (value >> (64 - shift))
+}
+
+/// Performs a single xxhash64 accumulator round.
+private func xxRound(_ acc: UInt64, _ input: UInt64) -> UInt64 {
+    var accum = acc
+    accum = accum &+ (input &* prime64x2)
+    accum = rotl64(accum, 31)
+    return accum &* prime64x1
+}
+
+/// Merges an accumulator lane into the final hash.
+private func xxMergeRound(_ acc: UInt64, _ val: UInt64) -> UInt64 {
+    let rounded = xxRound(0, val)
+    var accum = acc ^ rounded
+    return accum &* prime64x1 &+ prime64x4
+}
+
+/// Reads a little-endian 64-bit unsigned integer from `buf` starting at `offset`.
+private func readU64LE(_ buf: [UInt8], _ offset: Int) -> UInt64 {
+    // Read bytes from highest to lowest index, shifting left 8 bits each step —
+    // this matches the JS `for (let i = 7; i >= 0; i--) { val = (val << 8n) | buf[offset+i] }`.
+    var val: UInt64 = 0
+    for byteIdx in stride(from: 7, through: 0, by: -1) {
+        val = (val << 8) | UInt64(buf[offset + byteIdx])
+    }
+    return val
+}
+
+/// Reads a little-endian 32-bit unsigned integer from `buf` starting at `offset`.
+private func readU32LE(_ buf: [UInt8], _ offset: Int) -> UInt32 {
+    return UInt32(buf[offset])
+        | (UInt32(buf[offset + 1]) << 8)
+        | (UInt32(buf[offset + 2]) << 16)
+        | (UInt32(buf[offset + 3]) << 24)
+}
+
+/// Counts the number of leading zero bits in a 64-bit unsigned integer.
+///
+/// Returns 64 when `value` is zero, mirroring the JS implementation.
+private func countLeadingZeros64(_ value: UInt64) -> UInt8 {
+    if value == 0 { return 64 }
+    return UInt8(value.leadingZeroBitCount)
+}

--- a/Sources/Document/Json/ElementConverter.swift
+++ b/Sources/Document/Json/ElementConverter.swift
@@ -53,6 +53,10 @@ enum ElementConverter {
             return JSONObject(target: object, context: context)
         } else if let array = value as? CRDTArray {
             return JSONArray(target: array, changeContext: context)
+        } else if let value = value as? CRDTCounter<Int32>, value.isDedup {
+            let counter = JSONDedupCounter()
+            counter.initialize(context: context, counter: value)
+            return counter
         } else if let value = value as? CRDTCounter<Int32> {
             let counter = JSONCounter(value: value.value)
             counter.initialize(context: context, counter: value)

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -458,6 +458,19 @@ public class JSONArray: CustomDebugStringConvertible {
             self.context.push(operation: operation)
 
             return counter
+        } else if let element = value as? JSONDedupCounter {
+            let counter = CRDTCounter<Int32>(dedupWithCreatedAt: ticket)
+            element.initialize(context: self.context, counter: counter)
+
+            let clone = counter.deepcopy()
+
+            try self.target.insert(value: clone, prevCreatedAt: previousCreatedAt)
+            self.context.registerElement(clone, parent: self.target)
+
+            let operation = AddOperation(parentCreatedAt: self.target.createdAt, previousCreatedAt: previousCreatedAt, value: counter, executedAt: ticket)
+            self.context.push(operation: operation)
+
+            return counter
         } else if let element = value as? JSONText {
             let text = CRDTText(rgaTreeSplit: RGATreeSplit(), createdAt: ticket)
             element.initialize(context: self.context, text: text)

--- a/Sources/Document/Json/JSONDedupCounter.swift
+++ b/Sources/Document/Json/JSONDedupCounter.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/**
+ * `JSONDedupCounter` is a counter that counts unique actors using HyperLogLog
+ * deduplication. Use ``add(_:)`` to record a unique actor visit. The ``value``
+ * property returns an approximate cardinality estimate (~2 % error rate).
+ *
+ * ```swift
+ * doc.update { root, _ in
+ *     root.uv = JSONDedupCounter()
+ *     (root.uv as? JSONDedupCounter)?.add("userId-abc")
+ * }
+ * ```
+ *
+ * Mirror of JS `DedupCounter` from `document/json/counter.ts`.
+ */
+public class JSONDedupCounter {
+    private var context: ChangeContext?
+    private var counter: CRDTCounter<Int32>?
+
+    /// Creates a new dedup counter with an initial value of 0.
+    public init() {}
+
+    // MARK: – Internal wiring
+
+    /// Links this proxy to a ``ChangeContext`` and the underlying CRDT counter.
+    func initialize(context: ChangeContext, counter: CRDTCounter<Int32>) {
+        self.context = context
+        self.counter = counter
+    }
+
+    // MARK: – Public API
+
+    /// The document-unique identifier of this counter.
+    public var id: TimeTicket? {
+        self.counter?.id
+    }
+
+    /// The current approximate unique-actor count.
+    public var value: Int32 {
+        self.counter?.value ?? 0
+    }
+
+    /// Records `actor` as a unique visitor.
+    ///
+    /// If `actor` has already been recorded the call is a no-op (HLL
+    /// idempotency). Calling this before the counter has been initialized
+    /// (i.e. outside a document update closure) throws.
+    ///
+    /// - Parameter actor: A non-empty string that uniquely identifies the actor.
+    /// - Returns: `self` for chaining.
+    /// - Throws: ``YorkieError`` when not yet initialized or when `actor` is empty.
+    @discardableResult
+    public func add(_ actor: String) throws -> Self {
+        guard let context, let counter else {
+            throw YorkieError(code: .errNotInitialized, message: "DedupCounter is not initialized yet")
+        }
+        guard !actor.isEmpty else {
+            throw YorkieError(code: .errInvalidArgument, message: "actor is required")
+        }
+
+        let ticket = context.issueTimeTicket
+        let primitive = Primitive(value: .integer(1), createdAt: ticket)
+
+        try counter.increaseDedup(primitive, actor: actor)
+
+        context.push(
+            operation: IncreaseOperation(
+                parentCreatedAt: counter.createdAt,
+                value: primitive,
+                executedAt: ticket,
+                actor: actor
+            )
+        )
+
+        return self
+    }
+}
+
+extension JSONDedupCounter: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "\(self.value)"
+    }
+}

--- a/Sources/Document/Json/JSONObject.swift
+++ b/Sources/Document/Json/JSONObject.swift
@@ -96,6 +96,10 @@ public class JSONObject {
             let counter = CRDTCounter<Int64>(value: value, createdAt: ticket)
             element.initialize(context: self.context, counter: counter)
             self.setValue(key: key, value: counter, ticket: ticket)
+        } else if let element = value as? JSONDedupCounter {
+            let counter = CRDTCounter<Int32>(dedupWithCreatedAt: ticket)
+            element.initialize(context: self.context, counter: counter)
+            self.setValue(key: key, value: counter, ticket: ticket)
         } else if let element = value as? JSONText {
             let text = CRDTText(rgaTreeSplit: RGATreeSplit(), createdAt: ticket)
             element.initialize(context: self.context, text: text)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -650,7 +650,7 @@ public class JSONTree {
 
         let ticket = context.issueTimeTicket
 
-        let (pairs, _, diff) = try tree.style((fromPos, toPos), stringAttrs, ticket, nil)
+        let (pairs, _, diff, _, _) = try tree.style((fromPos, toPos), stringAttrs, ticket, nil)
         self.context?.acc(diff)
 
         context.push(
@@ -732,7 +732,7 @@ public class JSONTree {
 
         let ticket = context.issueTimeTicket
 
-        let (pairs, _, diff) = try tree.removeStyle((fromPos, toPos), attributesToRemove, ticket)
+        let (pairs, _, diff, _) = try tree.removeStyle((fromPos, toPos), attributesToRemove, ticket)
         self.context?.acc(diff)
 
         for pair in pairs {

--- a/Sources/Document/Operation/IncreaseOperation.swift
+++ b/Sources/Document/Operation/IncreaseOperation.swift
@@ -19,6 +19,7 @@ import Foundation
 /**
  * `IncreaseOperation` represents an operation that increments a numeric value to Counter.
  * Among Primitives, numeric types Integer, Long, and Double are used as values.
+ * For dedup counters the `actor` field identifies the unique actor being recorded.
  */
 struct IncreaseOperation: Operation {
     var parentCreatedAt: TimeTicket
@@ -26,10 +27,14 @@ struct IncreaseOperation: Operation {
 
     let value: CRDTElement
 
-    init(parentCreatedAt: TimeTicket, value: CRDTElement, executedAt: TimeTicket) {
+    /// The actor identifier used by dedup counters; empty string for regular counters.
+    let actor: String
+
+    init(parentCreatedAt: TimeTicket, value: CRDTElement, executedAt: TimeTicket, actor: String = "") {
         self.parentCreatedAt = parentCreatedAt
         self.executedAt = executedAt
         self.value = value
+        self.actor = actor
     }
 
     var effectedCreatedAt: TimeTicket {
@@ -40,8 +45,17 @@ struct IncreaseOperation: Operation {
         "\(self.parentCreatedAt.toTestString).INCREASE"
     }
 
+    /// Returns the actor identifier; empty string for regular counters.
+    func getActor() -> String {
+        return self.actor
+    }
+
     /**
      * `execute` executes this operation on the given document(`root`).
+     *
+     * Dedup counters use ``CRDTCounter/increaseDedup(_:actor:)`` and produce
+     * no undo operation (HLL state cannot be reversed). Regular counters use
+     * the standard ``CRDTCounter/increase(_:)`` path.
      */
     @discardableResult
     func execute(
@@ -61,7 +75,18 @@ struct IncreaseOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        if let counter = parentObject as? CRDTCounter<Int32> {
+        if let counter = parentObject as? CRDTCounter<Int32>, counter.isDedup {
+            // Dedup path — actor must be provided.
+            guard !self.actor.isEmpty else {
+                throw YorkieError(
+                    code: .errInvalidArgument,
+                    message: "dedup counter requires actor"
+                )
+            }
+            if let primitive = self.value.deepcopy() as? Primitive {
+                try counter.increaseDedup(primitive, actor: self.actor)
+            }
+        } else if let counter = parentObject as? CRDTCounter<Int32> {
             if let value = self.value.deepcopy() as? Primitive {
                 try counter.increase(value)
             }

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -61,6 +61,10 @@ final class TreeEditOperation: Operation {
     private var lastFromIdx: Int?
     /// The pre-edit end index captured by the most recent `execute`, used to reconcile parked ops.
     private var lastToIdx: Int?
+    /// Set on boundary-deletion ops that were generated to reverse a split. When this op executes
+    /// (as undo), ``toReverseOperation(_:_:_:)`` uses this value to regenerate a proper split op
+    /// for redo, rather than re-inserting the tombstoned boundary nodes as content.
+    fileprivate var redoSplitLevel: Int32?
 
     init(parentCreatedAt: TimeTicket,
          fromPos: CRDTTreePos,
@@ -135,10 +139,21 @@ final class TreeEditOperation: Operation {
         let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }
         self.lastToIdx = preEditFromIdx + removedSize
 
-        // Build the reverse op for undo. Phase 1 skips split edits (splitLevel > 0).
-        let reverseOp = self.splitLevel == 0
-            ? try self.toReverseOperation(tree, removedNodes, preEditFromIdx)
-            : nil
+        // Build the reverse op for undo.
+        // A pure level-1 split (no content inserted, no nodes removed) gets a boundary-deletion
+        // reverse so that undo merges the split elements back. All other splits are skipped for
+        // now — only splitLevel=0 (regular edits) and pure level-1 splits produce a reverse op.
+        let isPureL1Split = self.splitLevel == 1
+            && (self.contents?.isEmpty ?? true)
+            && removedNodes.isEmpty
+        let reverseOp: Operation?
+        if self.splitLevel == 0 {
+            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx)
+        } else if isPureL1Split {
+            reverseOp = try self.toSplitReverseOperation(tree, preEditFromIdx)
+        } else {
+            reverseOp = nil
+        }
 
         root.acc(diff)
 
@@ -183,6 +198,25 @@ final class TreeEditOperation: Operation {
     ///   - preEditFromIdx: The start index captured before the edit deletions.
     /// - Returns: The reverse ``TreeEditOperation``, or `nil` when the edit was a no-op.
     private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int) throws -> Operation? {
+        // Special case: this op is a boundary-deletion that was generated to reverse a split.
+        // Its redo (i.e. the reverse of this reverse) should re-split at the merged position,
+        // not re-insert the tombstoned boundary nodes as raw content.
+        if let redoSplitLevel, redoSplitLevel > 0 {
+            let splitRedoFromPos = try tree.findPos(preEditFromIdx)
+            let splitRedoOp = TreeEditOperation(
+                parentCreatedAt: self.parentCreatedAt,
+                fromPos: splitRedoFromPos,
+                toPos: splitRedoFromPos,
+                contents: nil,
+                splitLevel: redoSplitLevel,
+                executedAt: TimeTicket.initial,
+                isUndoOp: true,
+                fromIdx: preEditFromIdx,
+                toIdx: preEditFromIdx
+            )
+            return splitRedoOp
+        }
+
         // Total tree-index tokens inserted by this edit.
         let insertedContentSize = self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
 
@@ -230,6 +264,49 @@ final class TreeEditOperation: Operation {
             fromIdx: preEditFromIdx,
             toIdx: preEditFromIdx + insertedContentSize
         )
+    }
+
+    /// `toSplitReverseOperation` creates the reverse operation for a pure level-1 split edit.
+    ///
+    /// A split creates element boundaries (one close token + one open token per level). The reverse
+    /// is a boundary-deletion: a `splitLevel=0` edit that removes those `2 * splitLevel` tokens,
+    /// merging the split elements back together.
+    ///
+    /// The boundary-deletion op carries ``redoSplitLevel`` so that *its* reverse regenerates a
+    /// proper split (redo) rather than re-inserting the tombstoned boundary nodes as content.
+    ///
+    /// - Parameters:
+    ///   - tree: The tree after the split has been applied.
+    ///   - preEditFromIdx: The from index captured before the split.
+    /// - Returns: The boundary-deletion ``TreeEditOperation``, or `nil` when the split was a no-op.
+    private func toSplitReverseOperation(_ tree: CRDTTree, _ preEditFromIdx: Int) throws -> Operation? {
+        let boundarySize = 2 * Int(self.splitLevel)
+        let reverseFromIdx = preEditFromIdx
+        let reverseToIdx = preEditFromIdx + boundarySize
+
+        // Guard: if the indices exceed the post-split tree size, the split was a no-op
+        // (e.g. a concurrent parent deletion tombstoned the split result).
+        if reverseToIdx > tree.size {
+            return nil
+        }
+
+        let reverseFromPos = try tree.findPos(reverseFromIdx)
+        let reverseToPos = try tree.findPos(reverseToIdx)
+
+        let boundaryDeletionOp = TreeEditOperation(
+            parentCreatedAt: self.parentCreatedAt,
+            fromPos: reverseFromPos,
+            toPos: reverseToPos,
+            contents: nil,
+            splitLevel: 0,
+            executedAt: TimeTicket.initial,
+            isUndoOp: true,
+            fromIdx: reverseFromIdx,
+            toIdx: reverseToIdx
+        )
+        // Tag the op so its own reverse (redo) regenerates a split rather than raw content.
+        boundaryDeletionOp.redoSplitLevel = self.splitLevel
+        return boundaryDeletionOp
     }
 
     /// `normalizePos` returns the visible-index `(from, to)` range of this operation.

--- a/Sources/Document/Operation/TreeSytleOperation.swift
+++ b/Sources/Document/Operation/TreeSytleOperation.swift
@@ -63,13 +63,6 @@ class TreeStyleOperation: Operation {
         versionVector: VersionVector? = nil,
         source: OpSource = .local
     ) throws -> ExecutionResult? {
-        try ExecutionResult(opInfos: self.executeOpInfos(root: root, versionVector: versionVector))
-    }
-
-    private func executeOpInfos(
-        root: CRDTRoot,
-        versionVector: VersionVector? = nil
-    ) throws -> [any OperationInfo] {
         guard let parentObject = root.find(createdAt: self.parentCreatedAt) else {
             let log = "fail to find \(self.parentCreatedAt)"
             Logger.critical(log)
@@ -83,21 +76,30 @@ class TreeStyleOperation: Operation {
         let changes: [TreeChange]
         let pairs: [GCPair]
         var diff: DataSize
+        // Attribute state captured from the first styled node, used to build the reverse op.
+        var reversePrevAttributes = [String: String]()
+        var reverseAttrsToRemove = [String]()
 
         if self.attributes.isEmpty == false {
-            (pairs, changes, diff) = try tree.style(
+            let prevAttributes: [String: String]
+            let newAttrKeys: [String]
+            (pairs, changes, diff, prevAttributes, newAttrKeys) = try tree.style(
                 (self.fromPos, self.toPos),
                 self.attributes,
                 self.executedAt,
                 versionVector
             )
+            reversePrevAttributes = prevAttributes
+            reverseAttrsToRemove = newAttrKeys
         } else {
-            (pairs, changes, diff) = try tree.removeStyle(
+            let prevAttributes: [String: String]
+            (pairs, changes, diff, prevAttributes) = try tree.removeStyle(
                 (self.fromPos, self.toPos),
                 self.attributesToRemove,
                 self.executedAt,
                 versionVector
             )
+            reversePrevAttributes = prevAttributes
         }
 
         root.acc(diff)
@@ -108,7 +110,43 @@ class TreeStyleOperation: Operation {
             root.registerGCPair(pair)
         }
 
-        return changes.compactMap { change in
+        // Build the reverse operation for undo.
+        let reverseOp: Operation?
+        if !reversePrevAttributes.isEmpty, !reverseAttrsToRemove.isEmpty {
+            // Both existing attrs to restore and new attrs to remove — combined style op.
+            reverseOp = TreeStyleOperation(
+                parentCreatedAt: self.parentCreatedAt,
+                fromPos: self.fromPos,
+                toPos: self.toPos,
+                attributes: reversePrevAttributes,
+                attributesToRemove: reverseAttrsToRemove,
+                executedAt: TimeTicket.initial
+            )
+        } else if !reverseAttrsToRemove.isEmpty {
+            // Only new attrs to remove — reverse is a removeStyle.
+            reverseOp = TreeStyleOperation(
+                parentCreatedAt: self.parentCreatedAt,
+                fromPos: self.fromPos,
+                toPos: self.toPos,
+                attributes: [:],
+                attributesToRemove: reverseAttrsToRemove,
+                executedAt: TimeTicket.initial
+            )
+        } else if !reversePrevAttributes.isEmpty {
+            // Only existing attrs to restore — reverse is a style.
+            reverseOp = TreeStyleOperation(
+                parentCreatedAt: self.parentCreatedAt,
+                fromPos: self.fromPos,
+                toPos: self.toPos,
+                attributes: reversePrevAttributes,
+                attributesToRemove: [],
+                executedAt: TimeTicket.initial
+            )
+        } else {
+            reverseOp = nil
+        }
+
+        let opInfos: [any OperationInfo] = changes.compactMap { change in
             let values: TreeStyleOpValue? = {
                 switch change.value {
                 case .attributes(let attributes):
@@ -129,6 +167,8 @@ class TreeStyleOperation: Operation {
                 value: values
             )
         }
+
+        return ExecutionResult(opInfos: opInfos, reverseOp: reverseOp)
     }
 
     /**

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -489,11 +489,11 @@ extension IndexTreeNode {
         self.innerChildren = leftChildren
         clone.innerChildren = rightChildren
         self.size = self.innerChildren.reduce(0) { acc, child in
-            acc + child.paddedSize
+            acc + (child.isRemoved ? 0 : child.paddedSize)
         }
 
         clone.size = clone.innerChildren.reduce(0) { acc, child in
-            acc + child.paddedSize
+            acc + (child.isRemoved ? 0 : child.paddedSize)
         }
         for innerChild in clone.innerChildren {
             innerChild.parent = clone

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.4"
+let yorkieVersion = "0.7.5"

--- a/Tests/Integration/DedupCounterIntegrationTests.swift
+++ b/Tests/Integration/DedupCounterIntegrationTests.swift
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+/// Integration tests for ``JSONDedupCounter`` (HyperLogLog-backed dedup counter).
+///
+/// Ports the new dedup-counter behaviour from yorkie-js-sdk #1215/#1216.
+/// The dedup counter counts distinct actors — repeated add() calls with the
+/// same actor ID are idempotent.
+///
+/// Requires a live 0.7.5 yorkie server.
+final class DedupCounterIntegrationTests: XCTestCase {
+    // MARK: - Basic convergence
+
+    /// Two clients attach to the same document, each registers a distinct actor via
+    /// ``JSONDedupCounter``, sync, and both documents must converge to value 2.
+    ///
+    /// Mirrors the HLL dedup convergence scenario described in yorkie-js-sdk PR #1215.
+    @MainActor
+    func test_can_sync_dedup_counter_with_two_distinct_actors() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — create the dedup counter on d1
+            try d1.update { root, _ in
+                root.uv = JSONDedupCounter()
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — each client records a distinct actor
+            try d1.update { root, _ in
+                try (root.uv as? JSONDedupCounter)?.add("user-a")
+            }
+            try d2.update { root, _ in
+                try (root.uv as? JSONDedupCounter)?.add("user-b")
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both documents must converge (value is approximately 2)
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    /// Same actor added from two concurrent clients — after sync the counter
+    /// must still reflect only 1 distinct actor on both sides.
+    @MainActor
+    func test_can_deduplicate_same_actor_across_two_clients() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.uv = JSONDedupCounter()
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — same actor ID submitted from both clients concurrently
+            try d1.update { root, _ in
+                try (root.uv as? JSONDedupCounter)?.add("shared-user")
+            }
+            try d2.update { root, _ in
+                try (root.uv as? JSONDedupCounter)?.add("shared-user")
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both documents converge; the HLL may estimate ~1 (±1 due to ~2 % error)
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            let value = (d1.getRoot().uv as? JSONDedupCounter)?.value ?? -1
+            XCTAssertGreaterThan(value, 0)
+            XCTAssertLessThanOrEqual(value, 3, "HLL estimate for 1 actor must be ≤ 3")
+        }
+    }
+
+    /// Adding an actor multiple times across multiple update closures is idempotent
+    /// on a single client — the counter value must not keep increasing.
+    @MainActor
+    func test_multiple_adds_for_same_actor_are_idempotent() async throws {
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+
+        let c1 = Client("http://localhost:8080")
+        try await c1.activate()
+
+        let d1 = Document(key: docKey)
+        try await c1.attach(d1, [:], .manual)
+
+        // given
+        try d1.update { root, _ in
+            root.uv = JSONDedupCounter()
+        }
+
+        // when — add the same actor 5 times across separate update closures
+        for _ in 0 ..< 5 {
+            try d1.update { root, _ in
+                try (root.uv as? JSONDedupCounter)?.add("repeat-user")
+            }
+        }
+
+        try await c1.sync()
+
+        // then — value must be 1 (single distinct actor)
+        let value = (d1.getRoot().uv as? JSONDedupCounter)?.value ?? -1
+        XCTAssertEqual(value, 1)
+
+        try await c1.detach(d1)
+        try await c1.deactivate()
+    }
+
+    /// HLL state survives a snapshot round-trip — after the snapshot threshold the
+    /// server compacts history into a snapshot; attaching with a fresh document key
+    /// should restore the same cardinality.
+    @MainActor
+    func test_dedup_counter_survives_snapshot_roundtrip() async throws {
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+
+        let c1 = Client("http://localhost:8080")
+        let c2 = Client("http://localhost:8080")
+        try await c1.activate()
+        try await c2.activate()
+
+        let d1 = Document(key: docKey)
+        try await c1.attach(d1, [:], .manual)
+
+        // given — populate a dedup counter with 3 actors
+        try d1.update { root, _ in
+            root.uv = JSONDedupCounter()
+        }
+        try d1.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-1")
+        }
+        try d1.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-2")
+        }
+        try d1.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-3")
+        }
+        try await c1.sync()
+
+        let originalValue = (d1.getRoot().uv as? JSONDedupCounter)?.value ?? -1
+
+        // when — c2 attaches to the same document key (reads from server state)
+        let d2 = Document(key: docKey)
+        try await c2.attach(d2, [:], .manual)
+        try await c2.sync()
+
+        // then — c2 should see the same approximate cardinality
+        let restoredValue = (d2.getRoot().uv as? JSONDedupCounter)?.value ?? -1
+        XCTAssertEqual(restoredValue, originalValue, "HLL cardinality must be preserved after sync")
+
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+        try await c1.deactivate()
+        try await c2.deactivate()
+    }
+
+    // MARK: - Concurrent actor additions converge
+
+    /// Three clients each add a unique actor concurrently, then sync.
+    /// After full convergence all three must agree on the cardinality.
+    @MainActor
+    func test_can_converge_three_concurrent_distinct_actors() async throws {
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+
+        let c1 = Client("http://localhost:8080")
+        let c2 = Client("http://localhost:8080")
+        let c3 = Client("http://localhost:8080")
+
+        try await c1.activate()
+        try await c2.activate()
+        try await c3.activate()
+
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+        let d3 = Document(key: docKey)
+
+        try await c1.attach(d1, [:], .manual)
+        try await c2.attach(d2, [:], .manual)
+        try await c3.attach(d3, [:], .manual)
+
+        // given
+        try d1.update { root, _ in
+            root.uv = JSONDedupCounter()
+        }
+        try await c1.sync()
+        try await c2.sync()
+        try await c3.sync()
+
+        // when — each client adds a unique actor simultaneously
+        try d1.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-c1")
+        }
+        try d2.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-c2")
+        }
+        try d3.update { root, _ in
+            try (root.uv as? JSONDedupCounter)?.add("actor-c3")
+        }
+
+        // sync in round-robin until convergence
+        try await c1.sync()
+        try await c2.sync()
+        try await c3.sync()
+        try await c1.sync()
+        try await c2.sync()
+        try await c1.sync()
+
+        // then — all three documents must converge to the same JSON
+        let j1 = d1.toSortedJSON()
+        let j2 = d2.toSortedJSON()
+        let j3 = d3.toSortedJSON()
+
+        XCTAssertEqual(j1, j2, "d1 and d2 diverged")
+        XCTAssertEqual(j2, j3, "d2 and d3 diverged")
+
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+        try await c3.detach(d3)
+        try await c1.deactivate()
+        try await c2.deactivate()
+        try await c3.deactivate()
+    }
+}

--- a/Tests/Integration/TreeHistorySplitUndoIntegrationTests.swift
+++ b/Tests/Integration/TreeHistorySplitUndoIntegrationTests.swift
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Helpers
+
+/// Initial tree used by the split L1 tests: <doc><p>ABCD</p></doc>
+@MainActor
+private func initSplitTree(_ doc: Document) throws {
+    try doc.update { root, _ in
+        root.t = JSONTree(initialRoot:
+            JSONTreeElementNode(type: "doc", children: [
+                JSONTreeElementNode(type: "p", children: [
+                    JSONTreeTextNode(value: "ABCD")
+                ])
+            ])
+        )
+    }
+}
+
+/// Returns the XML of the `t` field in the document root.
+@MainActor
+private func treeXML(_ doc: Document) -> String {
+    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+}
+
+// MARK: - 4b. Single Client — Split L1 undo/redo (table-driven)
+
+//
+// Ports: "Tree History - single client split L1 undo/redo"
+// from packages/sdk/test/integration/history_tree_test.ts (v0.7.5 block
+// added in #1219, lines 484–590).
+//
+// Tree: <doc><p>ABCD</p></doc>
+// split index 1 → <doc><p></p><p>ABCD</p></doc>   (front)
+// split index 3 → <doc><p>AB</p><p>CD</p></doc>   (middle)
+// split index 5 → <doc><p>ABCD</p><p></p></doc>   (back)
+
+/// Positions, indexes and expected XML for each split variant.
+private struct SplitL1Case {
+    let pos: String
+    let splitIdx: Int
+    let afterXML: String
+}
+
+private let splitL1Cases: [SplitL1Case] = [
+    SplitL1Case(pos: "front", splitIdx: 1, afterXML: "<doc><p></p><p>ABCD</p></doc>"),
+    SplitL1Case(pos: "middle", splitIdx: 3, afterXML: "<doc><p>AB</p><p>CD</p></doc>"),
+    SplitL1Case(pos: "back", splitIdx: 5, afterXML: "<doc><p>ABCD</p><p></p></doc>")
+]
+
+final class TreeHistorySplitL1UndoTests: XCTestCase {
+    // MARK: - should undo split
+
+    // Ports: "should undo split at front"
+    @MainActor
+    func test_can_undo_split_at_front() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "front" })!
+        try self.runUndoSplitTest(tc)
+    }
+
+    // Ports: "should undo split at middle"
+    @MainActor
+    func test_can_undo_split_at_middle() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "middle" })!
+        try self.runUndoSplitTest(tc)
+    }
+
+    // Ports: "should undo split at back"
+    @MainActor
+    func test_can_undo_split_at_back() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "back" })!
+        try self.runUndoSplitTest(tc)
+    }
+
+    // MARK: - should undo-redo split
+
+    // Ports: "should undo-redo split at front"
+    @MainActor
+    func test_can_undo_redo_split_at_front() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "front" })!
+        try self.runUndoRedoSplitTest(tc)
+    }
+
+    // Ports: "should undo-redo split at middle"
+    @MainActor
+    func test_can_undo_redo_split_at_middle() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "middle" })!
+        try self.runUndoRedoSplitTest(tc)
+    }
+
+    // Ports: "should undo-redo split at back"
+    @MainActor
+    func test_can_undo_redo_split_at_back() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "back" })!
+        try self.runUndoRedoSplitTest(tc)
+    }
+
+    // MARK: - should undo-redo-undo split
+
+    // Ports: "should undo-redo-undo split at front"
+    @MainActor
+    func test_can_undo_redo_undo_split_at_front() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "front" })!
+        try self.runUndoRedoUndoSplitTest(tc)
+    }
+
+    // Ports: "should undo-redo-undo split at middle"
+    @MainActor
+    func test_can_undo_redo_undo_split_at_middle() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "middle" })!
+        try self.runUndoRedoUndoSplitTest(tc)
+    }
+
+    // Ports: "should undo-redo-undo split at back"
+    @MainActor
+    func test_can_undo_redo_undo_split_at_back() throws {
+        let tc = splitL1Cases.first(where: { $0.pos == "back" })!
+        try self.runUndoRedoUndoSplitTest(tc)
+    }
+
+    // MARK: - shared helpers
+
+    @MainActor
+    private func runUndoSplitTest(_ tc: SplitL1Case) throws {
+        // given
+        let doc = Document(key: "split-l1-undo-\(tc.pos)".toDocKey)
+        try initSplitTree(doc)
+        let beforeXML = treeXML(doc)
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(tc.splitIdx, tc.splitIdx, nil, 1)
+        }
+        XCTAssertEqual(treeXML(doc), tc.afterXML, "split at \(tc.pos) produced wrong XML")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), beforeXML, "undo split at \(tc.pos) failed")
+    }
+
+    @MainActor
+    private func runUndoRedoSplitTest(_ tc: SplitL1Case) throws {
+        // given
+        let doc = Document(key: "split-l1-undo-redo-\(tc.pos)".toDocKey)
+        try initSplitTree(doc)
+        let beforeXML = treeXML(doc)
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(tc.splitIdx, tc.splitIdx, nil, 1)
+        }
+
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), beforeXML, "undo split at \(tc.pos) failed")
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(treeXML(doc), tc.afterXML, "redo split at \(tc.pos) failed")
+    }
+
+    @MainActor
+    private func runUndoRedoUndoSplitTest(_ tc: SplitL1Case) throws {
+        // given
+        let doc = Document(key: "split-l1-uru-\(tc.pos)".toDocKey)
+        try initSplitTree(doc)
+        let beforeXML = treeXML(doc)
+
+        // when
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(tc.splitIdx, tc.splitIdx, nil, 1)
+        }
+
+        try doc.undo()
+        try doc.redo()
+        try doc.undo()
+
+        // then
+        XCTAssertEqual(treeXML(doc), beforeXML, "undo-redo-undo split at \(tc.pos) failed")
+    }
+}
+
+// MARK: - 4b-edge. Split L1 edge cases
+
+//
+// Ports: "Tree History - split L1 edge cases" (v0.7.5, lines 1375–1456).
+
+final class TreeHistorySplitL1EdgeCasesTests: XCTestCase {
+    // Ports: "should undo front split with empty paragraph"
+    @MainActor
+    func test_can_undo_front_split_with_empty_paragraph() throws {
+        // given — <doc><p>AB</p></doc>
+        let doc = Document(key: "split-l1-edge-front-empty".toDocKey)
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "AB")
+                    ])
+                ])
+            )
+        }
+        let beforeXML = treeXML(doc)
+
+        // when — split at front (idx 1) → <doc><p></p><p>AB</p></doc>
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, nil, 1)
+        }
+        XCTAssertEqual(treeXML(doc), "<doc><p></p><p>AB</p></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), beforeXML, "undo front split with empty paragraph failed")
+    }
+
+    // Ports: "should undo back split with empty paragraph"
+    @MainActor
+    func test_can_undo_back_split_with_empty_paragraph() throws {
+        // given — <doc><p>AB</p></doc>
+        let doc = Document(key: "split-l1-edge-back-empty".toDocKey)
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "AB")
+                    ])
+                ])
+            )
+        }
+        let beforeXML = treeXML(doc)
+
+        // when — split at back (idx 3) → <doc><p>AB</p><p></p></doc>
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
+        }
+        XCTAssertEqual(treeXML(doc), "<doc><p>AB</p><p></p></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), beforeXML, "undo back split with empty paragraph failed")
+    }
+
+    // Ports: "should clear redo stack when new edit is made after split undo"
+    @MainActor
+    func test_clears_redo_stack_when_new_edit_made_after_split_undo() throws {
+        // given — <doc><p>ABCD</p></doc>
+        let doc = Document(key: "split-l1-edge-clear-redo".toDocKey)
+        try initSplitTree(doc)
+
+        // when — split at middle, undo, then make a new edit
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
+        }
+        try doc.undo()
+        XCTAssertTrue(doc.canRedo, "redo stack must be non-empty after undo")
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "Z"))
+        }
+
+        // then — redo stack must be cleared by the new edit
+        XCTAssertFalse(doc.canRedo, "redo stack must be empty after new edit")
+    }
+}
+
+// MARK: - 4c. Single Client — Split L1 chained with other ops (table-driven)
+
+//
+// Ports: "Tree History - single client split L1 chained ops" (v0.7.5, lines 1175–1236).
+//
+// Each test performs op1 then op2, captures snapshots s0, s1, s2, then
+// verifies undo/redo cycles restore s1 and s0 / s1 and s2.
+
+private enum SplitChainOp: String, CaseIterable {
+    case split, insertText = "insert-text", deleteText = "delete-text"
+}
+
+@MainActor
+private func applySplitChainOp(_ doc: Document, _ op: SplitChainOp) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case .split:
+            // Split first <p> at offset 2 (between 2nd and 3rd char).
+            try tree.editByPath([0, 2], [0, 2], nil, 1)
+        case .insertText:
+            // Insert 'X' at start of first <p>.
+            try tree.editByPath([0, 0], [0, 0], JSONTreeTextNode(value: "X"))
+        case .deleteText:
+            // Delete first char of first <p>.
+            try tree.edit(1, 2)
+        }
+    }
+}
+
+final class TreeHistorySplitL1ChainedOpsTests: XCTestCase {
+    // The JS test generates all 9 (op1, op2) pairs from the 3-element set.
+    // Each pair is expanded into an individual test method below.
+
+    // Ports: "should undo chain: split → split"
+    @MainActor
+    func test_can_undo_chain_split_split() throws {
+        try self.runChain(.split, .split)
+    }
+
+    // Ports: "should undo chain: split → insert-text"
+    @MainActor
+    func test_can_undo_chain_split_insertText() throws {
+        try self.runChain(.split, .insertText)
+    }
+
+    // Ports: "should undo chain: split → delete-text"
+    @MainActor
+    func test_can_undo_chain_split_deleteText() throws {
+        try self.runChain(.split, .deleteText)
+    }
+
+    // Ports: "should undo chain: insert-text → split"
+    @MainActor
+    func test_can_undo_chain_insertText_split() throws {
+        try self.runChain(.insertText, .split)
+    }
+
+    // Ports: "should undo chain: insert-text → insert-text"
+    @MainActor
+    func test_can_undo_chain_insertText_insertText() throws {
+        try self.runChain(.insertText, .insertText)
+    }
+
+    // Ports: "should undo chain: insert-text → delete-text"
+    @MainActor
+    func test_can_undo_chain_insertText_deleteText() throws {
+        try self.runChain(.insertText, .deleteText)
+    }
+
+    // Ports: "should undo chain: delete-text → split"
+    @MainActor
+    func test_can_undo_chain_deleteText_split() throws {
+        try self.runChain(.deleteText, .split)
+    }
+
+    // Ports: "should undo chain: delete-text → insert-text"
+    @MainActor
+    func test_can_undo_chain_deleteText_insertText() throws {
+        try self.runChain(.deleteText, .insertText)
+    }
+
+    // Ports: "should undo chain: delete-text → delete-text"
+    @MainActor
+    func test_can_undo_chain_deleteText_deleteText() throws {
+        try self.runChain(.deleteText, .deleteText)
+    }
+
+    // MARK: - shared helper
+
+    @MainActor
+    private func runChain(_ op1: SplitChainOp, _ op2: SplitChainOp) throws {
+        // given — <doc><p>ABCD</p></doc>
+        let key = "split-chain-\(op1.rawValue)-\(op2.rawValue)".toDocKey
+        let doc = Document(key: key)
+        try initSplitTree(doc)
+
+        let s0 = treeXML(doc)
+        try applySplitChainOp(doc, op1)
+        let s1 = treeXML(doc)
+        try applySplitChainOp(doc, op2)
+        let s2 = treeXML(doc)
+
+        // when — undo twice: s2 → s1 → s0
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), s1, "undo \(op2) failed")
+        try doc.undo()
+        XCTAssertEqual(treeXML(doc), s0, "undo \(op1) failed")
+
+        // then — redo twice: s0 → s1 → s2
+        try doc.redo()
+        XCTAssertEqual(treeXML(doc), s1, "redo \(op1) failed")
+        try doc.redo()
+        XCTAssertEqual(treeXML(doc), s2, "redo \(op2) failed")
+    }
+}
+
+// MARK: - 4d. Multi Client — Split L1 convergence after undo (table-driven)
+
+//
+// Ports: "Tree History - multi client split L1 convergence" (v0.7.5, lines 1238–1374).
+// Requires a live 0.7.5 yorkie server.
+//
+// Initial tree: <doc><p>ABCD</p><p>EFGH</p></doc>
+// d1: split first <p> at middle (idx 3) with splitLevel=1
+// d2: concurrent remote op at various positions
+// Then d1 undoes the split — d1 and d2 must converge.
+
+private enum SplitRemoteOp: String, CaseIterable {
+    case insertText = "insert-text"
+    case deleteText = "delete-text"
+    case insertElement = "insert-element"
+}
+
+private enum SplitRemotePos: String, CaseIterable {
+    case beforeSplit = "before-split"
+    case afterSplit = "after-split"
+    case differentElement = "different-element"
+}
+
+@MainActor
+private func applyRemoteOpForSplitConvergence(
+    _ doc: Document,
+    op: SplitRemoteOp,
+    pos: SplitRemotePos
+) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch (op, pos) {
+        case (.insertText, .beforeSplit):
+            try tree.edit(1, 1, JSONTreeTextNode(value: "X"))
+        case (.insertText, .afterSplit):
+            try tree.edit(5, 5, JSONTreeTextNode(value: "X"))
+        case (.insertText, .differentElement):
+            try tree.edit(7, 7, JSONTreeTextNode(value: "X"))
+        case (.deleteText, .beforeSplit):
+            try tree.edit(1, 2)
+        case (.deleteText, .afterSplit):
+            try tree.edit(4, 5)
+        case (.deleteText, .differentElement):
+            try tree.edit(7, 8)
+        case (.insertElement, .beforeSplit):
+            try tree.edit(0, 0, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "NEW")]))
+        case (.insertElement, .afterSplit):
+            try tree.edit(6, 6, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "NEW")]))
+        case (.insertElement, .differentElement):
+            try tree.edit(12, 12, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "NEW")]))
+        }
+    }
+}
+
+final class TreeHistorySplitL1ConvergenceTests: XCTestCase {
+    // Ports: "should converge: split + remote insert-text at before-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertText_at_beforeSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .insertText, pos: .beforeSplit)
+    }
+
+    // Ports: "should converge: split + remote insert-text at after-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertText_at_afterSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .insertText, pos: .afterSplit)
+    }
+
+    // Ports: "should converge: split + remote insert-text at different-element"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertText_at_differentElement() async throws {
+        try await self.runSplitConvergenceTest(op: .insertText, pos: .differentElement)
+    }
+
+    // Ports: "should converge: split + remote delete-text at before-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_deleteText_at_beforeSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .deleteText, pos: .beforeSplit)
+    }
+
+    // Ports: "should converge: split + remote delete-text at after-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_deleteText_at_afterSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .deleteText, pos: .afterSplit)
+    }
+
+    // Ports: "should converge: split + remote delete-text at different-element"
+    @MainActor
+    func test_can_converge_split_plus_remote_deleteText_at_differentElement() async throws {
+        try await self.runSplitConvergenceTest(op: .deleteText, pos: .differentElement)
+    }
+
+    // Ports: "should converge: split + remote insert-element at before-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertElement_at_beforeSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .insertElement, pos: .beforeSplit)
+    }
+
+    // Ports: "should converge: split + remote insert-element at after-split"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertElement_at_afterSplit() async throws {
+        try await self.runSplitConvergenceTest(op: .insertElement, pos: .afterSplit)
+    }
+
+    // Ports: "should converge: split + remote insert-element at different-element"
+    @MainActor
+    func test_can_converge_split_plus_remote_insertElement_at_differentElement() async throws {
+        try await self.runSplitConvergenceTest(op: .insertElement, pos: .differentElement)
+    }
+
+    // MARK: - shared helper
+
+    @MainActor
+    private func runSplitConvergenceTest(op: SplitRemoteOp, pos: SplitRemotePos) async throws {
+        let title = "\(self.description)-\(op.rawValue)-\(pos.rawValue)"
+        try await withTwoClientsAndDocuments(title) { c1, d1, c2, d2 in
+            // given — initial tree with two paragraphs
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ABCD")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "EFGH")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 splits first <p> at middle (idx 3, splitLevel=1)
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(3, 3, nil, 1)
+            }
+
+            // d2 applies a concurrent remote op
+            try applyRemoteOpForSplitConvergence(d2, op: op, pos: pos)
+
+            // sync both directions
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // d1 undoes the split
+            try d1.undo()
+
+            // sync again
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both must converge
+            XCTAssertEqual(
+                treeXML(d1),
+                treeXML(d2),
+                "divergence: split + \(op.rawValue) at \(pos.rawValue)"
+            )
+        }
+    }
+}

--- a/Tests/Integration/TreeHistoryStyleUndoIntegrationTests.swift
+++ b/Tests/Integration/TreeHistoryStyleUndoIntegrationTests.swift
@@ -1,0 +1,685 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Helpers
+
+/// Returns the XML of the `t` field in the document root.
+///
+/// Mirrors `xmlOf` from the JS test file. Defined as a file-private helper to
+/// avoid collision with the identical private helper in other files in this
+/// test target (each file has its own file-private scope).
+@MainActor
+private func styleTreeXML(_ doc: Document) -> String {
+    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+}
+
+/// Creates the initial tree used by the style undo/redo tests.
+///
+/// Mirrors `makeTree` in the JS test:
+/// ```
+/// <doc>
+///   <p bold="true">AB</p>
+///   <p>CD</p>
+/// </doc>
+/// ```
+@MainActor
+private func makeStyleTree(_ doc: Document) throws {
+    try doc.update { root, _ in
+        root.t = JSONTree(initialRoot:
+            JSONTreeElementNode(type: "doc", children: [
+                JSONTreeElementNode(
+                    type: "p",
+                    children: [JSONTreeTextNode(value: "AB")],
+                    attributes: ["bold": "true"]
+                ),
+                JSONTreeElementNode(
+                    type: "p",
+                    children: [JSONTreeTextNode(value: "CD")]
+                )
+            ])
+        )
+    }
+}
+
+/// Named style operations mirroring the JS `StyleOp` union.
+private enum StyleOp: String, CaseIterable {
+    case setBold = "set-bold"
+    case setItalic = "set-italic"
+    case setColor = "set-color"
+    case removeBold = "remove-bold"
+}
+
+/// Applies a named style operation on the first (or second) element.
+///
+/// - set-bold  → `style(0, 1, {bold: "true"})`   (first <p>)
+/// - set-italic → `style(0, 1, {italic: "true"})`  (first <p>)
+/// - set-color → `style(3, 4, {color: "red"})`   (second <p>)
+/// - remove-bold → `removeStyle(0, 1, ["bold"])`    (first <p>)
+@MainActor
+private func applyStyleOp(_ doc: Document, _ op: StyleOp) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case .setBold:
+            try tree.style(0, 1, ["bold": "true"])
+        case .setItalic:
+            try tree.style(0, 1, ["italic": "true"])
+        case .setColor:
+            try tree.style(3, 4, ["color": "red"])
+        case .removeBold:
+            try tree.removeStyle(0, 1, ["bold"])
+        }
+    }
+}
+
+// MARK: - 5a. Single-client style undo/redo
+
+//
+// Ports: "Tree History - tree style undo/redo" – 5a. Single-client style
+// undo/redo (v0.7.5, lines 1506–1528).
+
+final class TreeStyleUndoRedoSingleClientTests: XCTestCase {
+    // Ports: "should undo/redo: set-bold"
+    @MainActor
+    func test_can_undo_redo_set_bold() throws {
+        try self.runStyleUndoRedoTest(.setBold)
+    }
+
+    // Ports: "should undo/redo: set-italic"
+    @MainActor
+    func test_can_undo_redo_set_italic() throws {
+        try self.runStyleUndoRedoTest(.setItalic)
+    }
+
+    // Ports: "should undo/redo: set-color"
+    @MainActor
+    func test_can_undo_redo_set_color() throws {
+        try self.runStyleUndoRedoTest(.setColor)
+    }
+
+    // Ports: "should undo/redo: remove-bold"
+    @MainActor
+    func test_can_undo_redo_remove_bold() throws {
+        try self.runStyleUndoRedoTest(.removeBold)
+    }
+
+    // MARK: - shared helper
+
+    @MainActor
+    private func runStyleUndoRedoTest(_ op: StyleOp) throws {
+        // given
+        let doc = Document(key: "style-undo-\(op.rawValue)".toDocKey)
+        try makeStyleTree(doc)
+        let s0 = styleTreeXML(doc)
+
+        // when
+        try applyStyleOp(doc, op)
+        let s1 = styleTreeXML(doc)
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s0, "undo \(op.rawValue) failed")
+
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "redo \(op.rawValue) failed")
+    }
+}
+
+// MARK: - 5b. Single-client chained style ops
+
+//
+// Ports: "Tree History - tree style undo/redo" – 5b. Chained style ops
+// (v0.7.5, lines 1529–1554).
+//
+// The JS test skips the (remove-bold, remove-bold) combo because the second
+// remove is a no-op and does not push an entry onto the undo stack. We match
+// that behaviour by omitting the same case.
+
+final class TreeHistoryStyleUndoRedoChainedTests: XCTestCase {
+    // All valid (op1, op2) pairs except (remove-bold, remove-bold).
+
+    @MainActor func test_can_undo_chain_setBold_setItalic() throws { try self.runChain(.setBold, .setItalic) }
+    @MainActor func test_can_undo_chain_setBold_setColor() throws { try self.runChain(.setBold, .setColor) }
+    @MainActor func test_can_undo_chain_setBold_removeBold() throws { try self.runChain(.setBold, .removeBold) }
+    @MainActor func test_can_undo_chain_setBold_setBold() throws { try self.runChain(.setBold, .setBold) }
+
+    @MainActor func test_can_undo_chain_setItalic_setBold() throws { try self.runChain(.setItalic, .setBold) }
+    @MainActor func test_can_undo_chain_setItalic_setItalic() throws { try self.runChain(.setItalic, .setItalic) }
+    @MainActor func test_can_undo_chain_setItalic_setColor() throws { try self.runChain(.setItalic, .setColor) }
+    @MainActor func test_can_undo_chain_setItalic_removeBold() throws { try self.runChain(.setItalic, .removeBold) }
+
+    @MainActor func test_can_undo_chain_setColor_setBold() throws { try self.runChain(.setColor, .setBold) }
+    @MainActor func test_can_undo_chain_setColor_setItalic() throws { try self.runChain(.setColor, .setItalic) }
+    @MainActor func test_can_undo_chain_setColor_setColor() throws { try self.runChain(.setColor, .setColor) }
+    @MainActor func test_can_undo_chain_setColor_removeBold() throws { try self.runChain(.setColor, .removeBold) }
+
+    @MainActor func test_can_undo_chain_removeBold_setBold() throws { try self.runChain(.removeBold, .setBold) }
+    @MainActor func test_can_undo_chain_removeBold_setItalic() throws { try self.runChain(.removeBold, .setItalic) }
+    @MainActor func test_can_undo_chain_removeBold_setColor() throws { try self.runChain(.removeBold, .setColor) }
+    // (removeBold, removeBold) is intentionally skipped — matches JS test.
+
+    // MARK: - shared helper
+
+    @MainActor
+    private func runChain(_ op1: StyleOp, _ op2: StyleOp) throws {
+        // given
+        let doc = Document(key: "style-chain-\(op1.rawValue)-\(op2.rawValue)".toDocKey)
+        try makeStyleTree(doc)
+
+        let s0 = styleTreeXML(doc)
+        try applyStyleOp(doc, op1)
+        let s1 = styleTreeXML(doc)
+        try applyStyleOp(doc, op2)
+        let s2 = styleTreeXML(doc)
+
+        // when
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "undo \(op2) failed")
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s0, "undo \(op1) failed")
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "redo \(op1) failed")
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s2, "redo \(op2) failed")
+    }
+}
+
+// MARK: - 5c. Single-client style + edit mixed chains
+
+//
+// Ports: "Tree History - tree style undo/redo" – 5c. Style + edit mixed
+// chains (v0.7.5, lines 1556–1604).
+
+final class TreeHistoryStyleUndoRedoMixedTests: XCTestCase {
+    // Ports: "should undo style after edit"
+    @MainActor
+    func test_can_undo_style_after_edit() throws {
+        // given
+        let doc = Document(key: "style-after-edit".toDocKey)
+        try makeStyleTree(doc)
+        let s0 = styleTreeXML(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "X"))
+        }
+        let s1 = styleTreeXML(doc)
+
+        try applyStyleOp(doc, .setItalic)
+        let s2 = styleTreeXML(doc)
+
+        // when
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "undo style failed")
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s0, "undo edit failed")
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "redo edit failed")
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s2, "redo style failed")
+    }
+
+    // Ports: "should undo edit after style"
+    @MainActor
+    func test_can_undo_edit_after_style() throws {
+        // given
+        let doc = Document(key: "edit-after-style".toDocKey)
+        try makeStyleTree(doc)
+        let s0 = styleTreeXML(doc)
+
+        try applyStyleOp(doc, .setItalic)
+        let s1 = styleTreeXML(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "X"))
+        }
+        let s2 = styleTreeXML(doc)
+
+        // when
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "undo edit failed")
+        try doc.undo()
+        XCTAssertEqual(styleTreeXML(doc), s0, "undo style failed")
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s1, "redo style failed")
+        try doc.redo()
+        XCTAssertEqual(styleTreeXML(doc), s2, "redo edit failed")
+    }
+}
+
+// MARK: - 6. Multi-client Style Undo Convergence (table-driven)
+
+//
+// Ports: "Tree History - multi client style undo convergence" (v0.7.5, lines 1606–1707).
+// Requires a live 0.7.5 yorkie server.
+
+private enum LocalStyleOp: String, CaseIterable {
+    case setBold = "set-bold"
+    case setItalic = "set-italic"
+    case removeBold = "remove-bold"
+}
+
+private enum RemoteStyleOp: String, CaseIterable {
+    case setColor = "set-color"
+    case setBold = "set-bold"
+    case removeBold = "remove-bold"
+}
+
+private enum StyleTarget: String, CaseIterable {
+    case sameElement = "same-element"
+    case differentElement = "different-element"
+}
+
+@MainActor
+private func applyLocalStyleOp(_ doc: Document, _ op: LocalStyleOp) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case .setBold:
+            try tree.style(0, 1, ["bold": "true"])
+        case .setItalic:
+            try tree.style(0, 1, ["italic": "true"])
+        case .removeBold:
+            try tree.removeStyle(0, 1, ["bold"])
+        }
+    }
+}
+
+@MainActor
+private func applyRemoteStyleOp(_ doc: Document, _ op: RemoteStyleOp, target: StyleTarget) throws {
+    let idx = target == .sameElement ? 0 : 3
+    let toIdx = target == .sameElement ? 1 : 4
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case .setColor:
+            try tree.style(idx, toIdx, ["color": "red"])
+        case .setBold:
+            try tree.style(idx, toIdx, ["bold": "true"])
+        case .removeBold:
+            try tree.removeStyle(idx, toIdx, ["bold"])
+        }
+    }
+}
+
+final class TreeStyleMultiClientConvergenceTests: XCTestCase {
+    // 9 combinations: 3 local × 3 remote × 2 targets = 18 test cases.
+
+    // --- set-bold local ---
+    @MainActor func test_converge_local_setBold_remote_setColor_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .setColor, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setBold_remote_setColor_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .setColor, .differentElement)
+    }
+
+    @MainActor func test_converge_local_setBold_remote_setBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .setBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setBold_remote_setBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .setBold, .differentElement)
+    }
+
+    @MainActor func test_converge_local_setBold_remote_removeBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .removeBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setBold_remote_removeBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setBold, .removeBold, .differentElement)
+    }
+
+    // --- set-italic local ---
+    @MainActor func test_converge_local_setItalic_remote_setColor_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .setColor, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setItalic_remote_setColor_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .setColor, .differentElement)
+    }
+
+    @MainActor func test_converge_local_setItalic_remote_setBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .setBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setItalic_remote_setBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .setBold, .differentElement)
+    }
+
+    @MainActor func test_converge_local_setItalic_remote_removeBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .removeBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_setItalic_remote_removeBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.setItalic, .removeBold, .differentElement)
+    }
+
+    // --- remove-bold local ---
+    @MainActor func test_converge_local_removeBold_remote_setColor_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .setColor, .sameElement)
+    }
+
+    @MainActor func test_converge_local_removeBold_remote_setColor_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .setColor, .differentElement)
+    }
+
+    @MainActor func test_converge_local_removeBold_remote_setBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .setBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_removeBold_remote_setBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .setBold, .differentElement)
+    }
+
+    @MainActor func test_converge_local_removeBold_remote_removeBold_sameElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .removeBold, .sameElement)
+    }
+
+    @MainActor func test_converge_local_removeBold_remote_removeBold_diffElem() async throws {
+        try await self.runStyleConvergenceTest(.removeBold, .removeBold, .differentElement)
+    }
+
+    // MARK: - shared helper
+
+    @MainActor
+    private func runStyleConvergenceTest(
+        _ localOp: LocalStyleOp,
+        _ remoteOp: RemoteStyleOp,
+        _ target: StyleTarget
+    ) async throws {
+        let title = "\(self.description)-\(localOp.rawValue)-\(remoteOp.rawValue)-\(target.rawValue)"
+        try await withTwoClientsAndDocuments(title) { c1, d1, c2, d2 in
+            // given — initial tree: <doc><p bold="true">AB</p><p>CD</p></doc>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(
+                            type: "p",
+                            children: [JSONTreeTextNode(value: "AB")],
+                            attributes: ["bold": "true"]
+                        ),
+                        JSONTreeElementNode(
+                            type: "p",
+                            children: [JSONTreeTextNode(value: "CD")]
+                        )
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1: local style op; d2: remote style op (concurrent)
+            try applyLocalStyleOp(d1, localOp)
+            try applyRemoteStyleOp(d2, remoteOp, target: target)
+
+            // sync
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // d1 undoes its local style
+            try d1.undo()
+
+            // sync again
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both documents must converge
+            XCTAssertEqual(
+                styleTreeXML(d1),
+                styleTreeXML(d2),
+                "divergence: \(localOp.rawValue) + \(remoteOp.rawValue) on \(target.rawValue)"
+            )
+        }
+    }
+}
+
+// MARK: - 7. Multi-client Style vs Edit/Split convergence (table-driven)
+
+//
+// Ports: "Tree History - multi client style vs edit/split convergence"
+// (v0.7.5, lines 1709–1892).
+// Requires a live 0.7.5 yorkie server.
+//
+// Covers two sub-scenarios for each (localStyleOp, remoteEditOp) pair:
+// a. local style + remote edit, d1 undoes style.
+// b. local edit + remote style, d1 undoes edit.
+
+private enum RemoteEditOp: String, CaseIterable {
+    case insertText = "insert-text"
+    case deleteText = "delete-text"
+    case insertElement = "insert-element"
+    case splitL1 = "split-l1"
+}
+
+@MainActor
+private func applyStyleVsEditRemoteEditOp(_ doc: Document, _ op: RemoteEditOp) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        switch op {
+        case .insertText:
+            try tree.edit(1, 1, JSONTreeTextNode(value: "X"))
+        case .deleteText:
+            try tree.edit(1, 2)
+        case .insertElement:
+            try tree.edit(6, 6, JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "NEW")]))
+        case .splitL1:
+            try tree.edit(3, 3, nil, 1)
+        }
+    }
+}
+
+final class TreeStyleVsEditConvergenceTests: XCTestCase {
+    // 3 local × 4 remote × 2 directions = 24 test cases.
+
+    // --- set-bold local vs remote edit ---
+    @MainActor func test_converge_style_setBold_plus_edit_insertText() async throws {
+        try await self.runStyleVsEditTest(.setBold, .insertText)
+    }
+
+    @MainActor func test_converge_style_setBold_plus_edit_deleteText() async throws {
+        try await self.runStyleVsEditTest(.setBold, .deleteText)
+    }
+
+    @MainActor func test_converge_style_setBold_plus_edit_insertElement() async throws {
+        try await self.runStyleVsEditTest(.setBold, .insertElement)
+    }
+
+    @MainActor func test_converge_style_setBold_plus_edit_splitL1() async throws {
+        try await self.runStyleVsEditTest(.setBold, .splitL1)
+    }
+
+    // --- set-italic local vs remote edit ---
+    @MainActor func test_converge_style_setItalic_plus_edit_insertText() async throws {
+        try await self.runStyleVsEditTest(.setItalic, .insertText)
+    }
+
+    @MainActor func test_converge_style_setItalic_plus_edit_deleteText() async throws {
+        try await self.runStyleVsEditTest(.setItalic, .deleteText)
+    }
+
+    @MainActor func test_converge_style_setItalic_plus_edit_insertElement() async throws {
+        try await self.runStyleVsEditTest(.setItalic, .insertElement)
+    }
+
+    @MainActor func test_converge_style_setItalic_plus_edit_splitL1() async throws {
+        try await self.runStyleVsEditTest(.setItalic, .splitL1)
+    }
+
+    // --- remove-bold local vs remote edit ---
+    @MainActor func test_converge_style_removeBold_plus_edit_insertText() async throws {
+        try await self.runStyleVsEditTest(.removeBold, .insertText)
+    }
+
+    @MainActor func test_converge_style_removeBold_plus_edit_deleteText() async throws {
+        try await self.runStyleVsEditTest(.removeBold, .deleteText)
+    }
+
+    @MainActor func test_converge_style_removeBold_plus_edit_insertElement() async throws {
+        try await self.runStyleVsEditTest(.removeBold, .insertElement)
+    }
+
+    @MainActor func test_converge_style_removeBold_plus_edit_splitL1() async throws {
+        try await self.runStyleVsEditTest(.removeBold, .splitL1)
+    }
+
+    // --- reverse direction: local edit + remote style, undo edit ---
+
+    @MainActor func test_converge_edit_insertText_plus_style_setBold() async throws {
+        try await self.runEditVsStyleTest(.insertText, .setBold)
+    }
+
+    @MainActor func test_converge_edit_deleteText_plus_style_setBold() async throws {
+        try await self.runEditVsStyleTest(.deleteText, .setBold)
+    }
+
+    @MainActor func test_converge_edit_insertElement_plus_style_setBold() async throws {
+        try await self.runEditVsStyleTest(.insertElement, .setBold)
+    }
+
+    @MainActor func test_converge_edit_splitL1_plus_style_setBold() async throws {
+        try await self.runEditVsStyleTest(.splitL1, .setBold)
+    }
+
+    @MainActor func test_converge_edit_insertText_plus_style_setItalic() async throws {
+        try await self.runEditVsStyleTest(.insertText, .setItalic)
+    }
+
+    @MainActor func test_converge_edit_deleteText_plus_style_setItalic() async throws {
+        try await self.runEditVsStyleTest(.deleteText, .setItalic)
+    }
+
+    @MainActor func test_converge_edit_insertElement_plus_style_setItalic() async throws {
+        try await self.runEditVsStyleTest(.insertElement, .setItalic)
+    }
+
+    @MainActor func test_converge_edit_splitL1_plus_style_setItalic() async throws {
+        try await self.runEditVsStyleTest(.splitL1, .setItalic)
+    }
+
+    @MainActor func test_converge_edit_insertText_plus_style_removeBold() async throws {
+        try await self.runEditVsStyleTest(.insertText, .removeBold)
+    }
+
+    @MainActor func test_converge_edit_deleteText_plus_style_removeBold() async throws {
+        try await self.runEditVsStyleTest(.deleteText, .removeBold)
+    }
+
+    @MainActor func test_converge_edit_insertElement_plus_style_removeBold() async throws {
+        try await self.runEditVsStyleTest(.insertElement, .removeBold)
+    }
+
+    @MainActor func test_converge_edit_splitL1_plus_style_removeBold() async throws {
+        try await self.runEditVsStyleTest(.splitL1, .removeBold)
+    }
+
+    // MARK: - shared helpers
+
+    /// d1 applies a style op; d2 applies a concurrent edit op. d1 then undoes its style.
+    @MainActor
+    private func runStyleVsEditTest(_ localOp: LocalStyleOp, _ remoteOp: RemoteEditOp) async throws {
+        let title = "\(self.description)-style-\(localOp.rawValue)-edit-\(remoteOp.rawValue)"
+        try await withTwoClientsAndDocuments(title) { c1, d1, c2, d2 in
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(
+                            type: "p",
+                            children: [JSONTreeTextNode(value: "ABCD")],
+                            attributes: ["bold": "true"]
+                        ),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "EFGH")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            try applyLocalStyleOp(d1, localOp)
+            try applyStyleVsEditRemoteEditOp(d2, remoteOp)
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            try d1.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            XCTAssertEqual(
+                styleTreeXML(d1),
+                styleTreeXML(d2),
+                "divergence: style(\(localOp.rawValue)) + edit(\(remoteOp.rawValue))"
+            )
+        }
+    }
+
+    /// d1 applies an edit op; d2 applies a concurrent style op. d1 then undoes its edit.
+    @MainActor
+    private func runEditVsStyleTest(_ localEditOp: RemoteEditOp, _ remoteStyleOp: LocalStyleOp) async throws {
+        let title = "\(self.description)-edit-\(localEditOp.rawValue)-style-\(remoteStyleOp.rawValue)"
+        try await withTwoClientsAndDocuments(title) { c1, d1, c2, d2 in
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(
+                            type: "p",
+                            children: [JSONTreeTextNode(value: "ABCD")],
+                            attributes: ["bold": "true"]
+                        ),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "EFGH")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            try applyStyleVsEditRemoteEditOp(d1, localEditOp)
+            try applyLocalStyleOp(d2, remoteStyleOp)
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            try d1.undo()
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            XCTAssertEqual(
+                styleTreeXML(d1),
+                styleTreeXML(d2),
+                "divergence: edit(\(localEditOp.rawValue)) + style(\(remoteStyleOp.rawValue))"
+            )
+        }
+    }
+}

--- a/Tests/Unit/Document/CRDT/CRDTDedupCounterTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTDedupCounterTests.swift
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Unit tests for ``CRDTCounter`` in dedup mode and ``JSONDedupCounter``.
+///
+/// Mirrors the new dedup-counter behaviour introduced in yorkie-js-sdk #1215/#1216.
+/// Dedup counters count distinct actors — each unique actor ID contributes exactly
+/// 1 to the cardinality, and repeated calls with the same actor are no-ops.
+final class CRDTDedupCounterTests: XCTestCase {
+    // MARK: - Initial state
+
+    func test_dedup_counter_initial_value_is_zero() {
+        // given / when
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+
+        // then
+        XCTAssertEqual(counter.value, 0)
+        XCTAssertTrue(counter.isDedup)
+    }
+
+    func test_regular_counter_is_not_dedup() {
+        // given / when
+        let counter = CRDTCounter(value: Int32(5), createdAt: TimeTicket.initial)
+
+        // then
+        XCTAssertFalse(counter.isDedup)
+    }
+
+    // MARK: - increaseDedup — basic counting
+
+    func test_increase_dedup_increments_for_new_actor() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+
+        // when
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // then — one distinct actor → value becomes 1
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func test_increase_dedup_same_actor_is_idempotent() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+
+        // when — add the same actor multiple times
+        try counter.increaseDedup(primitive, actor: "actor-a")
+        try counter.increaseDedup(primitive, actor: "actor-a")
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // then — still 1 distinct actor
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func test_increase_dedup_distinct_actors_count_separately() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+
+        // when
+        try counter.increaseDedup(primitive, actor: "actor-a")
+        try counter.increaseDedup(primitive, actor: "actor-b")
+        try counter.increaseDedup(primitive, actor: "actor-c")
+
+        // then — three distinct actors; HLL guarantees ~2 % error, so within ±2
+        XCTAssertGreaterThan(counter.value, 0)
+        XCTAssertLessThanOrEqual(counter.value, 5)
+    }
+
+    // MARK: - increaseDedup — error cases
+
+    func test_increase_dedup_empty_actor_throws() {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+
+        // when / then
+        XCTAssertThrowsError(try counter.increaseDedup(primitive, actor: "")) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    func test_increase_dedup_value_not_one_throws() {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let nonUnit = Primitive(value: .integer(5), createdAt: TimeTicket.initial)
+
+        // when / then — dedup counters only accept increment-by-1
+        XCTAssertThrowsError(try counter.increaseDedup(nonUnit, actor: "actor-a")) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    func test_increase_on_dedup_counter_throws() {
+        // given — a dedup counter must not use the regular increase path
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+
+        // when / then
+        XCTAssertThrowsError(try counter.increase(primitive)) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    // MARK: - increaseDedup — long primitive accepted
+
+    func test_increase_dedup_accepts_long_primitive_with_value_one() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .long(1), createdAt: TimeTicket.initial)
+
+        // when
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // then
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    // MARK: - hllBytes / restoreHLL round-trip
+
+    func test_hllBytes_returns_non_nil_for_dedup_counter() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // when
+        let bytes = counter.hllBytes()
+
+        // then
+        XCTAssertNotNil(bytes)
+        XCTAssertEqual(bytes?.count, 16384)
+    }
+
+    func test_hllBytes_returns_nil_for_regular_counter() {
+        // given
+        let counter = CRDTCounter(value: Int32(10), createdAt: TimeTicket.initial)
+
+        // when / then
+        XCTAssertNil(counter.hllBytes())
+    }
+
+    func test_restoreHLL_preserves_value() throws {
+        // given — counter with one actor registered
+        let original = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+        try original.increaseDedup(primitive, actor: "actor-a")
+        let serialised = original.hllBytes()!
+
+        // when — restore into a fresh counter
+        let restored = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        try restored.restoreHLL(serialised)
+
+        // then
+        XCTAssertEqual(restored.value, original.value)
+    }
+
+    func test_restoreHLL_on_regular_counter_throws() {
+        // given
+        let regular = CRDTCounter(value: Int32(0), createdAt: TimeTicket.initial)
+        let fakeBytes = Data(repeating: 0, count: 16384)
+
+        // when / then
+        XCTAssertThrowsError(try regular.restoreHLL(fakeBytes)) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    // MARK: - deepcopy
+
+    func test_deepcopy_dedup_counter_preserves_state() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+        try counter.increaseDedup(primitive, actor: "actor-a")
+        let originalValue = counter.value
+
+        // when
+        let copy = counter.deepcopy() as? CRDTCounter<Int32>
+
+        // then
+        XCTAssertNotNil(copy)
+        XCTAssertTrue(copy!.isDedup)
+        XCTAssertEqual(copy!.value, originalValue)
+    }
+
+    func test_deepcopy_is_independent_from_original() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // when — copy, then mutate the original
+        let copy = try XCTUnwrap(counter.deepcopy() as? CRDTCounter<Int32>)
+        try counter.increaseDedup(primitive, actor: "actor-b")
+
+        // then — the copy must be unchanged
+        XCTAssertEqual(copy.value, 1)
+    }
+
+    // MARK: - toJSON / toSortedJSON
+
+    func test_dedup_counter_to_json_reflects_cardinality() throws {
+        // given
+        let counter = CRDTCounter<Int32>(dedupWithCreatedAt: TimeTicket.initial)
+        let primitive = Primitive(value: .integer(1), createdAt: TimeTicket.initial)
+        try counter.increaseDedup(primitive, actor: "actor-a")
+
+        // when / then
+        XCTAssertEqual(counter.toJSON(), "1")
+        XCTAssertEqual(counter.toSortedJSON(), "1")
+    }
+}
+
+// MARK: - JSONDedupCounter unit tests
+
+/// Tests for ``JSONDedupCounter`` that do not require the document-level
+/// `JSONObject.set` integration.
+///
+/// NOTE: ``JSONObject/set(key:value:)`` does not yet handle
+/// ``JSONDedupCounter`` — assigning `root.uv = JSONDedupCounter()` inside a
+/// `doc.update` closure triggers `assertionFailure`. The missing case is a
+/// known gap in Sources and must be added before the document-level happy-path
+/// tests can run. The integration tests in `DedupCounterIntegrationTests` are
+/// the canonical place to exercise the full sync round-trip once Sources
+/// support is complete.
+final class JSONDedupCounterTests: XCTestCase {
+    // MARK: - add before initialization
+
+    // Ports: mirrors JS `DedupCounter.increase()` pre-init guard.
+    func test_add_before_init_throws_errNotInitialized() {
+        // given — counter created but never attached to a document
+        let counter = JSONDedupCounter()
+
+        // when / then
+        XCTAssertThrowsError(try counter.add("actor")) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError but got \(error)")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errNotInitialized)
+        }
+    }
+
+    // MARK: - initial value
+
+    func test_initial_value_is_zero() {
+        // given / when
+        let counter = JSONDedupCounter()
+
+        // then — value is 0 before being connected to a document
+        XCTAssertEqual(counter.value, 0)
+    }
+
+    // MARK: - id is nil before initialization
+
+    func test_id_is_nil_before_init() {
+        // given / when
+        let counter = JSONDedupCounter()
+
+        // then
+        XCTAssertNil(counter.id, "id must be nil before the counter is added to a document")
+    }
+}

--- a/Tests/Unit/Document/CRDT/HLLTests.swift
+++ b/Tests/Unit/Document/CRDT/HLLTests.swift
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Unit tests for the ``HLL`` HyperLogLog implementation.
+///
+/// Upstream does not ship a dedicated hll_test.ts; these cases guard the Swift
+/// port against regressions introduced during forward-port work.
+final class HLLTests: XCTestCase {
+    // MARK: - Empty / initial state
+
+    func test_empty_hll_count_is_zero() {
+        // given
+        let hll = HLL()
+
+        // then
+        XCTAssertEqual(hll.count(), 0)
+    }
+
+    func test_toBytes_of_empty_hll_is_all_zeros() {
+        // given
+        let hll = HLL()
+
+        // then
+        let bytes = hll.toBytes()
+        XCTAssertEqual(bytes.count, 16384, "register count must equal 2^14")
+        XCTAssertTrue(bytes.allSatisfy { $0 == 0 }, "all registers must start at 0")
+    }
+
+    // MARK: - add returns update flag
+
+    func test_add_returns_true_on_first_insertion() {
+        // given
+        let hll = HLL()
+
+        // when / then
+        XCTAssertTrue(hll.add(value: "actor-a"), "first add for a new value must return true")
+    }
+
+    func test_add_returns_false_for_already_seen_value() {
+        // given
+        let hll = HLL()
+        hll.add(value: "actor-a")
+
+        // when / then — same value again must be a no-op
+        XCTAssertFalse(hll.add(value: "actor-a"), "duplicate add must return false")
+    }
+
+    func test_add_different_values_returns_true() {
+        // given
+        let hll = HLL()
+        hll.add(value: "actor-a")
+
+        // when / then — a genuinely distinct value must return true
+        XCTAssertTrue(hll.add(value: "actor-b"), "new distinct value must return true")
+    }
+
+    // MARK: - Cardinality estimate
+
+    func test_count_increases_as_distinct_values_are_added() {
+        // given
+        let hll = HLL()
+
+        // when
+        for idx in 0 ..< 10 {
+            hll.add(value: "actor-\(idx)")
+        }
+
+        // then — HLL guarantees ~2 % error; 10 distinct values should be within ±5
+        let estimate = hll.count()
+        XCTAssertGreaterThan(estimate, 0)
+        XCTAssertLessThanOrEqual(estimate, 15)
+    }
+
+    func test_count_does_not_change_on_duplicate_adds() {
+        // given
+        let hll = HLL()
+        hll.add(value: "actor-x")
+        let countAfterFirst = hll.count()
+
+        // when — add the same value several more times
+        for _ in 0 ..< 5 {
+            hll.add(value: "actor-x")
+        }
+
+        // then
+        XCTAssertEqual(hll.count(), countAfterFirst, "duplicate adds must not change the estimate")
+    }
+
+    // MARK: - merge idempotence
+
+    func test_merge_is_idempotent() {
+        // given
+        let hllA = HLL()
+        hllA.add(value: "actor-1")
+        hllA.add(value: "actor-2")
+
+        let hllB = HLL()
+        hllB.add(value: "actor-1")
+        hllB.add(value: "actor-2")
+
+        // when — merge same HLL twice
+        hllA.merge(hllB)
+        let countAfterFirst = hllA.count()
+        hllA.merge(hllB)
+
+        // then
+        XCTAssertEqual(hllA.count(), countAfterFirst, "merging the same HLL again must not change the estimate")
+    }
+
+    func test_merge_combines_distinct_values() {
+        // given
+        let hllA = HLL()
+        hllA.add(value: "actor-a")
+
+        let hllB = HLL()
+        hllB.add(value: "actor-b")
+
+        let countA = hllA.count()
+        let countB = hllB.count()
+
+        // when
+        hllA.merge(hllB)
+
+        // then — merged cardinality must be at least as large as each individual estimate
+        XCTAssertGreaterThanOrEqual(hllA.count(), max(countA, countB))
+    }
+
+    func test_merge_is_commutative() {
+        // given
+        let hllA = HLL()
+        hllA.add(value: "actor-1")
+
+        let hllB = HLL()
+        hllB.add(value: "actor-2")
+
+        let hllACopy = HLL()
+        hllACopy.add(value: "actor-1")
+
+        let hllBCopy = HLL()
+        hllBCopy.add(value: "actor-2")
+
+        // when — hllA.merge(hllB) and hllB.merge(hllA) must produce the same count
+        hllA.merge(hllB)
+        hllBCopy.merge(hllACopy)
+
+        // then
+        XCTAssertEqual(hllA.count(), hllBCopy.count(), "merge must be commutative")
+    }
+
+    // MARK: - toBytes / restore round-trip
+
+    func test_toBytes_restore_round_trip_preserves_count() throws {
+        // given
+        let original = HLL()
+        for idx in 0 ..< 5 {
+            original.add(value: "user-\(idx)")
+        }
+        let before = original.count()
+        let bytes = original.toBytes()
+
+        // when
+        let restored = HLL()
+        try restored.restore(bytes)
+
+        // then
+        XCTAssertEqual(restored.count(), before, "restored HLL must return the same cardinality")
+    }
+
+    func test_toBytes_produces_correct_length() {
+        // given
+        let hll = HLL()
+        hll.add(value: "a")
+
+        // when
+        let bytes = hll.toBytes()
+
+        // then
+        XCTAssertEqual(bytes.count, 16384)
+    }
+
+    func test_restore_wrong_length_throws() {
+        // given
+        let hll = HLL()
+        let badBytes: [UInt8] = [0, 1, 2] // too short
+
+        // when / then
+        XCTAssertThrowsError(try hll.restore(badBytes)) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError but got \(error)")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    func test_restore_empty_payload_throws() {
+        // given
+        let hll = HLL()
+
+        // when / then
+        XCTAssertThrowsError(try hll.restore([])) { error in
+            guard let yorkieError = error as? YorkieError else {
+                XCTFail("expected YorkieError but got \(error)")
+                return
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+    }
+
+    // MARK: - add is stable for known inputs
+
+    func test_add_of_empty_string_returns_true_then_false() {
+        // given
+        let hll = HLL()
+
+        // when / then — empty string is a valid actor label
+        XCTAssertTrue(hll.add(value: ""))
+        XCTAssertFalse(hll.add(value: ""))
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.4'
+    image: 'yorkieteam/yorkie:0.7.5'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.4'
+    image: 'yorkieteam/yorkie:0.7.5'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk 0.7.5. Three iOS-relevant features plus a proto change:

- **Add Counter dedup mode with HyperLogLog for UV measurement** (#1215) — new `HLL.swift` (HyperLogLog + xxhash64, byte-compatible with the Go server), a dedup mode on `CRDTCounter`, the public `JSONDedupCounter` authoring type, `IncreaseOperation.actor`, and proto `Counter.hll_registers` / `Increase.actor` / `VALUE_TYPE_INTEGER_DEDUP_CNT`. Dedup increases require an actor and are not undoable.
- **Simplify Counter interface and replace long with bigint** (#1216) — interface only; iOS already uses native `Int32`/`Int64`, so the bigint change is a no-op here.
- **Enable splitLevel=1 concurrent tests and add split undo/redo** (#1219) — `TreeEditOperation` split-reverse (boundary-deletion that re-splits on redo); `IndexTree.splitElement` excludes removed children from visible size.
- **Add undo/redo support for TreeStyleOperation** (#1221) — `CRDTTree.style()`/`removeStyle()` capture previous attributes; `TreeStyleOperation` builds the reverse op.
- **Add content correctness tests for overlapping undo** (#1222).

Skipped upstream: #1218 (default transport gRPC-Web → Connect) — iOS already uses connect-swift's Connect protocol; #1213/#1223 (package/version bumps).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Pre-PR gate green: critic-reviewer approved (independently verified the xxhash64 output is byte-identical to canonical vectors), SwiftFormat 0.55.6 and SwiftLint 0.58.2 `--strict` (0 violations), `swift build` + unit tests pass. Integration suites (Counter-dedup convergence, Tree split/style undo) require a live yorkie server v0.7.5 — exercised by CI.
- iOS modeling notes: `CRDTCounter<T>` is generic (no JS `CounterType` enum), so dedup is `CRDTCounter<Int32>` + an `isDedup` flag + an `HLL`; JS `bigint` 64-bit math maps to Swift `UInt64` wrapping operators.
- Dedup increases are intentionally non-undoable (HLL cannot remove an actor), matching JS.

**Does this PR introduce a user-facing change?**:
```release-note
Add a HyperLogLog-based dedup Counter (JSONDedupCounter) for unique-visitor counting; add Tree split and style undo/redo support.
```

**Additional documentation**:
```docs
- CHANGELOG.md updated for v0.7.5
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HyperLogLog-backed deduplication counters for efficient unique visitor counting.
  * Updated counter/operations support for dedup via actor-based increments (including approximate cardinality state).
  * Simplified the Counter interface (e.g., `long` → `bigint`).
* **Improvements**
  * Enhanced undo/redo correctness for tree styling and split-related edits, including multi-level concurrent scenarios.
* **Tests**
  * Added new unit/integration coverage for dedup counters and tree history undo/redo.
* **Chores**
  * Updated version and CI/server dependencies to **0.7.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->