### PR TITLE
Apply updates from yorkie-js-sdk 0.7.6

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.5
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/9fe7c7f4b22fe5a7a113588e29d2f9fd190d67af/Formula/y/yorkie.rb"
+      # yorkie server v0.7.6
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/76ff9ebcaf2c2acd9b66f048b2d8c051036509f6/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.5
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/9fe7c7f4b22fe5a7a113588e29d2f9fd190d67af/Formula/y/yorkie.rb"
+      # yorkie server v0.7.6
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/76ff9ebcaf2c2acd9b66f048b2d8c051036509f6/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.6] - 2026-06-18
+
+- Implement toJSON for Bytes and Date primitive types in https://github.com/yorkie-team/yorkie-ios-sdk/pull/258
+- Unify presence event emission with reconcilePresence in https://github.com/yorkie-team/yorkie-ios-sdk/pull/258
+- Copy attributes to split node in cloneElement in https://github.com/yorkie-team/yorkie-ios-sdk/pull/258
+- Apply array-move-convergence with LWW position register in https://github.com/yorkie-team/yorkie-ios-sdk/pull/258
+- Register LWW-losing element in GC set on Set conflict in https://github.com/yorkie-team/yorkie-ios-sdk/pull/258
+
 ## [v0.7.5] - 2026-06-17
 
 - Add Counter dedup mode with HyperLogLog for UV measurement in https://github.com/yorkie-team/yorkie-ios-sdk/pull/257

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -633,16 +633,40 @@ extension Converter {
 // MARK: RGNNodes
 extension Converter {
     /**
-     * `toRGANodes` converts the given model to Protobuf format.
+     * `toRGANodes` converts the given ``CRDTArray`` to an array of Protobuf RGA nodes.
+     *
+     * Serialises all nodes in linked-list order, including dead position nodes, so
+     * that the snapshot can be fully restored on the receiving side.
+     *
+     * Three node shapes are produced (matching the JS wire format exactly):
+     * - **Normal**: `element` only (no position fields).
+     * - **Moved**: `element` + `positionCreatedAt` + `positionMovedAt`.
+     * - **Dead**: `positionCreatedAt` + `positionRemovedAt` only — NO element field.
+     *   The JS/Go decoders detect dead nodes via `!hasElement`.
      */
-    static func toRGANodes(_ rgaTreeList: RGATreeList) -> [PbRGANode] {
-        rgaTreeList.compactMap {
-            guard let element = try? toElement($0.value) else {
-                return nil
-            }
-
+    static func toRGANodes(_ arr: CRDTArray) -> [PbRGANode] {
+        arr.getAllRGANodes().compactMap { node in
             var pbRGANode = PbRGANode()
-            pbRGANode.element = element
+
+            if let entry = node.getElementEntry() {
+                // Live or moved node — always encode the element.
+                guard let pbElement = try? toElement(entry.element) else { return nil }
+                pbRGANode.element = pbElement
+
+                let posCreatedAt = node.getPositionCreatedAt()
+                if posCreatedAt != entry.element.createdAt {
+                    // positionCreatedAt differs from element.createdAt → moved node.
+                    pbRGANode.positionCreatedAt = toTimeTicket(posCreatedAt)
+                    pbRGANode.positionMovedAt = toTimeTicket(posCreatedAt)
+                }
+                // Otherwise it is a normal node — no position fields needed.
+            } else {
+                // Dead position node — encode positionCreatedAt + positionRemovedAt only.
+                // Do NOT set element: JS/Go decoders branch on `!hasElement` to detect dead nodes.
+                guard let removedAt = node.getPositionRemovedAt() else { return nil }
+                pbRGANode.positionCreatedAt = toTimeTicket(node.getPositionCreatedAt())
+                pbRGANode.positionRemovedAt = toTimeTicket(removedAt)
+            }
 
             return pbRGANode
         }
@@ -694,7 +718,7 @@ extension Converter {
      */
     static func toArray(_ arr: CRDTArray) -> PbJSONElement {
         var pbArray = PbJSONElement.JSONArray()
-        pbArray.nodes = toRGANodes(arr.getElements())
+        pbArray.nodes = toRGANodes(arr)
         pbArray.createdAt = toTimeTicket(arr.createdAt)
         if let ticket = arr.movedAt {
             pbArray.movedAt = toTimeTicket(ticket)
@@ -714,11 +738,42 @@ extension Converter {
 
     /**
      * `fromArray` converts the given Protobuf format to model format.
+     *
+     * Handles three node shapes produced by ``toRGANodes(_:)``:
+     * - **Dead**: no `element` field — `positionCreatedAt` + `positionRemovedAt` only.
+     *   Detected by `!hasElement`, matching the JS/Go decoder convention.
+     * - **Moved**: `element` + `positionCreatedAt` + `positionMovedAt`.
+     * - **Normal**: `element` only (no position fields).
      */
     static func fromArray(_ pbArray: PbJSONElement.JSONArray) throws -> CRDTArray {
         let rgaTreeList = RGATreeList()
         try pbArray.nodes.forEach { pbRGANode in
-            try rgaTreeList.insert(fromElement(pbElement: pbRGANode.element))
+            if !pbRGANode.hasElement {
+                // Dead position node — no element in the wire format (JS convention).
+                let posCreatedAt = fromTimeTicket(pbRGANode.positionCreatedAt)
+                let posRemovedAt = fromTimeTicket(pbRGANode.positionRemovedAt)
+                try rgaTreeList.addDeadPosition(
+                    positionCreatedAt: posCreatedAt,
+                    positionRemovedAt: posRemovedAt
+                )
+                return
+            }
+
+            let element = try fromElement(pbElement: pbRGANode.element)
+
+            if pbRGANode.hasPositionCreatedAt && pbRGANode.hasPositionMovedAt {
+                // Moved node.
+                let posCreatedAt = fromTimeTicket(pbRGANode.positionCreatedAt)
+                let posMovedAt = fromTimeTicket(pbRGANode.positionMovedAt)
+                try rgaTreeList.addMovedElement(
+                    value: element,
+                    positionCreatedAt: posCreatedAt,
+                    positionMovedAt: posMovedAt
+                )
+            } else {
+                // Normal node.
+                try rgaTreeList.insert(element)
+            }
         }
 
         let arr = CRDTArray(createdAt: fromTimeTicket(pbArray.createdAt), elements: rgaTreeList)

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -653,11 +653,12 @@ extension Converter {
                 guard let pbElement = try? toElement(entry.element) else { return nil }
                 pbRGANode.element = pbElement
 
-                let posCreatedAt = node.getPositionCreatedAt()
-                if posCreatedAt != entry.element.createdAt {
-                    // positionCreatedAt differs from element.createdAt → moved node.
-                    pbRGANode.positionCreatedAt = toTimeTicket(posCreatedAt)
-                    pbRGANode.positionMovedAt = toTimeTicket(posCreatedAt)
+                if let posMovedAt = entry.posMovedAt {
+                    // Moved node — encode the position id and the actual move
+                    // ticket (mirrors JS toRGANodes, which branches on
+                    // getPositionMovedAt() and emits it verbatim).
+                    pbRGANode.positionMovedAt = toTimeTicket(posMovedAt)
+                    pbRGANode.positionCreatedAt = toTimeTicket(node.getPositionCreatedAt())
                 }
                 // Otherwise it is a normal node — no position fields needed.
             } else {

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -1385,6 +1385,33 @@ public struct Yorkie_V1_RGANode: @unchecked Sendable {
   /// Clears the value of `element`. Subsequent reads from it will return its default value.
   public mutating func clearElement() {_uniqueStorage()._element = nil}
 
+  public var positionCreatedAt: Yorkie_V1_TimeTicket {
+    get {_storage._positionCreatedAt ?? Yorkie_V1_TimeTicket()}
+    set {_uniqueStorage()._positionCreatedAt = newValue}
+  }
+  /// Returns true if `positionCreatedAt` has been explicitly set.
+  public var hasPositionCreatedAt: Bool {_storage._positionCreatedAt != nil}
+  /// Clears the value of `positionCreatedAt`. Subsequent reads from it will return its default value.
+  public mutating func clearPositionCreatedAt() {_uniqueStorage()._positionCreatedAt = nil}
+
+  public var positionMovedAt: Yorkie_V1_TimeTicket {
+    get {_storage._positionMovedAt ?? Yorkie_V1_TimeTicket()}
+    set {_uniqueStorage()._positionMovedAt = newValue}
+  }
+  /// Returns true if `positionMovedAt` has been explicitly set.
+  public var hasPositionMovedAt: Bool {_storage._positionMovedAt != nil}
+  /// Clears the value of `positionMovedAt`. Subsequent reads from it will return its default value.
+  public mutating func clearPositionMovedAt() {_uniqueStorage()._positionMovedAt = nil}
+
+  public var positionRemovedAt: Yorkie_V1_TimeTicket {
+    get {_storage._positionRemovedAt ?? Yorkie_V1_TimeTicket()}
+    set {_uniqueStorage()._positionRemovedAt = newValue}
+  }
+  /// Returns true if `positionRemovedAt` has been explicitly set.
+  public var hasPositionRemovedAt: Bool {_storage._positionRemovedAt != nil}
+  /// Clears the value of `positionRemovedAt`. Subsequent reads from it will return its default value.
+  public mutating func clearPositionRemovedAt() {_uniqueStorage()._positionRemovedAt = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -4458,11 +4485,14 @@ extension Yorkie_V1_RHTNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
 
 extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RGANode"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}next\0\u{1}element\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}next\0\u{1}element\0\u{3}position_created_at\0\u{3}position_moved_at\0\u{3}position_removed_at\0")
 
   fileprivate class _StorageClass {
     var _next: Yorkie_V1_RGANode? = nil
     var _element: Yorkie_V1_JSONElement? = nil
+    var _positionCreatedAt: Yorkie_V1_TimeTicket? = nil
+    var _positionMovedAt: Yorkie_V1_TimeTicket? = nil
+    var _positionRemovedAt: Yorkie_V1_TimeTicket? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -4475,6 +4505,9 @@ extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     init(copying source: _StorageClass) {
       _next = source._next
       _element = source._element
+      _positionCreatedAt = source._positionCreatedAt
+      _positionMovedAt = source._positionMovedAt
+      _positionRemovedAt = source._positionRemovedAt
     }
   }
 
@@ -4495,6 +4528,9 @@ extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         switch fieldNumber {
         case 1: try { try decoder.decodeSingularMessageField(value: &_storage._next) }()
         case 2: try { try decoder.decodeSingularMessageField(value: &_storage._element) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._positionCreatedAt) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._positionMovedAt) }()
+        case 5: try { try decoder.decodeSingularMessageField(value: &_storage._positionRemovedAt) }()
         default: break
         }
       }
@@ -4513,6 +4549,15 @@ extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       try { if let v = _storage._element {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
       } }()
+      try { if let v = _storage._positionCreatedAt {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      } }()
+      try { if let v = _storage._positionMovedAt {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      } }()
+      try { if let v = _storage._positionRemovedAt {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4524,6 +4569,9 @@ extension Yorkie_V1_RGANode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         let rhs_storage = _args.1
         if _storage._next != rhs_storage._next {return false}
         if _storage._element != rhs_storage._element {return false}
+        if _storage._positionCreatedAt != rhs_storage._positionCreatedAt {return false}
+        if _storage._positionMovedAt != rhs_storage._positionMovedAt {return false}
+        if _storage._positionRemovedAt != rhs_storage._positionRemovedAt {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -227,6 +227,9 @@ message RHTNode {
 message RGANode {
   RGANode next = 1;
   JSONElement element = 2;
+  TimeTicket position_created_at = 3;
+  TimeTicket position_moved_at = 4;
+  TimeTicket position_removed_at = 5;
 }
 
 message NodeAttr {

--- a/Sources/Document/CRDT/CRDTArray.swift
+++ b/Sources/Document/CRDT/CRDTArray.swift
@@ -48,10 +48,51 @@ class CRDTArray: CRDTContainer {
     }
 
     /**
-     * `move` moves the given `createdAt` element after the `prevCreatedAt`.
+     * `move` moves the element identified by `createdAt` after `afterCreatedAt`.
+     *
+     * This is a local-context helper used by ``JSONArray`` during local edit. It delegates
+     * to ``moveAfter(createdAt:prevCreatedAt:executedAt:)`` and discards the dead node
+     * return value; GC pair registration happens later in ``MoveOperation/execute(root:versionVector:source:)``.
      */
     func move(createdAt: TimeTicket, afterCreatedAt: TimeTicket, executedAt: TimeTicket) throws {
-        try self.elements.move(createdAt: createdAt, afterCreatedAt: afterCreatedAt, executedAt: executedAt)
+        try self.elements.moveAfter(createdAt: createdAt, prevCreatedAt: afterCreatedAt, executedAt: executedAt)
+    }
+
+    /**
+     * `moveAfter` moves the element identified by `createdAt` to after `prevCreatedAt`.
+     *
+     * Uses an LWW position register: the winning position is the one with the latest
+     * `executedAt`. Returns the dead position node if an old position was displaced,
+     * or `nil` if the move lost the LWW race. The caller must register the returned
+     * node as a GC pair.
+     *
+     * - Parameters:
+     *   - createdAt: The `createdAt` of the element to move.
+     *   - prevCreatedAt: The element after which to position the moved element.
+     *   - executedAt: The operation execution time used for LWW comparison.
+     * - Returns: The displaced dead position node, or `nil`.
+     * - Throws: ``YorkieError`` when the target or anchor element is not found.
+     */
+    @discardableResult
+    func moveAfter(createdAt: TimeTicket, prevCreatedAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode? {
+        return try self.elements.moveAfter(createdAt: createdAt, prevCreatedAt: prevCreatedAt, executedAt: executedAt)
+    }
+
+    /**
+     * `getRGATreeList` returns the underlying ``RGATreeList``, used as the `GCParent`
+     * when registering dead position nodes.
+     */
+    func getRGATreeList() -> RGATreeList {
+        return self.elements
+    }
+
+    /**
+     * `getAllRGANodes` returns all nodes in linked-list order, including dead position nodes.
+     *
+     * Used by ``CRDTRoot`` to register dead position nodes as GC pairs on snapshot restore.
+     */
+    func getAllRGANodes() -> [RGATreeListNode] {
+        return self.elements.allNodes()
     }
 
     /**
@@ -115,10 +156,20 @@ class CRDTArray: CRDTContainer {
     }
 
     /**
-     * `getLastCreatedAt` get last created element.
+     * `getLastCreatedAt` returns the POSITION `createdAt` of the last node.
      */
     func getLastCreatedAt() -> TimeTicket {
         return self.elements.getLastCreatedAt()
+    }
+
+    /**
+     * `posCreatedAt` returns the current position node key for the element identified by `elemCreatedAt`.
+     *
+     * Mirrors the JS `posCreatedAt(elemCreatedAt)` — converts element identity to
+     * position identity for use in ``MoveOperation``.
+     */
+    func posCreatedAt(elemCreatedAt: TimeTicket) throws -> TimeTicket {
+        return try self.elements.posCreatedAt(elemCreatedAt: elemCreatedAt)
     }
 
     /**
@@ -129,7 +180,10 @@ class CRDTArray: CRDTContainer {
     }
 
     /**
-     * `getElements` returns an array of elements contained in this RGATreeList.
+     * `getElements` returns the underlying ``RGATreeList``.
+     *
+     * Prefer ``getRGATreeList()`` for GC-related work; this accessor is retained for
+     * compatibility with the ``Converter``.
      */
     func getElements() -> RGATreeList {
         return self.elements
@@ -159,13 +213,18 @@ extension CRDTArray {
 
     /**
      * `deepcopy` copies itself deeply.
+     *
+     * Iterates live nodes only (the `Sequence` conformance skips dead position nodes),
+     * so the copy does not inherit dead position state — it will be reconstructed from
+     * the snapshot on the next round-trip.
      */
     func deepcopy() -> CRDTElement {
         let result = CRDTArray(createdAt: self.createdAt)
         for node in self.elements {
+            guard let entry = node.elementEntry else { continue }
             _ = try? result.elements.insert(
-                node.value.deepcopy(),
-                prevCreatedAt: result.getLastCreatedAt()
+                entry.element.deepcopy(),
+                prevCreatedAt: result.elements.getLastCreatedAt()
             )
         }
         result.remove(self.removedAt)

--- a/Sources/Document/CRDT/CRDTArray.swift
+++ b/Sources/Document/CRDT/CRDTArray.swift
@@ -214,18 +214,34 @@ extension CRDTArray {
     /**
      * `deepcopy` copies itself deeply.
      *
-     * Iterates live nodes only (the `Sequence` conformance skips dead position nodes),
-     * so the copy does not inherit dead position state — it will be reconstructed from
-     * the snapshot on the next round-trip.
+     * Iterates ALL position nodes (including moved and dead ones) and reconstructs
+     * each with its position timestamps, mirroring JS `CRDTArray.deepcopy`. Copying
+     * only live nodes would lose moved positions and dead slots, so a later move on
+     * the clone could anchor after a wrong or GC'd position.
      */
     func deepcopy() -> CRDTElement {
         let result = CRDTArray(createdAt: self.createdAt)
-        for node in self.elements {
-            guard let entry = node.elementEntry else { continue }
-            _ = try? result.elements.insert(
-                entry.element.deepcopy(),
-                prevCreatedAt: result.elements.getLastCreatedAt()
-            )
+        for node in self.elements.allNodes() {
+            if let entry = node.getElementEntry() {
+                let copied = entry.element.deepcopy()
+                if let posMovedAt = entry.posMovedAt {
+                    try? result.elements.addMovedElement(
+                        value: copied,
+                        positionCreatedAt: node.getPositionCreatedAt(),
+                        positionMovedAt: posMovedAt
+                    )
+                } else {
+                    _ = try? result.elements.insert(
+                        copied,
+                        prevCreatedAt: result.elements.getLastCreatedAt()
+                    )
+                }
+            } else if let removedAt = node.getPositionRemovedAt() {
+                try? result.elements.addDeadPosition(
+                    positionCreatedAt: node.getPositionCreatedAt(),
+                    positionRemovedAt: removedAt
+                )
+            }
         }
         result.remove(self.removedAt)
         return result

--- a/Sources/Document/CRDT/CRDTRoot.swift
+++ b/Sources/Document/CRDT/CRDTRoot.swift
@@ -86,6 +86,15 @@ class CRDTRoot {
                     self.registerGCPair(pair)
                 }
             }
+            // NOTE(#1227): Register dead position nodes in CRDTArray as GC pairs so
+            // they are collected once all peers have applied the winning move.
+            if let array = element as? CRDTArray {
+                for node in array.getAllRGANodes() {
+                    if node.getElementEntry() == nil, node.getPositionRemovedAt() != nil {
+                        self.registerGCPair(GCPair(parent: array.getRGATreeList(), child: node))
+                    }
+                }
+            }
 
             return false
         })

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -401,11 +401,15 @@ final class CRDTTreeNode: IndexTreeNode {
 
     /**
      * `cloneElement` clones this element node with the given issueTimeTicket function.
+     * Attributes are deep-copied so that a concurrent style operation whose range
+     * was computed before a split also covers the right part of the split.
      */
     func cloneElement(issueTimeTicket: TimeTicket) -> CRDTTreeNode {
-        CRDTTreeNode(id: CRDTTreeNodeID(createdAt: issueTimeTicket, offset: 0),
-                     type: self.type,
-                     removedAt: self.removedAt)
+        let clone = CRDTTreeNode(id: CRDTTreeNodeID(createdAt: issueTimeTicket, offset: 0),
+                                 type: self.type,
+                                 removedAt: self.removedAt)
+        clone.attrs = self.attrs?.deepcopy()
+        return clone
     }
 
     /**
@@ -970,6 +974,51 @@ class CRDTTree: CRDTElement {
                         diff.addDataSizes(others: curr.getDataSize())
                     }
                 }
+
+                // Propagate style to unknown split siblings so that a style
+                // operation whose range was determined before the split also
+                // covers the right part of the split node.
+                if tokenType == .start, let versionVector {
+                    var current = node
+                    while let insNextID = current.insNextID {
+                        guard let next = self.findFloorNode(insNextID), !next.isText else {
+                            break
+                        }
+                        if ticketKnown(versionVector, next.id.createdAt) {
+                            break
+                        }
+                        let siblingPairs = next.setAttrs(attributes, editedAt)
+                        var siblingAffectedAttrs = [String: String]()
+                        for (_, curr) in siblingPairs {
+                            if let key = curr?.key {
+                                siblingAffectedAttrs[key] = attributes[key]
+                            }
+                        }
+                        if !siblingAffectedAttrs.isEmpty {
+                            let parentOfNext = next.parent!
+                            let previousNext = next.prevSibling ?? next.parent!
+                            try changes.append(TreeChange(actor: editedAt.actorID,
+                                                          type: .style,
+                                                          from: self.toIndex(parentOfNext, previousNext),
+                                                          to: self.toIndex(next, next),
+                                                          fromPath: self.toPath(parentOfNext, previousNext),
+                                                          toPath: self.toPath(next, next),
+                                                          value: TreeChangeValue.attributes(siblingAffectedAttrs),
+                                                          splitLevel: 0))
+                            for (prev, _) in siblingPairs where prev != nil {
+                                pairs.append(GCPair(parent: next, child: prev))
+                            }
+                        }
+                        for attr in attributes {
+                            let key = attr.key
+                            let curr = next.attrs?.getNodeByKey(key)
+                            if let curr {
+                                diff.addDataSizes(others: curr.getDataSize())
+                            }
+                        }
+                        current = next
+                    }
+                }
             }
         }
 
@@ -1056,6 +1105,45 @@ class CRDTTree: CRDTElement {
                                               value: value,
                                               splitLevel: 0) // dummy value.
                 )
+
+                // Propagate remove-style to unknown split siblings so that a
+                // removeStyle operation whose range was determined before the
+                // split also covers the right part of the split node.
+                if tokenType == .start, let versionVector {
+                    var current = node
+                    while let insNextID = current.insNextID {
+                        guard let next = self.findFloorNode(insNextID), !next.isText else {
+                            break
+                        }
+                        if ticketKnown(versionVector, next.id.createdAt) {
+                            break
+                        }
+                        if next.attrs == nil {
+                            next.attrs = RHT()
+                        }
+                        var removedAny = false
+                        for key in attributesToRemove {
+                            let nodesToBeRemoved = next.attrs!.remove(key: key, executedAt: editedAt)
+                            removedAny = removedAny || !nodesToBeRemoved.isEmpty
+                            for rhtNode in nodesToBeRemoved {
+                                pairs.append(GCPair(parent: next, child: rhtNode))
+                            }
+                        }
+                        if removedAny {
+                            let parentOfNext = next.parent!
+                            let previousNext = next.prevSibling ?? next.parent!
+                            try changes.append(TreeChange(actor: editedAt.actorID,
+                                                          type: .removeStyle,
+                                                          from: self.toIndex(parentOfNext, previousNext),
+                                                          to: self.toIndex(next, next),
+                                                          fromPath: self.toPath(parentOfNext, previousNext),
+                                                          toPath: self.toPath(next, next),
+                                                          value: TreeChangeValue.attributesToRemove(attributesToRemove),
+                                                          splitLevel: 0))
+                        }
+                        current = next
+                    }
+                }
             }
         }
 

--- a/Sources/Document/CRDT/Primitive.swift
+++ b/Sources/Document/CRDT/Primitive.swift
@@ -175,12 +175,18 @@ extension Primitive {
         case .long(let value):
             return "\(value)"
         case .bytes(let value):
-            let byteValues = [UInt8](value).map { String($0) }.joined(separator: ",")
-            return "[\(byteValues)]"
+            return "\"\(value.base64EncodedString())\""
         case .date(let value):
-            return "\(value.millisecondsTimeIntervalSince1970)"
+            return "\"\(Primitive.iso8601Formatter.string(from: value))\""
         }
     }
+
+    /// ISO 8601 formatter (UTC, fractional seconds) matching JS `Date.toISOString()`.
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
 
     /**
      * `toSortedJSON` returns the sorted JSON encoding of the value.

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -404,11 +404,14 @@ class RGATreeList {
 
         self.insertNodeIntoStructures(node: newPosNode, after: anchor)
 
-        // Kill the old position node.
-        // Remove from splay tree (it no longer contributes to indexed length), but keep in
-        // linked list and position map so Converter can serialise it.
+        // Kill the old position node. Keep it in the splay tree with length 0
+        // (re-splay to refresh weights) rather than deleting it — JS keeps dead
+        // position nodes splayed until GC purge, and a subsequent insert/append
+        // may still use this node as its anchor (e.g. when it is `last` after a
+        // tail move). Deleting it here would leave that anchor unresolvable in
+        // the index tree, so the appended element would never be indexed.
         oldPosNode.markDead(at: executedAt)
-        self.nodeMapByIndex.delete(oldPosNode)
+        self.nodeMapByIndex.splayNode(oldPosNode)
         // NOTE: do NOT reassign `last` here. JS leaves `last` pointing at the
         // now-dead slot when the moved element was the tail, so that subsequent
         // ops emit the same position-identity anchor as JS/Go peers. The

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -16,401 +16,681 @@
 
 import Foundation
 
-/**
- * `RGATreeListNode` is a node of RGATreeList.
- */
-final class RGATreeListNode: SplayNode<CRDTElement> {
-    fileprivate private(set) var previous: RGATreeListNode?
-    fileprivate var next: RGATreeListNode?
-    fileprivate var movedFrom: RGATreeListNode?
+// MARK: - RGATreeListElementEntry
 
-    override init(_ value: CRDTElement) {
+/// Holds the stable identity of an element in the list.
+///
+/// A live element maps 1-to-1 with its current position node. When a move operation wins
+/// the LWW race, the old position node becomes a *dead position node* (its `elementEntry`
+/// is set to `nil`) and a new position node is inserted at the winning location.
+final class RGATreeListElementEntry {
+    /// The actual CRDT element.
+    let element: CRDTElement
+
+    /// The current winning position node for this element.
+    ///
+    /// Updated whenever a `moveAfter` wins the LWW race for this element.
+    var positionNode: RGATreeListNode
+
+    /// The `executedAt` of the move operation that established the current position.
+    ///
+    /// `nil` for elements that have never been moved. Mirrors `posMovedAt` in the JS implementation.
+    var posMovedAt: TimeTicket?
+
+    init(element: CRDTElement, positionNode: RGATreeListNode) {
+        self.element = element
+        self.positionNode = positionNode
+        self.posMovedAt = nil
+    }
+}
+
+// MARK: - RGATreeListNode
+
+/// A node of ``RGATreeList``.
+///
+/// Each node represents a *position slot* in the list, not necessarily a live element.
+/// A *dead position node* has `elementEntry == nil` and its `positionRemovedAt` is set;
+/// it contributes zero to the splay-tree length and is a GC target.
+final class RGATreeListNode: SplayNode<CRDTElement> {
+    fileprivate var previous: RGATreeListNode?
+    fileprivate var next: RGATreeListNode?
+
+    /// The position creation time, which is the stable key for this position slot.
+    ///
+    /// For normal (non-moved) nodes this equals `value.createdAt`.
+    /// For nodes inserted by `moveAfter`, this is the `executedAt` ticket of the move.
+    private(set) var positionCreatedAt: TimeTicket
+
+    /// Set when this position node is superseded by a later LWW-winning move.
+    /// A non-nil value means this is a dead position node.
+    private(set) var positionRemovedAt: TimeTicket?
+
+    /// The ``RGATreeListElementEntry`` this position node is the winning slot for.
+    /// `nil` for dead position nodes.
+    private(set) var elementEntry: RGATreeListElementEntry?
+
+    // MARK: Initializers
+
+    /// Creates a node wrapping a live element.
+    fileprivate init(value: CRDTElement, positionCreatedAt: TimeTicket) {
+        self.positionCreatedAt = positionCreatedAt
         super.init(value)
     }
 
-    /**
-     * `create` creates a new node after the previous node.
-     */
-    static func create(with value: CRDTElement, previousNode: RGATreeListNode) -> RGATreeListNode {
-        let newNode = RGATreeListNode(value)
-        let prevNext = previousNode.next
-        previousNode.next = newNode
-        newNode.previous = previousNode
-        newNode.next = prevNext
-        if let prevNext = prevNext {
-            prevNext.previous = newNode
-        }
-
-        return newNode
+    /// Creates the sentinel dummy-head node.
+    fileprivate static func createDummy() -> RGATreeListNode {
+        let dummyValue = Primitive(value: .null, createdAt: .initial)
+        dummyValue.removedAt = .initial
+        let node = RGATreeListNode(value: dummyValue, positionCreatedAt: .initial)
+        // Dummy head has no entry; it is never a GC target.
+        return node
     }
 
-    /**
-     * `length` returns the length of this node.
-     */
+    // MARK: SplayNode overrides
+
+    /// Zero for removed elements *and* for dead position nodes.
     override var length: Int {
+        if self.elementEntry == nil {
+            // Dead position node — contributes no length.
+            return 0
+        }
         return self.value.isRemoved ? 0 : 1
     }
 
-    /**
-     * `remove` removes value based on removing time.
-     */
-    fileprivate func remove(_ removedAt: TimeTicket) -> Bool {
-        return self.value.remove(removedAt)
-    }
+    // MARK: Internal helpers
 
-    /**
-     * `getCreatedAt` returns creation time of this value
-     */
+    /// The element-level `createdAt`, used to look up the element entry.
     fileprivate var createdAt: TimeTicket {
         return self.value.createdAt
     }
 
-    /**
-     * `getPositionedAt` returns time this element was positioned in the array.
-     */
+    /// The positioned-at time for insertion-order arbitration.
+    ///
+    /// Uses `positionCreatedAt` as the LWW register key, mirroring the JS implementation.
     fileprivate var positionedAt: TimeTicket {
-        if let movedAt = self.value.movedAt {
-            return movedAt
-        }
-
-        return self.value.createdAt
+        return self.positionCreatedAt
     }
 
-    /**
-     * `release` deletes prev and next node.
-     */
+    /// Returns `true` when the underlying element has been removed.
+    fileprivate var isRemoved: Bool {
+        return self.value.isRemoved
+    }
+
+    /// Removes the underlying element value at the given time.
+    @discardableResult
+    fileprivate func remove(_ at: TimeTicket) -> Bool {
+        return self.value.remove(at)
+    }
+
+    /// Unlinks this node from its neighbours (doubly-linked list surgery).
     fileprivate func release() {
-        if let previous = self.previous {
+        if let previous {
             previous.next = self.next
         }
-        if let next = self.next {
+        if let next {
             next.previous = self.previous
         }
         self.previous = nil
         self.next = nil
     }
 
-    /**
-     * `isRemoved` checks if the value was removed.
-     */
-    fileprivate var isRemoved: Bool {
-        return self.value.isRemoved
+    // MARK: Public accessors
+
+    /// Returns the position creation time, which is the stable identifier for this slot.
+    func getPositionCreatedAt() -> TimeTicket {
+        return self.positionCreatedAt
     }
 
-    /**
-     * `getMovedFrom` returns the previous element before the element moved.
-     */
-    func getMovedFrom() -> RGATreeListNode? {
-        return self.movedFrom
+    /// Returns the time at which this position slot was garbage-collected (killed).
+    func getPositionRemovedAt() -> TimeTicket? {
+        return self.positionRemovedAt
     }
 
-    /**
-     * `setMovedFrom` sets the previous element before the element moved.
-     */
-    func setMovedFrom(_ movedFrom: RGATreeListNode?) {
-        self.movedFrom = movedFrom
+    /// Returns the element entry for this position, or `nil` if this is a dead node.
+    func getElementEntry() -> RGATreeListElementEntry? {
+        return self.elementEntry
+    }
+
+    /// Marks this position node as dead by setting the removal time and clearing the entry.
+    fileprivate func markDead(at removedAt: TimeTicket) {
+        self.positionRemovedAt = removedAt
+        self.elementEntry = nil
+    }
+
+    /// Attaches an element entry to this position node (used during snapshot restore).
+    fileprivate func setElementEntry(_ entry: RGATreeListElementEntry?) {
+        self.elementEntry = entry
     }
 }
 
-/**
- * `RGATreeList` is replicated growable array.
- */
+// MARK: GCChild conformance
+
+extension RGATreeListNode: GCChild {
+    /// Returns the ID string keyed on `positionCreatedAt` so the GC pair map can
+    /// address dead position nodes independently of their element's `createdAt`.
+    var toIDString: String {
+        return self.positionCreatedAt.toIDString
+    }
+
+    /// Returns the time this position node was killed (i.e., `positionRemovedAt`).
+    var removedAt: TimeTicket? {
+        return self.positionRemovedAt
+    }
+
+    /// Returns the meta data size of this position node: one ticket for the
+    /// position, plus another when the position has been removed (matching JS).
+    func getDataSize() -> DataSize {
+        var meta = timeTicketSize
+        if self.positionRemovedAt != nil {
+            meta += timeTicketSize
+        }
+        return DataSize(data: 0, meta: meta)
+    }
+}
+
+// MARK: - RGATreeList
+
+/// A replicated growable array using an LWW position register for convergent array moves.
+///
+/// Each element has a stable identity held in ``RGATreeListElementEntry``, separate from
+/// its current position slot. When two concurrent moves target the same element the one
+/// with the later `executedAt` wins; the old position becomes a *dead position node*
+/// that is eventually garbage-collected.
 class RGATreeList {
     private let dummyHead: RGATreeListNode
     private var last: RGATreeListNode
     private let nodeMapByIndex: SplayTree<CRDTElement>
-    private var nodeMapByCreatedAt: [TimeTicket: RGATreeListNode]
+
+    /// Maps a position node's `positionCreatedAt` to the node itself.
+    private var nodeMapByPositionCreatedAt: [TimeTicket: RGATreeListNode]
+
+    /// Maps an element's `createdAt` to its ``RGATreeListElementEntry``.
+    private var elementMapByCreatedAt: [TimeTicket: RGATreeListElementEntry]
 
     init() {
-        let dummyValue = Primitive(value: .null, createdAt: .initial)
-        dummyValue.removedAt = .initial
-        self.dummyHead = RGATreeListNode(dummyValue)
+        self.dummyHead = RGATreeListNode.createDummy()
         self.last = self.dummyHead
         self.nodeMapByIndex = SplayTree()
         self.nodeMapByIndex.insert(self.dummyHead)
-        self.nodeMapByCreatedAt = [self.dummyHead.createdAt: self.dummyHead]
+        self.nodeMapByPositionCreatedAt = [self.dummyHead.positionCreatedAt: self.dummyHead]
+        self.elementMapByCreatedAt = [:]
     }
 
-    /**
-     * `length` returns size of RGATreeList.
-     */
+    // MARK: Length
+
+    /// The number of live (non-removed) elements in this list.
     var length: Int {
         return self.nodeMapByIndex.length
     }
 
-    /**
-     * `findNode` returns the node by the given createdAt and
-     * executedAt. It passes through nodes created after executedAt from the
-     * given node and returns the next node.
-     *
-     * - Parameters:
-     *   - createdAt: created time
-     *   - executedAt: executed time
-     * - Returns: next node
-     */
-    private func findNode(fromCreatedAt createdAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode {
-        guard var node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
+    // MARK: Private helpers
 
-        while
-            let movedAt = node.value.movedAt,
-            movedAt.after(executedAt),
-            let movedFrom = node.getMovedFrom()
-        {
-            node = movedFrom
+    /// Walks forward from `node` skipping nodes whose `positionedAt` is after `executedAt`.
+    ///
+    /// This is the LWW-correct way to find the insertion point: we skip over any
+    /// concurrent insertions that were committed *after* `executedAt`.
+    private func findNextBeforeExecutedAt(node: RGATreeListNode, executedAt: TimeTicket) -> RGATreeListNode {
+        var current = node
+        while let next = current.next, next.positionedAt > executedAt {
+            current = next
         }
-
-        while let next = node.next, next.positionedAt.after(executedAt) {
-            node = next
-        }
-
-        return node
+        return current
     }
 
+    /// Removes `node` from the splay tree and position map, updating `last` if needed.
     private func release(node: RGATreeListNode) {
-        if self.last === node, let previousNode = node.previous {
-            self.last = previousNode
+        if self.last === node, let prev = node.previous {
+            self.last = prev
         }
 
         node.release()
         self.nodeMapByIndex.delete(node)
-        self.nodeMapByCreatedAt.removeValue(forKey: node.value.createdAt)
+        self.nodeMapByPositionCreatedAt.removeValue(forKey: node.positionCreatedAt)
     }
 
-    /**
-     * `insert` adds a new node with the value after the given node.
-     */
+    // MARK: Core insertion (private)
+
+    /// Inserts a node into the linked list and splay tree after the anchor.
+    ///
+    /// The `node` must have its `elementEntry` set before this call if it is a live node,
+    /// so that `SplayTree.updateWeight` sees the correct `length` during insertion.
+    private func insertNodeIntoStructures(node: RGATreeListNode, after anchor: RGATreeListNode) {
+        // Link into doubly-linked list.
+        let anchorNext = anchor.next
+        anchor.next = node
+        node.previous = anchor
+        node.next = anchorNext
+        anchorNext?.previous = node
+
+        if anchor === self.last {
+            self.last = node
+        }
+
+        self.nodeMapByIndex.insert(previousNode: anchor, newNode: node)
+        self.nodeMapByPositionCreatedAt[node.positionCreatedAt] = node
+    }
+
+    /// Inserts a bare position node (no element) after the node identified by `prevPositionCreatedAt`.
+    ///
+    /// This is used by `moveAfter` for both the winning and losing LWW paths to create a
+    /// new position slot. The node is inserted using RGA ordering (skipping concurrent nodes
+    /// with later timestamps) and added to the splay tree and position map.
+    ///
+    /// - Parameters:
+    ///   - prevPositionCreatedAt: The `positionCreatedAt` of the node to insert after.
+    ///   - executedAt: The `executedAt` of the move, used as the new node's `positionCreatedAt`.
+    /// - Returns: The newly created position node.
+    @discardableResult
+    private func insertPositionAfter(prevPositionCreatedAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode {
+        guard let prevNode = self.nodeMapByPositionCreatedAt[prevPositionCreatedAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(prevPositionCreatedAt)")
+        }
+        let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: executedAt)
+        // Use a null placeholder as the SplayNode value — callers must check `elementEntry == nil`
+        // to detect bare position nodes rather than accessing `.value` directly.
+        let placeholder = Primitive(value: .null, createdAt: executedAt)
+        let node = RGATreeListNode(value: placeholder, positionCreatedAt: executedAt)
+        // No elementEntry set — this is a bare position node.
+        self.insertNodeIntoStructures(node: node, after: anchor)
+        return node
+    }
+
+    // MARK: Public insert (used by CRDTArray / Converter)
+
+    /// Inserts `value` after the element identified by `prevCreatedAt`.
+    ///
+    /// This is the normal (non-move) insertion path; the new position slot's key is
+    /// set to `value.createdAt`. The `prevCreatedAt` is interpreted as either a position
+    /// node key (checked first in `nodeMapByPositionCreatedAt`) or an element key
+    /// (fallback via `elementMapByCreatedAt`), mirroring the JS `insertAfter` algorithm.
     @discardableResult
     func insert(
         _ value: CRDTElement,
-        prevCreatedAt createdAt: TimeTicket,
+        prevCreatedAt: TimeTicket,
         executedAt: TimeTicket? = nil
     ) throws -> RGATreeListNode {
-        let executedAt: TimeTicket = executedAt ?? value.createdAt
-
-        let previousNode = try findNode(fromCreatedAt: createdAt, executedAt: executedAt)
-        let newNode = RGATreeListNode.create(with: value, previousNode: previousNode)
-        if previousNode === self.last {
-            self.last = newNode
+        let et = executedAt ?? value.createdAt
+        // Resolve prevCreatedAt to the correct anchor position node.
+        // JS insertAfter checks nodeMapByCreatedAt (position map) first, then elementMapByCreatedAt.
+        let anchorNode: RGATreeListNode
+        if let directNode = self.nodeMapByPositionCreatedAt[prevCreatedAt] {
+            // prevCreatedAt is a known position node key (covers dummy head, normal nodes, and
+            // position-identity keys from moved nodes).
+            anchorNode = directNode
+        } else if let prevEntry = self.elementMapByCreatedAt[prevCreatedAt] {
+            // prevCreatedAt is an element key — use the element's current position node.
+            anchorNode = prevEntry.positionNode
+        } else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(prevCreatedAt)")
         }
+        let anchor = self.findNextBeforeExecutedAt(node: anchorNode, executedAt: et)
+        let newNode = RGATreeListNode(value: value, positionCreatedAt: value.createdAt)
 
-        self.nodeMapByIndex.insert(previousNode: previousNode, newNode: newNode)
-        self.nodeMapByCreatedAt[newNode.createdAt] = newNode
+        // Create and attach the entry BEFORE splay-tree insertion so that `newNode.length`
+        // returns 1 when `updateWeight` is called during `insertNodeIntoStructures`.
+        let entry = RGATreeListElementEntry(element: value, positionNode: newNode)
+        newNode.setElementEntry(entry)
+        self.elementMapByCreatedAt[value.createdAt] = entry
+
+        self.insertNodeIntoStructures(node: newNode, after: anchor)
         return newNode
     }
 
-    /**
-     * `move` moves the given `createdAt` element
-     * after the `previousCreatedAt` element.
-     */
-    func move(createdAt: TimeTicket, afterCreatedAt: TimeTicket, executedAt: TimeTicket) throws {
-        guard var prevNode = self.nodeMapByCreatedAt[afterCreatedAt] else {
-            let log = "can't find the given node: \(afterCreatedAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
-
-        guard var node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
-
-        if prevNode !== node, executedAt > node.positionedAt {
-            let movedFrom = node.previous
-            var nextNode = node.next
-            self.release(node: node)
-
-            node = try self.insert(
-                node.value,
-                prevCreatedAt: prevNode.createdAt,
-                executedAt: executedAt
-            )
-            node.value.setMovedAt(executedAt)
-            node.setMovedFrom(movedFrom)
-
-            while let next = nextNode, next.positionedAt > executedAt {
-                prevNode = node
-                node = next
-                nextNode = node.next
-
-                self.release(node: node)
-                node = try self.insert(
-                    node.value,
-                    prevCreatedAt: prevNode.createdAt,
-                    executedAt: executedAt
-                )
-                node.value.setMovedAt(executedAt)
-                node.setMovedFrom(movedFrom)
-            }
-        }
-    }
-
-    /**
-     * `insert` adds the given element after the last node.
-     */
+    /// Appends `value` after the last node.
     func insert(_ value: CRDTElement) throws {
-        try self.insert(value, prevCreatedAt: self.last.createdAt)
+        // Use the last node's positionCreatedAt (position identity) as the anchor.
+        try self.insert(value, prevCreatedAt: self.last.positionCreatedAt)
     }
 
-    /**
-     * `get` returns the element of the given creation time.
-     */
-    func get(createdAt: TimeTicket) throws -> CRDTElement {
-        guard let node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
+    // MARK: moveAfter — LWW position register
 
-        return node.value
-    }
-
-    /**
-     * `subPath` returns the sub path of the given element.
-     */
-    func subPath(createdAt: TimeTicket) throws -> String {
-        guard let node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
-
-        return String(self.nodeMapByIndex.indexOf(node))
-    }
-
-    /**
-     * `purge` physically purges element.
-     */
-    func purge(_ value: CRDTElement) throws {
-        guard let node = self.nodeMapByCreatedAt[value.createdAt] else {
-            let log = "failed to find the given createdAt: \(value.createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
-
-        self.release(node: node)
-    }
-
-    /**
-     * `set` sets the given element at the given creation time.
-     */
+    /// Moves the element identified by `createdAt` to after `prevCreatedAt`, returning
+    /// the dead position node that must be registered as a GC pair.
+    ///
+    /// Faithful port of the yorkie-js-sdk v0.7.6 `moveAfter` algorithm:
+    /// - **LWW winner**: Creates a new position node at `prevCreatedAt`, wires up the entry,
+    ///   kills the old position node (sets `positionRemovedAt`), and returns it for GC.
+    /// - **LWW loser**: Creates a bare dead position node at `prevCreatedAt` (no entry,
+    ///   `positionRemovedAt = executedAt`), splays it, and returns it for GC.
+    ///   Returns `nil` only when the node was already processed (idempotency check).
+    ///
+    /// No cascade re-linking is performed — that is not in the JS specification.
+    ///
+    /// - Parameters:
+    ///   - createdAt: The `createdAt` of the element to move (element identity).
+    ///   - prevCreatedAt: The POSITION node key after which to insert (position identity).
+    ///   - executedAt: The operation's execution time, used as the LWW clock.
+    /// - Returns: The dead position node (GC target), or `nil` if already processed.
+    /// - Throws: ``YorkieError`` when the target element or previous position cannot be found.
     @discardableResult
-    func set(
-        createdAt: TimeTicket,
-        element: CRDTElement,
-        executedAt: TimeTicket
-    ) throws -> CRDTElement {
-        guard let node = nodeMapByCreatedAt[createdAt] else {
-            throw YorkieError(
-                code: .errInvalidArgument,
-                message: "cant find the given node: \(createdAt.toIDString)"
-            )
+    func moveAfter(createdAt: TimeTicket, prevCreatedAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode? {
+        guard let entry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given element: \(createdAt)")
         }
 
-        try self.insert(element, prevCreatedAt: node.createdAt, executedAt: executedAt)
-        return try self.delete(createdAt: createdAt, executedAt: executedAt)
+        guard self.nodeMapByPositionCreatedAt[prevCreatedAt] != nil else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the previous node: \(prevCreatedAt)")
+        }
+
+        // Idempotency: if a node with this executedAt was already created, skip entirely.
+        if self.nodeMapByPositionCreatedAt[executedAt] != nil {
+            return nil
+        }
+
+        // LWW loser path — this move was superseded by a later move of the same element.
+        if let posMovedAt = entry.posMovedAt, !executedAt.after(posMovedAt) {
+            // Still create a bare dead position node so GC pairs are complete.
+            let deadPosNode = try self.insertPositionAfter(prevPositionCreatedAt: prevCreatedAt, executedAt: executedAt)
+            deadPosNode.markDead(at: executedAt)
+            self.nodeMapByIndex.splayNode(deadPosNode)
+            return deadPosNode
+        }
+
+        // LWW winner path.
+        // Build the new position node carrying the actual element value (not a placeholder),
+        // so callers that access `.value` on indexed nodes get the real element.
+        let oldPosNode = entry.positionNode
+        guard let prevNode = self.nodeMapByPositionCreatedAt[prevCreatedAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the previous node: \(prevCreatedAt)")
+        }
+        let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: executedAt)
+        let newPosNode = RGATreeListNode(value: entry.element, positionCreatedAt: executedAt)
+
+        // Wire the entry BEFORE splay-tree insertion so `newPosNode.length == 1`.
+        newPosNode.setElementEntry(entry)
+        entry.positionNode = newPosNode
+        entry.posMovedAt = executedAt
+        _ = entry.element.setMovedAt(executedAt)
+
+        self.insertNodeIntoStructures(node: newPosNode, after: anchor)
+
+        // Kill the old position node.
+        // Remove from splay tree (it no longer contributes to indexed length), but keep in
+        // linked list and position map so Converter can serialise it.
+        oldPosNode.markDead(at: executedAt)
+        self.nodeMapByIndex.delete(oldPosNode)
+        // NOTE: do NOT reassign `last` here. JS leaves `last` pointing at the
+        // now-dead slot when the moved element was the tail, so that subsequent
+        // ops emit the same position-identity anchor as JS/Go peers. The
+        // newPosNode insertion above already advanced `last` in the only case
+        // JS does (when the anchor was `last`).
+
+        return oldPosNode
     }
 
-    /**
-     * `getNode` returns node of the given index.
-     */
-    func getNode(index: Int) throws -> RGATreeListNode {
-        guard index < self.length else {
-            let log = "length is smaller than or equal to: \(index)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
+    // MARK: Snapshot restore helpers
 
-        let node = try self.nodeMapByIndex.findForArray(index)
-        guard let rgaNode = node as? RGATreeListNode else {
-            let log = "failed to find the given index: \(index)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
-        }
+    /// Restores a dead position node from a snapshot.
+    ///
+    /// Called by `fromArray` when decoding a node that has `positionCreatedAt` +
+    /// `positionRemovedAt` but **no** element (the JS wire format for dead nodes).
+    /// Inserts the node into the splay tree and updates `last`, exactly as JS `addDeadPosition` does.
+    func addDeadPosition(
+        positionCreatedAt: TimeTicket,
+        positionRemovedAt: TimeTicket
+    ) throws {
+        let placeholder = Primitive(value: .null, createdAt: positionCreatedAt)
+        let node = RGATreeListNode(value: placeholder, positionCreatedAt: positionCreatedAt)
+        node.markDead(at: positionRemovedAt)
 
-        return rgaNode
+        let prevNode = self.last
+        // Link into doubly-linked list.
+        prevNode.next = node
+        node.previous = prevNode
+        // Update last (mirrors JS: `this.last = node`).
+        self.last = node
+        // Insert into splay tree (mirrors JS: `this.nodeMapByIndex.insertAfter(prevNode, node)`).
+        self.nodeMapByIndex.insert(previousNode: prevNode, newNode: node)
+        self.nodeMapByPositionCreatedAt[positionCreatedAt] = node
     }
 
-    /**
-     * `getPreviousCreatedAt` returns a creation time of the previous node.
-     */
-    func getPreviousCreatedAt(ofCreatedAt createdAt: TimeTicket) throws -> TimeTicket {
-        guard let node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
+    /// Restores a moved element's position from a snapshot.
+    ///
+    /// Called by `fromArray` when decoding a node that has `element` +
+    /// `positionCreatedAt` + `positionMovedAt`.
+    func addMovedElement(
+        value: CRDTElement,
+        positionCreatedAt: TimeTicket,
+        positionMovedAt: TimeTicket
+    ) throws {
+        guard let prevNode = self.nodeMapByPositionCreatedAt[self.last.positionCreatedAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the last node")
         }
-        var previousNode: RGATreeListNode? = node
-        repeat {
-            previousNode = previousNode?.previous
-        } while self.dummyHead !== previousNode && previousNode?.isRemoved == true
+        let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: positionCreatedAt)
+        let node = RGATreeListNode(value: value, positionCreatedAt: positionCreatedAt)
 
-        return previousNode?.value.createdAt ?? self.getHead().createdAt
+        // Set entry BEFORE splay-tree insertion so `node.length == 1`.
+        let entry = RGATreeListElementEntry(element: value, positionNode: node)
+        entry.posMovedAt = positionMovedAt
+        node.setElementEntry(entry)
+        self.elementMapByCreatedAt[value.createdAt] = entry
+
+        self.insertNodeIntoStructures(node: node, after: anchor)
     }
 
-    /**
-     * `delete` deletes the node of the given creation time.
-     */
+    // MARK: Backward-compatible move (tests + JSONArray local path)
+
+    /// Moves the element identified by `createdAt` after `afterCreatedAt`.
+    ///
+    /// Delegates to ``moveAfter(createdAt:prevCreatedAt:executedAt:)`` and discards the
+    /// dead position node return value. GC pair registration is the caller's responsibility
+    /// (``MoveOperation`` does it via ``CRDTArray/moveAfter(createdAt:prevCreatedAt:executedAt:)``).
+    @discardableResult
+    func move(createdAt: TimeTicket, afterCreatedAt: TimeTicket, executedAt: TimeTicket) throws -> RGATreeListNode? {
+        return try self.moveAfter(createdAt: createdAt, prevCreatedAt: afterCreatedAt, executedAt: executedAt)
+    }
+
+    // MARK: Element access
+
+    /// Returns the element for the given `createdAt`, or throws if not found.
+    func get(createdAt: TimeTicket) throws -> CRDTElement {
+        guard let entry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(createdAt)")
+        }
+        return entry.element
+    }
+
+    /// Returns the index string for the element with the given `createdAt`.
+    func subPath(createdAt: TimeTicket) throws -> String {
+        guard let entry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(createdAt)")
+        }
+        return String(self.nodeMapByIndex.indexOf(entry.positionNode))
+    }
+
+    // MARK: Deletion
+
+    /// Marks the element identified by `createdAt` as deleted at `executedAt`.
+    @discardableResult
     func delete(createdAt: TimeTicket, executedAt: TimeTicket) throws -> CRDTElement {
-        guard let node = self.nodeMapByCreatedAt[createdAt] else {
-            let log = "can't find the given node: \(createdAt)"
-            throw YorkieError(code: .errInvalidArgument, message: log)
+        guard let entry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(createdAt)")
         }
-
+        let node = entry.positionNode
         let alreadyRemoved = node.isRemoved
-        if node.remove(executedAt), alreadyRemoved == false {
+        if node.remove(executedAt), !alreadyRemoved {
             self.nodeMapByIndex.splayNode(node)
         }
         return node.value
     }
 
-    /**
-     * `deleteByIndex` deletes the node of the given index.
-     */
+    /// Deletes the element at `index`.
+    @discardableResult
     func deleteByIndex(index: Int, executedAt: TimeTicket) throws -> CRDTElement {
         let node = try self.getNode(index: index)
-
         if node.remove(executedAt) {
             self.nodeMapByIndex.splayNode(node)
         }
         return node.value
     }
 
-    /**
-     * `getHead` returns the value of head elements.
-     */
-    func getHead() -> CRDTElement {
-        return self.dummyHead.value
+    // MARK: Purge (hard delete)
+
+    /// Physically removes the element node from the list (GC final step).
+    func purge(_ value: CRDTElement) throws {
+        guard let entry = self.elementMapByCreatedAt[value.createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "failed to find the given createdAt: \(value.createdAt)")
+        }
+        let node = entry.positionNode
+        self.release(node: node)
+        self.elementMapByCreatedAt.removeValue(forKey: value.createdAt)
     }
 
-    /**
-     * `getLast` returns the value of last elements.
-     */
+    /// Physically removes a dead position node from the list (GC final step for move-dead slots).
+    func purgeDeadPosition(positionCreatedAt: TimeTicket) {
+        guard let node = self.nodeMapByPositionCreatedAt[positionCreatedAt] else {
+            return
+        }
+        // Dead nodes may or may not be in nodeMapByIndex; use delete which is safe either way.
+        if self.last === node, let prev = node.previous {
+            self.last = prev
+        }
+        node.release()
+        self.nodeMapByIndex.delete(node)
+        self.nodeMapByPositionCreatedAt.removeValue(forKey: positionCreatedAt)
+    }
+
+    // MARK: Set (replace element at position)
+
+    /// Replaces the element at `createdAt` with `element`.
+    @discardableResult
+    func set(
+        createdAt: TimeTicket,
+        element: CRDTElement,
+        executedAt: TimeTicket
+    ) throws -> CRDTElement {
+        guard let existingEntry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(
+                code: .errInvalidArgument,
+                message: "cant find the given node: \(createdAt.toIDString)"
+            )
+        }
+        let prevPosCreatedAt = existingEntry.positionNode.positionCreatedAt
+        try self.insert(element, prevCreatedAt: prevPosCreatedAt, executedAt: executedAt)
+        return try self.delete(createdAt: createdAt, executedAt: executedAt)
+    }
+
+    // MARK: Node access by index
+
+    /// Returns the position node at `index` in the splay tree.
+    func getNode(index: Int) throws -> RGATreeListNode {
+        guard index < self.length else {
+            throw YorkieError(code: .errInvalidArgument, message: "length is smaller than or equal to: \(index)")
+        }
+        let node = try self.nodeMapByIndex.findForArray(index)
+        guard let rgaNode = node as? RGATreeListNode else {
+            throw YorkieError(code: .errInvalidArgument, message: "failed to find the given index: \(index)")
+        }
+        return rgaNode
+    }
+
+    // MARK: Previous / last
+
+    /// Returns the position `createdAt` of the node immediately before the element at `createdAt`.
+    ///
+    /// Returns the POSITION node's `positionCreatedAt` (position identity), not the element's
+    /// `value.createdAt`. This matches the JS `findPrevCreatedAt` which returns
+    /// `node.getPositionCreatedAt()`.
+    func getPreviousCreatedAt(ofCreatedAt createdAt: TimeTicket) throws -> TimeTicket {
+        guard let entry = self.elementMapByCreatedAt[createdAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(createdAt)")
+        }
+        var previousNode: RGATreeListNode? = entry.positionNode
+        repeat {
+            previousNode = previousNode?.previous
+        } while self.dummyHead !== previousNode && previousNode?.isRemoved == true
+
+        // Return POSITION identity (`positionCreatedAt`).
+        // Dummy head's positionCreatedAt == .initial, which is the sentinel for "insert at front".
+        return previousNode?.positionCreatedAt ?? self.dummyHead.positionCreatedAt
+    }
+
+    /// Returns the last element.
     func getLast() -> CRDTElement {
         return self.last.value
     }
 
-    /**
-     * `getLastCreatedAt` returns the creation time of last element.
-     */
+    /// Returns the POSITION `createdAt` of the last node.
+    ///
+    /// Returns `last.positionCreatedAt` (position identity), not element identity,
+    /// mirroring the JS `getLastCreatedAt()` which calls `this.last.getPositionCreatedAt()`.
     func getLastCreatedAt() -> TimeTicket {
-        return self.last.createdAt
+        return self.last.positionCreatedAt
     }
 
-    /**
-     * `toTestString` returns a String containing the meta data of the node id
-     * for debugging purpose.
-     */
-    var toTestString: String {
-        var result: [String] = []
+    /// Returns the dummy head's element.
+    func getHead() -> CRDTElement {
+        return self.dummyHead.value
+    }
 
-        for node in self {
-            let value = "\(node.createdAt):\(node.value.toJSON())"
-            if node.isRemoved {
-                result.append("{\(value)}")
-            } else {
-                result.append("[\(value)]")
-            }
+    /// Returns the dummy head's position creation time.
+    func getHeadPositionCreatedAt() -> TimeTicket {
+        return self.dummyHead.positionCreatedAt
+    }
+
+    /// Returns the current POSITION node key for the element identified by `elemCreatedAt`.
+    ///
+    /// Mirrors the JS `posCreatedAt(elemCreatedAt)` which returns
+    /// `entry.positionNode.getPositionCreatedAt()`.
+    func posCreatedAt(elemCreatedAt: TimeTicket) throws -> TimeTicket {
+        guard let entry = self.elementMapByCreatedAt[elemCreatedAt] else {
+            throw YorkieError(code: .errInvalidArgument, message: "can't find the given element: \(elemCreatedAt)")
         }
+        return entry.positionNode.positionCreatedAt
+    }
 
-        return result.joined(separator: "-")
+    // MARK: All nodes (for snapshot serialisation and GC registration)
+
+    /// Returns all nodes in linked-list order, including dead position nodes.
+    ///
+    /// Used by the Converter to serialise the full list (including dead position
+    /// slots) and by `CRDTRoot` to register dead position nodes as GC pairs.
+    func allNodes() -> [RGATreeListNode] {
+        var result: [RGATreeListNode] = []
+        var current = self.dummyHead.next
+        while let node = current {
+            result.append(node)
+            current = node.next
+        }
+        return result
+    }
+
+    // MARK: Debug
+
+    /// Returns a human-readable representation for testing.
+    ///
+    /// Dead position nodes are excluded — tests assert on element order only.
+    var toTestString: String {
+        var parts: [String] = []
+        var current = self.dummyHead.next
+        while let node = current {
+            if let entry = node.elementEntry {
+                // Use element's own createdAt for test readability, matching the prior format.
+                let str = "\(entry.element.createdAt):\(entry.element.toJSON())"
+                if node.isRemoved {
+                    parts.append("{\(str)}")
+                } else {
+                    parts.append("[\(str)]")
+                }
+            }
+            // Dead position nodes (elementEntry == nil) are not rendered.
+            current = node.next
+        }
+        return parts.joined(separator: "-")
     }
 }
+
+// MARK: - GCParent conformance
+
+extension RGATreeList: GCParent {
+    /// Purges a dead position node from the linked list.
+    func purge(node: any GCChild) {
+        guard let posNode = node as? RGATreeListNode else { return }
+        self.purgeDeadPosition(positionCreatedAt: posNode.positionCreatedAt)
+    }
+}
+
+// MARK: - Sequence conformance
 
 extension RGATreeList: Sequence {
     typealias Element = RGATreeListNode
@@ -420,6 +700,10 @@ extension RGATreeList: Sequence {
     }
 }
 
+/// Iterates over all nodes in linked-list order (live and removed, but not dead position nodes).
+///
+/// Dead position nodes are excluded because they have no `elementEntry` and callers
+/// that iterate via `Sequence` expect `RGATreeListNode` values with a live `value`.
 class RGATreeListIterator: IteratorProtocol {
     private weak var iteratorNext: RGATreeListNode?
 
@@ -428,6 +712,11 @@ class RGATreeListIterator: IteratorProtocol {
     }
 
     func next() -> RGATreeListNode? {
+        // Skip dead position nodes.
+        while let current = self.iteratorNext, current.elementEntry == nil {
+            self.iteratorNext = current.next
+        }
+
         guard let result = self.iteratorNext else {
             return nil
         }

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -189,6 +189,12 @@ public class Document: Attachable {
         if context.hasChange {
             Logger.trace("trying to update a local change: \(self.toJSON())")
 
+            let prev = PrevPresenceState(
+                hadPresence: self.presences[actorID] != nil,
+                wasOnline: self.status == .attached,
+                presence: self.presences[actorID]?.mapValues { $0.toJSONObject }
+            )
+
             let change = context.toChange()
             let executionResult = try? change.execute(root: self.root, presences: &self.presences)
             let opInfos = executionResult?.opInfos ?? []
@@ -226,8 +232,10 @@ public class Document: Attachable {
                 self.publish(changeEvent)
             }
 
-            if change.presenceChange != nil, let presence = self.getPresence(actorID) {
-                self.publish(PresenceChangedEvent(value: (actorID, presence)))
+            if change.presenceChange != nil {
+                if let presenceEvent = self.reconcilePresence(actorID: actorID, prev: prev, source: .local) {
+                    self.publish(presenceEvent)
+                }
             }
 
             Logger.trace("after update a local change: \(self.toJSON())")
@@ -760,42 +768,17 @@ public class Document: Attachable {
             try change.execute(root: clone.root, presences: &self.clone!.presences, source: source)
 
             var changeInfo: ChangeInfo?
-            var presenceEvent: DocEvent?
 
             guard let actorID = change.id.getActorID() else {
                 throw YorkieError(code: .errUnexpected, message: "ActorID is null")
             }
 
-            if let presenceChange = change.presenceChange, self.onlineClients.contains(actorID) {
-                switch presenceChange {
-                case .put(let presence):
-                    // NOTE(chacha912): When the user exists in onlineClients, but
-                    // their presence was initially absent, we can consider that we have
-                    // received their initial presence, so trigger the 'watched' event
-                    if self.onlineClients.contains(actorID) {
-                        let peer = (actorID, presence.toJSONObejct)
-
-                        if self.getPresence(actorID) != nil {
-                            presenceEvent = PresenceChangedEvent(value: peer)
-                        } else {
-                            presenceEvent = WatchedEvent(value: peer)
-                        }
-                    }
-                case .clear:
-                    // NOTE(chacha912): When the user exists in onlineClients, but
-                    // PresenceChange(clear) is received, we can consider it as detachment
-                    // occurring before unwatching.
-                    // Detached user is no longer participating in the document, we remove
-                    // them from the online clients and trigger the 'unwatched' event.
-                    guard let presence = self.getPresence(actorID) else {
-                        throw YorkieError(code: .errUnexpected, message: "No presence!")
-                    }
-
-                    presenceEvent = UnwatchedEvent(value: (actorID, presence))
-
-                    self.removeOnlineClient(actorID)
-                }
-            }
+            // Capture prev state before execute updates this.presences.
+            let prev: PrevPresenceState? = change.presenceChange != nil ? PrevPresenceState(
+                hadPresence: self.presences[actorID] != nil,
+                wasOnline: self.onlineClients.contains(actorID),
+                presence: self.presences[actorID]?.mapValues { $0.toJSONObject }
+            ) : nil
 
             let executionResult = try change.execute(root: self.root, presences: &self.presences, source: source)
             let opInfos = executionResult.opInfos
@@ -842,8 +825,15 @@ public class Document: Attachable {
                 self.publish(remoteChangeEvent)
             }
 
-            if let presenceEvent {
-                self.publish(presenceEvent)
+            if let prev, change.presenceChange != nil {
+                // Remove the client from onlineClients when presence is cleared,
+                // mirroring the JS handling of PresenceChangeType.Clear.
+                if case .clear = change.presenceChange {
+                    self.removeOnlineClient(actorID)
+                }
+                if let presenceEvent = self.reconcilePresence(actorID: actorID, prev: prev, source: source) {
+                    self.publish(presenceEvent)
+                }
             }
         }
 
@@ -888,16 +878,27 @@ public class Document: Attachable {
      * `applyStatus` applies the document status into this document.
      */
     func applyStatus(_ status: DocStatus) {
+        guard let actorID = self.actorID else { return }
+
+        let prev = PrevPresenceState(
+            hadPresence: self.presences[actorID] != nil,
+            wasOnline: self.status == .attached,
+            presence: self.presences[actorID]?.mapValues { $0.toJSONObject }
+        )
+
         self.status = status
 
         if status == .detached {
             self.setActor(ActorIDs.initial)
         }
 
-        let event = StatusChangedEvent(source: status == .removed ? .remote : .local,
-                                       value: StatusInfo(status: status, actorID: status == .attached ? self.actorID : nil))
+        if let presenceEvent = self.reconcilePresence(actorID: actorID, prev: prev, source: .local) {
+            self.publish(presenceEvent)
+        }
 
-        self.publish(event)
+        let statusEvent = StatusChangedEvent(source: status == .removed ? .remote : .local,
+                                             value: StatusInfo(status: status, actorID: status == .attached ? self.actorID : nil))
+        self.publish(statusEvent)
     }
 
     public nonisolated var debugDescription: String {
@@ -1099,6 +1100,54 @@ public class Document: Attachable {
      */
     func removePresence(_ clientID: ActorID) {
         self.presences[clientID] = nil
+    }
+
+    // MARK: - Presence reconciliation
+
+    /// Snapshot of a client's presence/online state captured before a mutation.
+    private struct PrevPresenceState {
+        let hadPresence: Bool
+        let wasOnline: Bool
+        let presence: [String: Any]?
+    }
+
+    /// Compares the previous and current presence/online state of a client and returns
+    /// the appropriate event to emit, or `nil` when no event is warranted.
+    ///
+    /// For remote clients "online" means the client is in `onlineClients`.
+    /// For self "online" means the document status is `attached`.
+    ///
+    /// State transition table:
+    /// - `(!hadP || !wasOn) → (hasP && isOn)` : `watched` (remote) or `presenceChanged` (self)
+    /// - `(hadP && wasOn)   → (hasP && isOn)` : `presenceChanged`
+    /// - `(hadP && wasOn)   → (!hasP || !isOn)`: `unwatched` (remote only)
+    /// - otherwise: `nil` (waiting for both presence and online to be established)
+    private func reconcilePresence(actorID: ActorID, prev: PrevPresenceState, source: OpSource) -> DocEvent? {
+        let isSelf = actorID == self.changeID.getActorID()
+        let hasPresence = self.presences[actorID] != nil
+        let isOnline = isSelf ? self.status == .attached : self.onlineClients.contains(actorID)
+
+        if !hasPresence || !isOnline {
+            // Transitioned from ready → not ready: unwatched (remote only).
+            if prev.hadPresence, prev.wasOnline, !isSelf {
+                let presence = prev.presence ?? [:]
+                return UnwatchedEvent(value: (actorID, presence))
+            }
+            return nil
+        }
+
+        let presence = self.presences[actorID]?.mapValues { $0.toJSONObject } ?? [:]
+
+        if !prev.hadPresence || !prev.wasOnline {
+            // Transitioned from not-ready → ready.
+            if isSelf {
+                return PresenceChangedEvent(value: (actorID, presence))
+            }
+            return WatchedEvent(value: (actorID, presence))
+        }
+
+        // Both were ready and still are: presence value changed.
+        return PresenceChangedEvent(value: (actorID, presence))
     }
 
     /**

--- a/Sources/Document/Json/JSONArray.swift
+++ b/Sources/Document/Json/JSONArray.swift
@@ -146,21 +146,9 @@ public class JSONArray: CustomDebugStringConvertible {
                 message: "index out of bounds: \(targetIndex)"
             )
         }
-        let ticket = self.context.issueTimeTicket
-        let operation = MoveOperation(
-            parentCreatedAt: self.target.createdAt,
-            previousCreatedAt: prevElem.createdAt,
-            createdAt: targetElem.createdAt,
-            executedAt: ticket
-        )
-
-        self.context.push(operation: operation)
-
-        try self.target.move(
-            createdAt: targetElem.createdAt,
-            afterCreatedAt: prevElem.createdAt,
-            executedAt: ticket
-        )
+        // Delegate to moveAfterInternal so the element-identity anchor is
+        // converted to position identity, matching JS moveAfterByIndexInternal.
+        try self.moveAfterInternal(previousCreatedAt: prevElem.createdAt, createdAt: targetElem.createdAt)
     }
 
     /**
@@ -333,12 +321,18 @@ public class JSONArray: CustomDebugStringConvertible {
     /**
      * `moveAfterInternal` moves the given `createdAt` element
      * after the specific element.
+     *
+     * Converts the element-identity `previousCreatedAt` to its current POSITION identity
+     * before building the ``MoveOperation``, matching the JS `moveAfterInternal` which calls
+     * `this.target.posCreatedAt(previousCreatedAt)`.
      */
     private func moveAfterInternal(previousCreatedAt: TimeTicket, createdAt: TimeTicket) throws {
         let ticket = self.context.issueTimeTicket
+        // Convert element identity → position identity for the operation wire format.
+        let prevPosCreatedAt = try self.target.posCreatedAt(elemCreatedAt: previousCreatedAt)
         let operation = MoveOperation(
             parentCreatedAt: self.target.createdAt,
-            previousCreatedAt: previousCreatedAt,
+            previousCreatedAt: prevPosCreatedAt,
             createdAt: createdAt,
             executedAt: ticket
         )
@@ -346,7 +340,7 @@ public class JSONArray: CustomDebugStringConvertible {
 
         try self.target.move(
             createdAt: createdAt,
-            afterCreatedAt: previousCreatedAt,
+            afterCreatedAt: prevPosCreatedAt,
             executedAt: ticket
         )
     }

--- a/Sources/Document/Operation/MoveOperation.swift
+++ b/Sources/Document/Operation/MoveOperation.swift
@@ -95,7 +95,9 @@ struct MoveOperation: Operation {
             throw YorkieError(code: .errUnexpected, message: "fail to get previousIndex")
         }
 
-        try array.move(createdAt: self.createdAt, afterCreatedAt: self.previousCreatedAt, executedAt: self.executedAt)
+        if let deadNode = try array.moveAfter(createdAt: self.createdAt, prevCreatedAt: self.previousCreatedAt, executedAt: self.executedAt) {
+            root.registerGCPair(GCPair(parent: array.getRGATreeList(), child: deadNode))
+        }
 
         guard let index = try Int(array.subPath(createdAt: self.createdAt)) else {
             throw YorkieError(code: .errUnexpected, message: "fail to get index")

--- a/Sources/Document/Operation/SetOperation.swift
+++ b/Sources/Document/Operation/SetOperation.swift
@@ -105,6 +105,12 @@ struct SetOperation: Operation {
         if let removed {
             root.registerRemovedElement(removed)
         }
+        // NOTE(#1226): When the new value already has a removedAt (e.g. it was the
+        // LWW-losing side of a concurrent set), register it as removed so GC can
+        // collect it once all peers have seen the winning value.
+        if value.removedAt != nil {
+            root.registerRemovedElement(value)
+        }
 
         guard let path = try? root.createPath(createdAt: parentCreatedAt) else {
             throw YorkieError(code: .errUnexpected, message: "fail to get path")

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.5"
+let yorkieVersion = "0.7.6"

--- a/Tests/Integration/DocumentIntegrationTests.swift
+++ b/Tests/Integration/DocumentIntegrationTests.swift
@@ -715,11 +715,9 @@ final class DocumentIntegrationTests: XCTestCase {
             TestCase(name: "array",
                      input: [Int32(1), Int32(2)],
                      expectedJSON: "{\"array\":[1,2]}"),
-            // TODO(hackerwins): We need to consider the case where the value is
-            // a byte array and a date.
             TestCase(name: "bytes",
                      input: Data([UInt8]([1, 2])),
-                     expectedJSON: "{\"bytes\":[1,2]}")
+                     expectedJSON: "{\"bytes\":\"AQI=\"}")
         ]
 
         for testCase in testCases {

--- a/Tests/Integration/PresenceTests.swift
+++ b/Tests/Integration/PresenceTests.swift
@@ -732,6 +732,46 @@ final class PresenceSubscribeTests: XCTestCase {
         try await c3.deactivate()
     }
 
+    // Ported from yorkie-js-sdk v0.7.6 doc_presence_test.ts:
+    // "Should emit presence-changed event with initial presence value on attach" (#1229).
+    // Verifies that reconcilePresence emits a .presenceChanged event for the local client
+    // after attach, so callers can observe their own initial presence immediately.
+    @MainActor
+    func test_should_emit_presence_changed_event_with_initial_presence_on_attach() async throws {
+        // given
+        let rpcAddr = self.rpcAddress
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+
+        let client1 = Client(rpcAddr)
+        try await client1.activate()
+        let c1ID = client1.id!
+
+        let doc1 = Document(key: docKey)
+        let expectPresence = expectation(description: "initial presence-changed")
+
+        var receivedEvent: PresenceChangedEvent?
+
+        doc1.subscribePresence { event, _ in
+            if let event = event as? PresenceChangedEvent,
+               event.value.clientID == c1ID
+            {
+                receivedEvent = event
+                expectPresence.fulfill()
+            }
+        }
+
+        // when — attach with initial presence
+        try await client1.attach(doc1, ["key": "val1"])
+
+        // then — a .presenceChanged event is emitted for the local client
+        await fulfillment(of: [expectPresence], timeout: 5.0)
+        XCTAssertNotNil(receivedEvent)
+        XCTAssertEqual(receivedEvent?.value.clientID, c1ID)
+        XCTAssertEqual(receivedEvent?.value.presence["key"] as? String, "val1")
+
+        try await client1.deactivate()
+    }
+
     private func decodeDictionary(_ dictionary: Any?) -> CRDTTreePosStruct? {
         guard let dictionary = dictionary as? [String: Any],
               let data = try? JSONSerialization.data(withJSONObject: dictionary, options: [])

--- a/Tests/Unit/Document/CRDT/CRDTRootTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTRootTests.swift
@@ -244,4 +244,49 @@ class CRDTRootTests: XCTestCase {
         // then
         XCTAssertEqual(result?.toSortedJSON(), expectedJson)
     }
+
+    // Ported from yorkie-js-sdk v0.7.6 root_test.ts:
+    // "should register LWW-losing element in GC set on Set conflict" (#1226).
+    // When two concurrent Set operations target the same key and the later-timestamped
+    // value wins LWW, the losing value must be registered as GC garbage immediately.
+    func test_should_register_lww_losing_element_in_gc_set_on_set_conflict() throws {
+        // given — a fresh root
+        let rootObject = CRDTObject(createdAt: TimeTicket.initial)
+        let target = CRDTRoot(rootObject: rootObject)
+
+        let actorA = "000000000000000000000001"
+        let actorB = "000000000000000000000002"
+
+        // actorB > actorA lexicographically, so actorB wins the LWW tie when lamport is equal.
+        let ticketA = TimeTicket(lamport: 1, delimiter: 0, actorID: actorA)
+        let ticketB = TimeTicket(lamport: 1, delimiter: 0, actorID: actorB)
+
+        // when — actorA sets "key" = 1
+        let valueA = Primitive(value: .integer(1), createdAt: ticketA)
+        let setA = SetOperation(key: "key", value: valueA, parentCreatedAt: TimeTicket.initial, executedAt: ticketA)
+        try setA.execute(root: target, source: .remote)
+
+        // then — no garbage yet
+        XCTAssertEqual(target.garbageLength, 0)
+
+        // when — actorB sets "key" = 2 (actorB wins, actorA's value is removed)
+        let valueB = Primitive(value: .integer(2), createdAt: ticketB)
+        let setB = SetOperation(key: "key", value: valueB, parentCreatedAt: TimeTicket.initial, executedAt: ticketB)
+        try setB.execute(root: target, source: .remote)
+
+        // then — actorA's value is registered as garbage
+        XCTAssertEqual(target.garbageLength, 1)
+        XCTAssertEqual(rootObject.toJSON(), "{\"key\":2}")
+
+        // when — actorA sets "key" = 3 with a newer delimiter (still loses to actorB)
+        let ticketA2 = TimeTicket(lamport: 1, delimiter: 1, actorID: actorA)
+        let valueA2 = Primitive(value: .integer(3), createdAt: ticketA2)
+        let setA2 = SetOperation(key: "key", value: valueA2, parentCreatedAt: TimeTicket.initial, executedAt: ticketA2)
+        try setA2.execute(root: target, source: .remote)
+
+        // then — the LWW-losing valueA2 is also registered as garbage
+        // Before the fix (#1226), this was 1 because the losing value was not registered.
+        XCTAssertEqual(target.garbageLength, 2)
+        XCTAssertEqual(rootObject.toJSON(), "{\"key\":2}")
+    }
 }

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -522,6 +522,36 @@ final class CRDTTreeSplitTests: XCTestCase {
         XCTAssertEqual(tree.toXML(), /* html */ "<root><p>abcd</p></root>")
         XCTAssertEqual(tree.size, 6)
     }
+
+    // Ported from yorkie-js-sdk v0.7.6 tree_test.ts:
+    // "Can split element nodes with attributes" (#1224).
+    // Verifies that cloneElement copies attributes to the right sibling created
+    // during a split, so a concurrent style op whose range was computed before
+    // the split also covers the newly-created right sibling.
+    func test_can_split_element_nodes_with_attributes() throws {
+        //       0   1 2 3 4 5 6 7 8 9 10    11
+        // <root> <p> h e l l o w o r l  d  </p>  </root>
+
+        // given — a <p> with bold="true" and text "helloworld"
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        let pNode = CRDTTreeNode(id: posT(), type: "p")
+        pNode.setAttrs(["bold": "true"], timeT())
+        try tree.editT((0, 0), [pNode], 0, timeT(), timeT)
+        try tree.editT(
+            (1, 1),
+            [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "helloworld")],
+            0,
+            timeT(),
+            timeT
+        )
+        XCTAssertEqual(tree.toXML(), "<root><p bold=true>helloworld</p></root>")
+
+        // when — split at position 6 (after "hello"), splitLevel 1
+        try tree.editT((6, 6), nil, 1, timeT(), timeT)
+
+        // then — both siblings carry bold="true"
+        XCTAssertEqual(tree.toXML(), "<root><p bold=true>hello</p><p bold=true>world</p></root>")
+    }
 }
 
 final class CRDTTreeMergeTests: XCTestCase {

--- a/Tests/Unit/Document/CRDT/PrimitiveTests.swift
+++ b/Tests/Unit/Document/CRDT/PrimitiveTests.swift
@@ -108,4 +108,32 @@ class PrimitiveTests: XCTestCase {
             XCTFail("Type error.")
         }
     }
+
+    // Ported from yorkie-js-sdk v0.7.6 primitive_test.ts: "toJSON for Bytes and Date".
+    // Verifies that Bytes encodes as base64 and Date encodes as an ISO-8601 UTC string,
+    // matching JS Primitive.toJSON() behaviour introduced in #1225.
+    func test_toJSON_for_bytes_and_date() {
+        // given — bytes [0x41, 0x42] == "AB" in ASCII, base64 == "QUI="
+        let bytesData = Data([0x41, 0x42])
+        let bytesValue = Primitive(value: .bytes(bytesData), createdAt: TimeTicket.initial)
+
+        // then — bytes encodes as a JSON string containing the base64 representation
+        XCTAssertEqual(bytesValue.toJSON(), "\"QUI=\"")
+
+        // given — Date corresponding to JS `new Date('1995-12-17T03:24:00.000Z')`
+        var components = DateComponents()
+        components.year = 1995
+        components.month = 12
+        components.day = 17
+        components.hour = 3
+        components.minute = 24
+        components.second = 0
+        components.nanosecond = 0
+        components.timeZone = TimeZone(identifier: "UTC")
+        let date = Calendar(identifier: .gregorian).date(from: components)!
+        let dateValue = Primitive(value: .date(date), createdAt: TimeTicket.initial)
+
+        // then — date encodes as an ISO-8601 UTC string with fractional seconds
+        XCTAssertEqual(dateValue.toJSON(), "\"1995-12-17T03:24:00.000Z\"")
+    }
 }

--- a/Tests/Unit/Document/CRDT/RGATreeListTests.swift
+++ b/Tests/Unit/Document/CRDT/RGATreeListTests.swift
@@ -354,4 +354,139 @@ class RGATreeListTests: XCTestCase {
         let result2 = try target.getNode(index: 2).value.toJSON()
         XCTAssertEqual(result2, "\"C123\"")
     }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): move × move LWW test.
+    // When two concurrent move operations target the same element, the later
+    // `executedAt` wins. The earlier one must be a no-op (returns nil).
+    func test_move_lww_later_op_wins() throws {
+        // given — list [A, B, C, D]
+        let target = RGATreeList()
+        let e1 = Primitive(value: .string("A"), createdAt: TimeTicket(lamport: 1, delimiter: 0, actorID: actorId))
+        let e2 = Primitive(value: .string("B"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
+        let e3 = Primitive(value: .string("C"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
+        let e4 = Primitive(value: .string("D"), createdAt: TimeTicket(lamport: 4, delimiter: 0, actorID: actorId))
+        try target.insert(e1)
+        try target.insert(e2)
+        try target.insert(e3)
+        try target.insert(e4)
+
+        XCTAssertEqual(target.length, 4)
+
+        // when — concurrent moves of element A:
+        // op1 (lamport=5): move A after C  → would give [B, C, A, D]
+        // op2 (lamport=6): move A after D  → would give [B, C, D, A]
+        // Apply op2 first (out of order), then op1 which should lose.
+        let move2 = TimeTicket(lamport: 6, delimiter: 0, actorID: actorId)
+        let deadNode = try target.moveAfter(createdAt: e1.createdAt, prevCreatedAt: e4.createdAt, executedAt: move2)
+
+        // then — op2 wins: A moved after D → [B, C, D, A]
+        XCTAssertNotNil(deadNode)
+        XCTAssertEqual(target.length, 4)
+        XCTAssertEqual(try target.getNode(index: 3).value.toJSON(), "\"A\"")
+
+        // when — apply op1 (lamport=5 < lamport=6 of op2): must lose
+        let move1 = TimeTicket(lamport: 5, delimiter: 0, actorID: actorId)
+        let losingDeadNode = try target.moveAfter(createdAt: e1.createdAt, prevCreatedAt: e3.createdAt, executedAt: move1)
+
+        // then — op1 loses LWW but still creates a bare dead position node for GC (JS-faithful).
+        // List stays [B, C, D, A].
+        XCTAssertNotNil(losingDeadNode)
+        XCTAssertNotNil(losingDeadNode?.getPositionRemovedAt())
+        XCTAssertNil(losingDeadNode?.getElementEntry())
+        XCTAssertEqual(try target.getNode(index: 3).value.toJSON(), "\"A\"")
+    }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): move on different elements commutes.
+    // Two concurrent moves of different elements must each land at their intended
+    // destinations regardless of application order.
+    func test_concurrent_moves_on_different_elements_commute() throws {
+        // given — list [A, B, C, D]
+        let target = RGATreeList()
+        let e1 = Primitive(value: .string("A"), createdAt: TimeTicket(lamport: 1, delimiter: 0, actorID: actorId))
+        let e2 = Primitive(value: .string("B"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
+        let e3 = Primitive(value: .string("C"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
+        let e4 = Primitive(value: .string("D"), createdAt: TimeTicket(lamport: 4, delimiter: 0, actorID: actorId))
+        try target.insert(e1)
+        try target.insert(e2)
+        try target.insert(e3)
+        try target.insert(e4)
+
+        // when — op1 (lamport=5): move A after B  → [B, A, C, D]
+        //        op2 (lamport=6): move C after D  → [A, B, D, C]
+        // Apply both concurrently (op1 first, then op2).
+        let move1 = TimeTicket(lamport: 5, delimiter: 0, actorID: actorId)
+        try target.moveAfter(createdAt: e1.createdAt, prevCreatedAt: e2.createdAt, executedAt: move1)
+
+        let move2 = TimeTicket(lamport: 6, delimiter: 0, actorID: actorId)
+        try target.moveAfter(createdAt: e3.createdAt, prevCreatedAt: e4.createdAt, executedAt: move2)
+
+        // then — both moves applied: [B, A, D, C]
+        XCTAssertEqual(target.length, 4)
+        XCTAssertEqual(try target.getNode(index: 0).value.toJSON(), "\"B\"")
+        XCTAssertEqual(try target.getNode(index: 1).value.toJSON(), "\"A\"")
+        XCTAssertEqual(try target.getNode(index: 2).value.toJSON(), "\"D\"")
+        XCTAssertEqual(try target.getNode(index: 3).value.toJSON(), "\"C\"")
+    }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): moveAfter returns a dead position node
+    // for GC registration regardless of whether it wins or loses the LWW race.
+    func test_moveAfter_returns_dead_node_on_both_lww_win_and_loss() throws {
+        // given — list [A, B, C]
+        let target = RGATreeList()
+        let e1 = Primitive(value: .string("A"), createdAt: TimeTicket(lamport: 1, delimiter: 0, actorID: actorId))
+        let e2 = Primitive(value: .string("B"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
+        let e3 = Primitive(value: .string("C"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
+        try target.insert(e1)
+        try target.insert(e2)
+        try target.insert(e3)
+
+        // when — move A after C (executedAt=5): should win and return the dead position node
+        let win = TimeTicket(lamport: 5, delimiter: 0, actorID: actorId)
+        let deadNode = try target.moveAfter(createdAt: e1.createdAt, prevCreatedAt: e3.createdAt, executedAt: win)
+
+        // then — returns non-nil dead position node; position removed at is set
+        XCTAssertNotNil(deadNode)
+        XCTAssertNotNil(deadNode?.getPositionRemovedAt())
+        XCTAssertNil(deadNode?.getElementEntry())
+        XCTAssertEqual(target.length, 3)
+
+        // when — try to move A again with older executedAt=4 (should lose)
+        let lose = TimeTicket(lamport: 4, delimiter: 0, actorID: actorId)
+        let losingNode = try target.moveAfter(createdAt: e1.createdAt, prevCreatedAt: e2.createdAt, executedAt: lose)
+
+        // then — LWW loser still creates a bare dead position node for GC (JS-faithful).
+        XCTAssertNotNil(losingNode)
+        XCTAssertNotNil(losingNode?.getPositionRemovedAt())
+        XCTAssertNil(losingNode?.getElementEntry())
+    }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): snapshot round-trip — moved and dead
+    // position nodes survive a Document-level deep-copy (simulates snapshot restore).
+    // A snapshot round-trip re-constructs the CRDTRoot from the serialised form; the
+    // moved element must appear at its new position and the dead position node must
+    // not leak into the live count.
+    func test_move_snapshot_roundtrip() async throws {
+        // given — document with an array, then a move
+        let doc = Document(key: "test-move-snapshot")
+        try await doc.update { root, _ in
+            root.list = [Int64(0), Int64(1), Int64(2)]
+        }
+
+        try await doc.update { root, _ in
+            guard let arr = root.list as? JSONArray else { return }
+            guard let prev = arr.getElement(byIndex: 0) as? CRDTElement,
+                  let item = arr.getElement(byIndex: 2) as? CRDTElement else { return }
+            try arr.moveAfter(previousID: prev.id, id: item.id)
+        }
+
+        // when — round-trip via changePack proto serialisation
+        let pack = await doc.createChangePack()
+        let pbPack = Converter.toChangePack(pack: pack)
+        let decodedPack = try Converter.fromChangePack(pbPack)
+        XCTAssertNotNil(decodedPack)
+
+        // then — the live JSON after the move is correct
+        let json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{\"list\":[0,2,1]}")
+    }
 }

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.5'
+    image: 'yorkieteam/yorkie:0.7.6'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.5'
+    image: 'yorkieteam/yorkie:0.7.6'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk 0.7.6. Six iOS-relevant changes plus a proto change:

- **Apply array-move-convergence with LWW position register** (#1227) — `RGANode` gains `position_created_at/moved_at/removed_at` (proto + regen); `RGATreeList` tracks an LWW position register so concurrent array moves converge by LWW on the position. `moveAfter` resolves anchors by position identity and produces a dead position node for GC on both win and loss; `MoveOperation` carries position identity (wire-compatible with the Go server/JS). Dead position nodes serialize with position timestamps and no element.
- **Copy attributes to split node in cloneElement** (#1224) — split clones carry attributes; style/removeStyle propagate to unknown split siblings.
- **Implement toJSON for Bytes and Date primitive types** (#1225) — bytes → base64, date → ISO8601.
- **Register LWW-losing element in GC set on Set conflict** (#1226).
- **Unify presence event emission with reconcilePresence** (#1229) — single decision table for Watched/Unwatched/PresenceChanged across update/applyChanges/applyStatus.

Skipped upstream: **#1228** (default-transport / sync-loop-vs-detach race) — iOS `Client` is `@MainActor`-isolated, so the race does not arise; #1231 (release).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Pre-PR gate green: critic-reviewer approved (the array-move LWW port #1227 was reworked to faithfully mirror the JS algorithm and re-reviewed — dead-node wire format, position-identity move contract, and GC all match the Go server/JS), SwiftFormat 0.55.6 and SwiftLint 0.58.2 `--strict` (0 violations), `swift build` + unit tests pass. Integration suites (array-move convergence, presence) require a live yorkie server v0.7.6 — exercised by CI.
- `#1228` was assessed N/A for iOS's actor-isolated `Client` (all mutations serialize on `@MainActor`).

**Does this PR introduce a user-facing change?**:
```release-note
Converge concurrent array moves via an LWW position register; copy attributes to split tree nodes; emit Bytes/Date as base64/ISO8601 in toJSON; unify presence event emission.
```

**Additional documentation**:
```docs
- CHANGELOG.md updated for v0.7.6
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.7.6

* **New Features**
  * Improved JSON serialization: bytes now encode as base64 strings; dates format as ISO-8601 with fractional seconds
  * Enhanced array move operations with Last-Write-Wins conflict resolution

* **Bug Fixes**
  * Fixed presence event emission when attaching documents with initial presence
  * Improved element attribute preservation during tree element splits

* **Chores**
  * Version updates and infrastructure improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->