### PR TITLE
Apply updates from yorkie-js-sdk 0.7.8

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.7
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/62431c4cc20c9d5e9b949b7a45fb8d1984a722b7/Formula/y/yorkie.rb"
+      # yorkie server v0.7.8
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/5cead0822356395e42d9d9504fc638078188ab04/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.7
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/62431c4cc20c9d5e9b949b7a45fb8d1984a722b7/Formula/y/yorkie.rb"
+      # yorkie server v0.7.8
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/5cead0822356395e42d9d9504fc638078188ab04/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.8] - 2026-06-19
+
+- Add SyncMode.Polling for Document in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
+- Filter pre-tombstoned descendants in tree reverseOp in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
+- Clear history after attach and make undo/redo no-op on empty stack in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
+- Fix editByPath split-then-merge and cross-boundary merge undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
+
 ## [v0.7.7] - 2026-06-19
 
 - Support splitLevel>=2 undo/redo with multi-client convergence in https://github.com/yorkie-team/yorkie-ios-sdk/pull/259

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 
 ## [v0.7.8] - 2026-06-19
 
-- Add SyncMode.Polling for Document in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
-- Filter pre-tombstoned descendants in tree reverseOp in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
-- Clear history after attach and make undo/redo no-op on empty stack in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
-- Fix editByPath split-then-merge and cross-boundary merge undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/NNN
+- Add SyncMode.Polling for Document in https://github.com/yorkie-team/yorkie-ios-sdk/pull/260
+- Filter pre-tombstoned descendants in tree reverseOp in https://github.com/yorkie-team/yorkie-ios-sdk/pull/260
+- Clear history after attach and make undo/redo no-op on empty stack in https://github.com/yorkie-team/yorkie-ios-sdk/pull/260
+- Fix editByPath split-then-merge and cross-boundary merge undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/260
 
 ## [v0.7.7] - 2026-06-19
 

--- a/Sources/Core/Attachment.swift
+++ b/Sources/Core/Attachment.swift
@@ -27,6 +27,8 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
     var syncMode: SyncMode?
     var changeEventReceived: Bool?
     var lastHeartbeatTime: TimeInterval
+    var pollInterval: TimeInterval
+    var pollIntervalPinned: Bool
     var remoteWatchStream: YorkieServerStream?
     var watchLoopReconnectTimer: Timer?
     var cancelled: Bool
@@ -38,13 +40,17 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
         syncMode: SyncMode? = nil,
         changeEventReceived: Bool? = nil,
         watchLoopReconnectTimer: Timer? = nil,
-        cancelled: Bool = false
+        cancelled: Bool = false,
+        pollInterval: TimeInterval = 0,
+        pollIntervalPinned: Bool = false
     ) {
         self.resource = resource
         self.resourceID = resourceID
         self.syncMode = syncMode
         self.changeEventReceived = changeEventReceived
         self.lastHeartbeatTime = Date().timeIntervalSince1970
+        self.pollInterval = pollInterval
+        self.pollIntervalPinned = pollIntervalPinned
         self.watchLoopReconnectTimer = watchLoopReconnectTimer
         self.isDisconnected = false
         self.cancelled = cancelled
@@ -68,9 +74,19 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
             return await self.resource.hasLocalChanges()
         }
 
+        if syncMode == .polling {
+            // Time-based: pull at every poll interval, regardless of local changes.
+            return Date().timeIntervalSince1970 - self.lastHeartbeatTime >= self.pollInterval
+        }
+
         let hasLocalChanges = await self.resource.hasLocalChanges()
 
         return syncMode != .manual && (hasLocalChanges || (self.changeEventReceived ?? false))
+    }
+
+    /// Updates the last heartbeat timestamp to the current time.
+    func updateHeartbeatTime() {
+        self.lastHeartbeatTime = Date().timeIntervalSince1970
     }
 
     func connectStream(_ stream: YorkieServerStream?) {

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -980,12 +980,14 @@ public class Client {
             return doc
         }
 
+        // Set the mode first so an in-flight stream-disconnect callback observes
+        // the new (stream-less) mode and does not reschedule a reconnect.
+        docAttachment.syncMode = syncMode
+
         // Tear down stream when leaving a stream-using mode.
         if syncMode == .manual || syncMode == .polling {
             try self.stopWatchLoop(docKey, with: docAttachment)
         }
-
-        docAttachment.syncMode = syncMode
 
         if syncMode == .realtime {
             // NOTE(hackerwins): In non-pushpull mode, the client does not receive change events
@@ -1389,8 +1391,12 @@ public class Client {
     private func onStreamDisconnect<R: Attachable>(_ key: String, with attachment: Attachment<R>) throws {
         let cancelled = attachment.cancelled
         self.disconnectWatchStream(key, with: attachment)
-        // check if watch loop is stopped
-        guard self.attachmentMap[key] != nil, attachment.syncMode != .manual else {
+        // check if watch loop is stopped. `.manual` and `.polling` are stream-less
+        // modes — never reschedule a watch-stream reconnect for them.
+        guard self.attachmentMap[key] != nil,
+              attachment.syncMode != .manual,
+              attachment.syncMode != .polling
+        else {
             return
         }
         // NOTE: Only schedule reconnect if the stream was not explicitly cancelled

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -405,6 +405,10 @@ public class Client {
                 }
             }
 
+            // Clear undo/redo stacks so that initialRoot setup operations
+            // are not reachable via undo.
+            doc.clearHistory()
+
             return doc
         } catch {
             Logger.error("Failed to request attach document(\(self.key)).", error: error)

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -59,6 +59,11 @@ public enum SyncMode {
      * but the watch stream is kept active.
      */
     case realtimeSyncOff
+
+    /// `polling` mode runs the sync loop without opening a watch stream.
+    /// `PushPullChanges` runs at the polling interval; remote changes arrive on the next tick
+    /// (latency = interval). Not suitable for collaborative editing — use `realtime` for that.
+    case polling
 }
 
 /**
@@ -181,6 +186,7 @@ public class Client {
     private let retrySyncLoopDelay: Int
     private let maximumAttachmentTimeout: Int
     private let channelHeartbeatInterval: TimeInterval = 5.0 // 5 seconds
+    private let defaultPollingInterval: TimeInterval = 3.0 // 3 seconds
 
     private var yorkieService: YorkieService
     private var authTokenInjector: AuthTokenInjector?
@@ -327,7 +333,8 @@ public class Client {
                        _ initialPresence: PresenceData = [:],
                        _ syncMode: SyncMode = .realtime,
                        _ schema: String = "",
-                       initialRoot: [String: JSONValuable?]? = nil) async throws -> Document
+                       initialRoot: [String: JSONValuable?]? = nil,
+                       documentPollInterval: TimeInterval? = nil) async throws -> Document
     {
         // 01. Check if the client is ready to attach documents.
         guard self.isActive else {
@@ -341,6 +348,17 @@ public class Client {
         guard doc.status == .detached else {
             throw YorkieError(code: .errNotDetached, message: "\(self.key) is not detached.")
         }
+
+        if let interval = documentPollInterval, interval <= 0 {
+            throw YorkieError(code: .errInvalidArgument, message: "documentPollInterval must be greater than 0")
+        }
+        let pollIntervalPinned = documentPollInterval != nil
+        let pollInterval: TimeInterval = {
+            if let interval = documentPollInterval {
+                return interval
+            }
+            return syncMode == .polling ? self.defaultPollingInterval : 0
+        }()
 
         doc.setActor(clientID)
         try doc.update { _, presence in
@@ -385,9 +403,13 @@ public class Client {
             self.attachmentMap[doc.getKey()] = Attachment<Document>(resource: doc,
                                                                     resourceID: message.documentID,
                                                                     syncMode: syncMode,
-                                                                    changeEventReceived: false)
+                                                                    changeEventReceived: false,
+                                                                    pollInterval: pollInterval,
+                                                                    pollIntervalPinned: pollIntervalPinned)
 
-            if syncMode != .manual {
+            // Polling mode opens no watch stream; the timer-driven sync loop drives pushpull
+            // via needRealtimeSync. Skip waitForInitialization too — no stream to wait for.
+            if syncMode != .manual && syncMode != .polling {
                 try self.runWatchLoop(docKey)
                 try await self.waitForInitialization(semaphore, docKey)
             }
@@ -954,13 +976,12 @@ public class Client {
             return doc
         }
 
-        docAttachment.syncMode = syncMode
-
-        // realtime to manual
-        if syncMode == .manual {
+        // Tear down stream when leaving a stream-using mode.
+        if syncMode == .manual || syncMode == .polling {
             try self.stopWatchLoop(docKey, with: docAttachment)
-            return doc
         }
+
+        docAttachment.syncMode = syncMode
 
         if syncMode == .realtime {
             // NOTE(hackerwins): In non-pushpull mode, the client does not receive change events
@@ -970,8 +991,16 @@ public class Client {
             docAttachment.changeEventReceived = true
         }
 
-        // manual to realtime
-        if prevSyncMode == .manual {
+        // Recompute interval default if the user did not pin it.
+        if !docAttachment.pollIntervalPinned {
+            docAttachment.pollInterval = (syncMode == .polling) ? self.defaultPollingInterval : 0
+        }
+
+        // Start watch stream when entering a stream-using mode from a stream-less one.
+        if (prevSyncMode == .manual || prevSyncMode == .polling)
+            && syncMode != .manual && syncMode != .polling
+        {
+            // runWatchLoop already resets cancelled (line 1244), no extra reset needed.
             try self.runWatchLoop(docKey)
         }
 
@@ -1445,6 +1474,7 @@ public class Client {
             }
 
             try doc.applyChangePack(responsePack)
+            attachment.updateHeartbeatTime()
 
             if doc.status == .removed {
                 self.attachmentMap.removeValue(forKey: docKey)

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -327,6 +327,10 @@ public class Client {
     /**
      *   `attach` attaches the given document to this client. It tells the server that
      *   the client will synchronize the given document.
+     *
+     *   - Parameter documentPollInterval: The poll interval in **seconds** (iOS `TimeInterval`),
+     *     used only when `syncMode` is `.polling`. Unlike the JS SDK's millisecond `documentPollInterval`
+     *     (default 3000), this is seconds (default `3.0`). Must be greater than 0.
      */
     @discardableResult
     public func attach(_ doc: Document,
@@ -1000,7 +1004,7 @@ public class Client {
         if (prevSyncMode == .manual || prevSyncMode == .polling)
             && syncMode != .manual && syncMode != .polling
         {
-            // runWatchLoop already resets cancelled (line 1244), no extra reset needed.
+            // runWatchLoop already resets the attachment's `cancelled` flag, no extra reset needed.
             try self.runWatchLoop(docKey)
         }
 

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1240,15 +1240,22 @@ class CRDTTree: CRDTElement {
         }
     }
 
-    /**
-     * `narrowedCollectRange` narrows the edit traversal range when `fromLeft` and
-     * `toLeft` straddle a concurrent element split: it follows `fromLeft`'s
-     * `insNextID` chain to find a split sibling in `toParent`. Returns the
-     * (parent, left) pair to traverse; the original `fromParent`/`fromLeft` are
-     * preserved by the caller for the merge, split, and insert steps.
-     * VV-independent for clone/root consistency.
-     */
-    private func narrowedCollectRange(fromParent: CRDTTreeNode, fromLeft: CRDTTreeNode, toParent: CRDTTreeNode) -> (CRDTTreeNode, CRDTTreeNode) {
+    /// `narrowedCollectRange` narrows the edit traversal range when `fromLeft` and
+    /// `toLeft` straddle a concurrent element split: it follows `fromLeft`'s
+    /// `insNextID` chain to find a split sibling in `toParent`. Returns the
+    /// (parent, left) pair to traverse; the original `fromParent`/`fromLeft` are
+    /// preserved by the caller for the merge, split, and insert steps.
+    /// VV-independent for clone/root consistency.
+    ///
+    /// - Parameters:
+    ///   - fromParent: The parent node at the start of the edit range.
+    ///   - fromLeft: The left sibling node at the start of the edit range.
+    ///   - toParent: The parent node at the end of the edit range.
+    ///   - toLeft: The left sibling node at the end of the edit range. When
+    ///     `toLeft === toParent` (offset 0, leftmost child position), narrowing
+    ///     is skipped because the narrowed `collectFromLeft` would be a child at
+    ///     offset >= 1, producing a backwards range that suppresses the intended merge.
+    private func narrowedCollectRange(fromParent: CRDTTreeNode, fromLeft: CRDTTreeNode, toParent: CRDTTreeNode, toLeft: CRDTTreeNode) -> (CRDTTreeNode, CRDTTreeNode) {
         guard fromLeft !== fromParent, fromParent !== toParent else {
             return (fromParent, fromLeft)
         }
@@ -1258,7 +1265,14 @@ class CRDTTree: CRDTElement {
                 break
             }
             if let nextParent = next.parent, nextParent === toParent {
-                return (toParent, next)
+                // Skip narrowing when toLeft === toParent (leftmost child
+                // position, offset 0). The narrowed collectFromLeft would be
+                // a child at offset >= 1, producing a backwards range that
+                // suppresses the intended merge.
+                if toLeft !== toParent {
+                    return (toParent, next)
+                }
+                break
             }
             current = next
         }
@@ -1277,7 +1291,7 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
@@ -1296,7 +1310,7 @@ class CRDTTree: CRDTElement {
         // Phase 3: Range Narrowing — narrow the traversal range when fromLeft and
         // toLeft straddle a concurrent element split. The original
         // fromParent/fromLeft are preserved for merge, split, and insert steps.
-        let (collectFromParent, collectFromLeft) = self.narrowedCollectRange(fromParent: fromParent, fromLeft: fromLeft, toParent: toParent)
+        let (collectFromParent, collectFromLeft) = self.narrowedCollectRange(fromParent: fromParent, fromLeft: fromLeft, toParent: toParent, toLeft: toLeft)
 
         let fromIdx = try self.toIndex(fromParent, fromLeft)
         let fromPath = try self.toPath(fromParent, fromLeft)
@@ -1353,6 +1367,11 @@ class CRDTTree: CRDTElement {
         // NOTE(hackerwins): If concurrent deletion happens, we need to seperate the
         // range(from, to) into multiple ranges.
         var changes = try self.makeDeletionChanges(tokensToBeRemoved, editedAt)
+
+        // 01-2. Count merged nodes before children are moved (step 03).
+        // The undo system uses this count to generate a split reverse op
+        // instead of re-inserting empty shells.
+        let mergeLevel = toBeMergedNodes.count
 
         // 02. Delete: delete the nodes that are marked as removed.
         var pairs = [GCPair]()
@@ -1444,7 +1463,7 @@ class CRDTTree: CRDTElement {
                 }
             }
         }
-        return (changes, pairs, diff, nodesToBeRemoved, fromIdx)
+        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel)
     }
 
     /**
@@ -1539,20 +1558,19 @@ class CRDTTree: CRDTElement {
         return pairs
     }
 
-    /**
-     * `editT` edits the given range with the given value.
-     * This method uses indexes instead of a pair of TreePos for testing.
-     */
+    /// `editT` edits the given range with the given value.
+    /// Uses integer indexes instead of a ``CRDTTreePos`` pair. For testing only.
+    @discardableResult
     func editT(
         _ range: (Int, Int),
         _ contents: [CRDTTreeNode]?,
         _ splitLevel: Int32,
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket
-    ) throws {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int) {
         let fromPos = try self.findPos(range.0)
         let toPos = try self.findPos(range.1)
-        try self.edit(
+        return try self.edit(
             (fromPos, toPos),
             contents,
             splitLevel,

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1291,7 +1291,7 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
@@ -1319,6 +1319,7 @@ class CRDTTree: CRDTElement {
         var tokensToBeRemoved = [TreeToken<CRDTTreeNode>]()
         var toBeMovedToFromParents = [CRDTTreeNode]()
         var toBeMergedNodes = [CRDTTreeNode]()
+        var preTombstoned = Set<String>()
         try self.traverseInPosRange(collectFromParent, collectFromLeft, toParent, toLeft, includeRemoved: true) { treeToken, ended in
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
@@ -1352,6 +1353,11 @@ class CRDTTree: CRDTElement {
                 // NOTE(hackerwins): If the node overlaps as an end token with the
                 // range then we need to keep the node.
                 if tokenType == .text || tokenType == .start {
+                    // Track nodes already tombstoned before this edit so the
+                    // reverse operation does not accidentally resurrect them.
+                    if node.isRemoved {
+                        preTombstoned.insert(node.toIDString)
+                    }
                     nodesToBeRemoved.append(node)
 
                     // Cascade delete to split siblings created by concurrent
@@ -1463,7 +1469,7 @@ class CRDTTree: CRDTElement {
                 }
             }
         }
-        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel)
+        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel, preTombstoned)
     }
 
     /**
@@ -1567,7 +1573,7 @@ class CRDTTree: CRDTElement {
         _ splitLevel: Int32,
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>) {
         let fromPos = try self.findPos(range.0)
         let toPos = try self.findPos(range.1)
         return try self.edit(

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -304,7 +304,7 @@ public class Document: Attachable {
         }
 
         guard let ops = isUndo ? self.internalHistory.popUndo() : self.internalHistory.popRedo() else {
-            throw YorkieError(code: .errRefused, message: "There is no operation to be \(isUndo ? "undone" : "redone")")
+            return
         }
 
         guard let actorID = self.actorID else {

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -787,7 +787,7 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, pairs, diff, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
+        let (_, pairs, diff, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
             context.issueTimeTicket
         }, nil)
         self.context?.acc(diff)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -787,7 +787,7 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, pairs, diff, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
+        let (_, pairs, diff, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
             context.issueTimeTicket
         }, nil)
         self.context?.acc(diff)

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -16,21 +16,56 @@
 
 import Foundation
 
-/// `clearRemovedAt` clears the `removedAt` tombstone markers from a node and all its descendants,
-/// so they can be re-inserted as live nodes on undo.
+/// `cloneAndDropPreTombstoned` deep-copies `node` and drops descendants whose ID is in
+/// `preTombstoned` — i.e., descendants that were already tombstoned before this edit ran.
+/// Those descendants represent the user's earlier delete intent and must not be resurrected
+/// by undoing this edit.
 ///
+/// For nodes kept in the clone, `removedAt` is cleared so the redo re-inserts them as live.
 /// iOS tracks a single visible `size` per node (unlike the JS SDK's separate `visibleSize` /
-/// `totalSize`), so removal only decreases an element's `size`. The traversal is postorder, so by
-/// the time an element node is visited its descendants are already live again — recomputing the
-/// element's `size` from its (now all-live) `children` restores the full visible size. Text nodes
-/// keep their `size`, which removal never decreased.
-private func clearRemovedAt(_ node: CRDTTreeNode) {
-    traverseAll(node: node) { node, _ in
-        node.removedAt = nil
-        if node.isText == false {
-            node.size = node.children.reduce(0) { $0 + $1.paddedSize }
+/// `totalSize`). The traversal clears tombstones and recomputes `size` bottom-up: element
+/// nodes derive size from their children's `paddedSize`; text nodes keep their value-length
+/// size unchanged.
+///
+/// - Parameters:
+///   - node: The node to deep-copy and filter.
+///   - preTombstoned: IDs of nodes already tombstoned before this edit.
+/// - Returns: A deep copy of `node` with pre-tombstoned descendants removed and
+///   `removedAt` cleared on surviving nodes.
+private func cloneAndDropPreTombstoned(_ node: CRDTTreeNode, _ preTombstoned: Set<String>) -> CRDTTreeNode? {
+    guard let clone = node.deepcopy() else { return nil }
+    filterChildren(clone, preTombstoned)
+    // Post-order: clear tombstone on every survivor and recompute size from its
+    // (already-resized) children. The deepcopy carried the original node's size;
+    // after filterChildren dropped descendants that size is stale and must be
+    // recomputed bottom-up.
+    traverseAll(node: clone) { n, _ in
+        n.removedAt = nil
+        if n.isText == false {
+            n.size = n.innerChildren.reduce(0) { $0 + $1.paddedSize }
         }
     }
+    return clone
+}
+
+/// `filterChildren` walks `node.innerChildren` and drops descendants whose IDs are in
+/// `preTombstoned`. Used by ``cloneAndDropPreTombstoned(_:_:)`` to keep only nodes that
+/// this edit actually transitioned from visible to tombstoned.
+///
+/// - Parameters:
+///   - node: The node (within a deep copy) whose children to filter.
+///   - preTombstoned: IDs of nodes already tombstoned before this edit.
+private func filterChildren(_ node: CRDTTreeNode, _ preTombstoned: Set<String>) {
+    var kept = [CRDTTreeNode]()
+    for child in node.innerChildren {
+        if preTombstoned.contains(child.toIDString) {
+            // Already tombstoned before this edit — drop from reverseOp.
+            continue
+        }
+        filterChildren(child, preTombstoned)
+        kept.append(child)
+    }
+    node.innerChildren = kept
 }
 
 /// `TreeEditOperation` is an operation representing Tree editing.
@@ -121,7 +156,7 @@ final class TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
+        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -148,7 +183,7 @@ final class TreeEditOperation: Operation {
             && removedNodes.isEmpty
         let reverseOp: Operation?
         if self.splitLevel == 0 {
-            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx, mergeLevel: mergeLevel)
+            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx, preTombstoned: preTombstoned, mergeLevel: mergeLevel)
         } else if isPureSplit {
             reverseOp = try self.toSplitReverseOperation(tree, preEditFromIdx)
         } else {
@@ -197,14 +232,19 @@ final class TreeEditOperation: Operation {
     /// re-insertion — so a split op with `splitLevel = mergeLevel` is returned instead of
     /// the normal content-reinsertion reverse.
     ///
+    /// Nodes whose IDs appear in `preTombstoned` were already tombstoned before this edit ran.
+    /// They represent the user's earlier delete intent and must not be resurrected when undoing
+    /// this edit. They are excluded from `topLevelRemoved` and from the cloned content.
+    ///
     /// - Parameters:
     ///   - tree: The tree after this edit has been applied.
     ///   - removedNodes: The nodes removed by this edit, to be re-inserted on undo.
     ///   - preEditFromIdx: The start index captured before the edit deletions.
+    ///   - preTombstoned: IDs of nodes already tombstoned before this edit ran.
     ///   - mergeLevel: The number of element boundaries merged by this edit. When greater than
     ///     zero the reverse op is a split rather than a content reinsertion.
     /// - Returns: The reverse ``TreeEditOperation``, or `nil` when the edit was a no-op.
-    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int, mergeLevel: Int = 0) throws -> Operation? {
+    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int, preTombstoned: Set<String> = [], mergeLevel: Int = 0) throws -> Operation? {
         // Special case: this op is a boundary-deletion that was generated to reverse a split.
         // Its redo (i.e. the reverse of this reverse) should re-split at the merged position,
         // not re-insert the tombstoned boundary nodes as raw content.
@@ -253,23 +293,28 @@ final class TreeEditOperation: Operation {
             return nil
         }
 
-        // Keep only top-level removed nodes (whose parent is not also removed).
+        // Filter to top-level removed nodes (whose parent is NOT also removed).
+        // Also exclude nodes that were already tombstoned before this edit ran:
+        // those represent the user's earlier delete intent and must not be
+        // resurrected by a parent-level undo, even at the root of topLevelRemoved.
         let topLevelRemoved = removedNodes.filter { node in
+            if preTombstoned.contains(node.toIDString) {
+                return false
+            }
             guard let parent = node.parent else {
                 return true
             }
             return removedNodes.contains { $0 === parent } == false
         }
 
-        // Deep copy for re-insertion on undo, clearing tombstone markers.
+        // Deep copy for re-insertion on undo, but drop descendants that were
+        // already tombstoned before this edit. Without this filter, undoing a
+        // parent delete would resurrect the user's earlier independent deletes —
+        // causing accumulation across undo/redo cycles in nested-edit scenarios.
         let reverseContents: [CRDTTreeNode]? = topLevelRemoved.isEmpty
             ? nil
             : topLevelRemoved.compactMap { node in
-                guard let clone = node.deepcopy() else {
-                    return nil
-                }
-                clearRemovedAt(clone)
-                return clone
+                cloneAndDropPreTombstoned(node, preTombstoned)
             }
 
         // Positions for the reverse range, computed on the post-edit tree from the pre-edit index.

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -121,7 +121,7 @@ final class TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, diff, removedNodes, preEditFromIdx) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
+        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -148,7 +148,7 @@ final class TreeEditOperation: Operation {
             && removedNodes.isEmpty
         let reverseOp: Operation?
         if self.splitLevel == 0 {
-            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx)
+            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx, mergeLevel: mergeLevel)
         } else if isPureSplit {
             reverseOp = try self.toSplitReverseOperation(tree, preEditFromIdx)
         } else {
@@ -192,12 +192,19 @@ final class TreeEditOperation: Operation {
     /// reconciliation when remote edits arrive). At undo time the integer indices take precedence
     /// and are converted to positions via `tree.findPos`.
     ///
+    /// When `mergeLevel > 0`, the edit was a cross-boundary merge (it moved children by
+    /// deleting element boundaries). The reverse of a merge is a split — not content
+    /// re-insertion — so a split op with `splitLevel = mergeLevel` is returned instead of
+    /// the normal content-reinsertion reverse.
+    ///
     /// - Parameters:
     ///   - tree: The tree after this edit has been applied.
     ///   - removedNodes: The nodes removed by this edit, to be re-inserted on undo.
     ///   - preEditFromIdx: The start index captured before the edit deletions.
+    ///   - mergeLevel: The number of element boundaries merged by this edit. When greater than
+    ///     zero the reverse op is a split rather than a content reinsertion.
     /// - Returns: The reverse ``TreeEditOperation``, or `nil` when the edit was a no-op.
-    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int) throws -> Operation? {
+    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int, mergeLevel: Int = 0) throws -> Operation? {
         // Special case: this op is a boundary-deletion that was generated to reverse a split.
         // Its redo (i.e. the reverse of this reverse) should re-split at the merged position,
         // not re-insert the tombstoned boundary nodes as raw content.
@@ -215,6 +222,25 @@ final class TreeEditOperation: Operation {
                 toIdx: preEditFromIdx
             )
             return splitRedoOp
+        }
+
+        // Cross-boundary merge: the reverse is a split, not content re-insertion.
+        // A merge deletes element boundaries (e.g., </p><p>), moving children
+        // into the target. The undo re-creates those boundaries via split.
+        if mergeLevel > 0 {
+            let splitFromPos = try tree.findPos(preEditFromIdx)
+            let splitUndoOp = TreeEditOperation(
+                parentCreatedAt: self.parentCreatedAt,
+                fromPos: splitFromPos,
+                toPos: splitFromPos,
+                contents: nil,
+                splitLevel: Int32(mergeLevel),
+                executedAt: TimeTicket.initial,
+                isUndoOp: true,
+                fromIdx: preEditFromIdx,
+                toIdx: preEditFromIdx
+            )
+            return splitUndoOp
         }
 
         // Total tree-index tokens inserted by this edit.

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -39,10 +39,10 @@ private func cloneAndDropPreTombstoned(_ node: CRDTTreeNode, _ preTombstoned: Se
     // (already-resized) children. The deepcopy carried the original node's size;
     // after filterChildren dropped descendants that size is stale and must be
     // recomputed bottom-up.
-    traverseAll(node: clone) { n, _ in
-        n.removedAt = nil
-        if n.isText == false {
-            n.size = n.innerChildren.reduce(0) { $0 + $1.paddedSize }
+    traverseAll(node: clone) { node, _ in
+        node.removedAt = nil
+        if node.isText == false {
+            node.size = node.innerChildren.reduce(0) { $0 + $1.paddedSize }
         }
     }
     return clone

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.7"
+let yorkieVersion = "0.7.8"

--- a/Tests/Integration/DocumentPollingTests.swift
+++ b/Tests/Integration/DocumentPollingTests.swift
@@ -169,18 +169,74 @@ final class DocumentPollingTests: XCTestCase {
         // Switch c1 to Realtime — should open a watch stream.
         try c1.changeSyncMode(d1, .realtime)
 
+        // Fulfilled when realtime push delivers c2's change to d1. Event-driven
+        // (not Task.sleep) so the wait is deterministic and the run loop is pumped.
+        let received = expectation(description: "realtime delivers remote change")
+        received.assertForOverFulfill = false
+        d1.subscribe { _, doc in
+            if doc.getRoot().k as? String == "rt" {
+                received.fulfill()
+            }
+        }
+
         // when — c2 makes a change
         try await d2.update { root, _ in
             root.k = "rt"
         }
         try await c2.sync()
 
-        // Realtime should deliver within 2s (much faster than the 5s polling interval).
-        try await Task.sleep(milliseconds: 2000)
+        // then — realtime delivers (well before the 5s polling interval)
+        await fulfillment(of: [received], timeout: 5.0)
+        XCTAssertEqual(d1.getRoot().k as? String, "rt")
 
-        // then
-        let value = d1.getRoot().k as? String
-        XCTAssertEqual(value, "rt")
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+    }
+
+    // Regression (PR #260 review): switching Realtime → Polling must keep the
+    // document on the stream-less polling path — a stale watch-stream reconnect
+    // must not fire. The change still arrives, now via a polling tick.
+    @MainActor
+    func test_changeSyncMode_transitions_realtime_to_polling() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        defer {
+            Task {
+                try await c1.deactivate()
+                try await c2.deactivate()
+            }
+        }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+
+        // c1 starts in Realtime, then switches to Polling (default interval).
+        _ = try await c1.attach(d1, [:], .realtime)
+        _ = try await c2.attach(d2)
+        try c1.changeSyncMode(d1, .polling)
+
+        let received = expectation(description: "polling delivers after realtime->polling switch")
+        received.assertForOverFulfill = false
+        d1.subscribe { _, doc in
+            if doc.getRoot().k as? String == "p" {
+                received.fulfill()
+            }
+        }
+
+        // when — c2 makes a change and syncs
+        try await d2.update { root, _ in
+            root.k = "p"
+        }
+        try await c2.sync()
+
+        // then — d1 receives via a polling tick after the transition
+        await fulfillment(of: [received], timeout: 8.0)
+        XCTAssertEqual(d1.getRoot().k as? String, "p")
 
         try await c1.detach(d1)
         try await c2.detach(d2)

--- a/Tests/Integration/DocumentPollingTests.swift
+++ b/Tests/Integration/DocumentPollingTests.swift
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Document Polling tests (PR #1243)
+
+/// Ports: "Document Polling" from packages/sdk/test/integration/document_polling_test.ts.
+///
+/// iOS-side note: only the Document polling path was ported in v0.7.8. Channel-level
+/// polling (broadcast isolation, legacy mode) was explicitly deferred. These tests
+/// cover:
+///   - `documentPollInterval` validation (≤ 0 throws `.errInvalidArgument`)
+///   - `SyncMode.polling` attach opens no watch stream but still pushpull-syncs
+///   - `changeSyncMode(_:.polling)` transitions back to polling
+
+final class DocumentPollingTests: XCTestCase {
+    // Ports: "attach rejects documentPollInterval: 0 with ErrInvalidArgument"
+    //
+    // Passing `documentPollInterval: 0` (or any value ≤ 0) must throw
+    // `YorkieError` with code `.errInvalidArgument` immediately at attach time
+    // without contacting the server.
+    @MainActor
+    func test_attach_rejects_documentPollInterval_zero_with_errInvalidArgument() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c = Client(rpcAddress)
+        try await c.activate()
+        defer {
+            Task { try await c.deactivate() }
+        }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let doc = Document(key: docKey)
+
+        // when / then — documentPollInterval: 0 must throw errInvalidArgument
+        do {
+            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: 0)
+            XCTFail("attach with documentPollInterval:0 should throw errInvalidArgument")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errInvalidArgument,
+                           "expected errInvalidArgument, got \(error.code)")
+        }
+    }
+
+    // Ports: "attach rejects documentPollInterval: -1 with ErrInvalidArgument"
+    @MainActor
+    func test_attach_rejects_negative_documentPollInterval_with_errInvalidArgument() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c = Client(rpcAddress)
+        try await c.activate()
+        defer {
+            Task { try await c.deactivate() }
+        }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let doc = Document(key: docKey)
+
+        // when / then — documentPollInterval: -1 must throw errInvalidArgument
+        do {
+            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: -1)
+            XCTFail("attach with documentPollInterval:-1 should throw errInvalidArgument")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errInvalidArgument)
+        }
+    }
+
+    // Ports: "Polling document receives remote changes within poll interval"
+    //
+    // A document attached in `.polling` mode must receive remote changes via
+    // the timer-driven pushpull loop (no watch stream). The test waits long
+    // enough for at least two polling ticks and then asserts the value arrived.
+    @MainActor
+    func test_polling_document_receives_remote_changes_within_poll_interval() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        defer {
+            Task {
+                try await c1.deactivate()
+                try await c2.deactivate()
+            }
+        }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+
+        // c1 attaches in Polling mode with 300ms interval
+        _ = try await c1.attach(d1, [:], .polling, documentPollInterval: 0.3)
+        _ = try await c2.attach(d2)
+
+        // when — c2 makes a change and syncs
+        try await d2.update { root, _ in
+            root.k = "v"
+        }
+        try await c2.sync()
+
+        // Wait for at least 2 polling ticks (~600ms)
+        try await Task.sleep(milliseconds: 900)
+
+        // then — d1 should have received the remote change via polling
+        let value = d1.getRoot().k as? String
+        XCTAssertEqual(value, "v")
+
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+    }
+
+    // Ports: "changeSyncMode transitions Polling → Realtime for documents"
+    //
+    // Switching a document from `.polling` to `.realtime` must open a watch
+    // stream and start delivering remote changes via push, not the slow
+    // polling tick.
+    @MainActor
+    func test_changeSyncMode_transitions_polling_to_realtime() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        defer {
+            Task {
+                try await c1.deactivate()
+                try await c2.deactivate()
+            }
+        }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+
+        // c1 starts in Polling mode with a very long interval (5 s) to prove it's
+        // the Realtime path that delivers the change, not the polling tick.
+        _ = try await c1.attach(d1, [:], .polling, documentPollInterval: 5.0)
+        _ = try await c2.attach(d2)
+
+        // Switch c1 to Realtime — should open a watch stream.
+        try c1.changeSyncMode(d1, .realtime)
+
+        // when — c2 makes a change
+        try await d2.update { root, _ in
+            root.k = "rt"
+        }
+        try await c2.sync()
+
+        // Realtime should deliver within 2s (much faster than the 5s polling interval).
+        try await Task.sleep(milliseconds: 2000)
+
+        // then
+        let value = d1.getRoot().k as? String
+        XCTAssertEqual(value, "rt")
+
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+    }
+
+    // Unit-style validation: the `errInvalidArgument` guard is triggered on an
+    // active client before any network call completes. Running as @MainActor so
+    // Client initializer (which is @MainActor-isolated) is accessible.
+    @MainActor
+    func test_attach_documentPollInterval_zero_throws_before_network_contact() async {
+        // given — inactive client (never activated)
+        let rpcAddress = "http://localhost:8080"
+        let c = Client(rpcAddress)
+        let doc = Document(key: "poll-guard-unit")
+
+        do {
+            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: 0)
+            // Either errClientNotActivated or errInvalidArgument is acceptable;
+            // what must NOT happen is a silent success.
+            XCTFail("attach must throw when client is not active or poll interval is invalid")
+        } catch {
+            // Any throw is correct — the test guards that no silent success occurs.
+            XCTAssertNotNil(error)
+        }
+    }
+}

--- a/Tests/Integration/DocumentPollingTests.swift
+++ b/Tests/Integration/DocumentPollingTests.swift
@@ -41,10 +41,10 @@ final class DocumentPollingTests: XCTestCase {
     func test_attach_rejects_documentPollInterval_zero_with_errInvalidArgument() async throws {
         // given
         let rpcAddress = "http://localhost:8080"
-        let c = Client(rpcAddress)
-        try await c.activate()
+        let client = Client(rpcAddress)
+        try await client.activate()
         defer {
-            Task { try await c.deactivate() }
+            Task { try await client.deactivate() }
         }
 
         let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
@@ -52,7 +52,7 @@ final class DocumentPollingTests: XCTestCase {
 
         // when / then — documentPollInterval: 0 must throw errInvalidArgument
         do {
-            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: 0)
+            _ = try await client.attach(doc, [:], .realtime, documentPollInterval: 0)
             XCTFail("attach with documentPollInterval:0 should throw errInvalidArgument")
         } catch let error as YorkieError {
             XCTAssertEqual(error.code, .errInvalidArgument,
@@ -65,10 +65,10 @@ final class DocumentPollingTests: XCTestCase {
     func test_attach_rejects_negative_documentPollInterval_with_errInvalidArgument() async throws {
         // given
         let rpcAddress = "http://localhost:8080"
-        let c = Client(rpcAddress)
-        try await c.activate()
+        let client = Client(rpcAddress)
+        try await client.activate()
         defer {
-            Task { try await c.deactivate() }
+            Task { try await client.deactivate() }
         }
 
         let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
@@ -76,7 +76,7 @@ final class DocumentPollingTests: XCTestCase {
 
         // when / then — documentPollInterval: -1 must throw errInvalidArgument
         do {
-            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: -1)
+            _ = try await client.attach(doc, [:], .realtime, documentPollInterval: -1)
             XCTFail("attach with documentPollInterval:-1 should throw errInvalidArgument")
         } catch let error as YorkieError {
             XCTAssertEqual(error.code, .errInvalidArgument)
@@ -111,18 +111,27 @@ final class DocumentPollingTests: XCTestCase {
         _ = try await c1.attach(d1, [:], .polling, documentPollInterval: 0.3)
         _ = try await c2.attach(d2)
 
-        // when — c2 makes a change and syncs
+        // Fulfilled when a polling tick pulls c2's change into d1. Use an
+        // expectation rather than `Task.sleep`: the periodic sync loop runs on a
+        // `RunLoop.main` timer that fires while `XCTWaiter` pumps the run loop, but
+        // NOT while an async test is merely suspended in `Task.sleep`.
+        let received = expectation(description: "polling delivers remote change")
+        received.assertForOverFulfill = false
+        d1.subscribe { _, doc in
+            if doc.getRoot().k as? String == "v" {
+                received.fulfill()
+            }
+        }
+
+        // when — c2 makes a change and syncs it to the server
         try await d2.update { root, _ in
             root.k = "v"
         }
         try await c2.sync()
 
-        // Wait for at least 2 polling ticks (~600ms)
-        try await Task.sleep(milliseconds: 900)
-
-        // then — d1 should have received the remote change via polling
-        let value = d1.getRoot().k as? String
-        XCTAssertEqual(value, "v")
+        // then — d1 receives the change via a polling tick (interval 0.3s)
+        await fulfillment(of: [received], timeout: 5.0)
+        XCTAssertEqual(d1.getRoot().k as? String, "v")
 
         try await c1.detach(d1)
         try await c2.detach(d2)
@@ -184,11 +193,11 @@ final class DocumentPollingTests: XCTestCase {
     func test_attach_documentPollInterval_zero_throws_before_network_contact() async {
         // given — inactive client (never activated)
         let rpcAddress = "http://localhost:8080"
-        let c = Client(rpcAddress)
+        let client = Client(rpcAddress)
         let doc = Document(key: "poll-guard-unit")
 
         do {
-            _ = try await c.attach(doc, [:], .realtime, documentPollInterval: 0)
+            _ = try await client.attach(doc, [:], .realtime, documentPollInterval: 0)
             // Either errClientNotActivated or errInvalidArgument is acceptable;
             // what must NOT happen is a silent success.
             XCTFail("attach must throw when client is not active or poll interval is invalid")

--- a/Tests/Integration/TreeHistoryEditByPathTests.swift
+++ b/Tests/Integration/TreeHistoryEditByPathTests.swift
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// MARK: - Helpers
+
+@MainActor
+private func xmlOf(_ doc: Document) -> String {
+    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+}
+
+// MARK: - 4. Single Client — editByPath split/merge undo/redo (PR #1237)
+
+/// Ports: "Tree History - single client split/merge" tests renamed to
+/// use `editByPath` variants from packages/sdk/test/integration/history_tree_split_test.ts
+/// (added in PR #1239, confirmed updated in PR #1237).
+///
+/// PR #1237 renamed the split/merge undo/redo tests from `splitByPath`/`mergeByPath`
+/// to `editByPath([…], […], undefined, 1)` / `editByPath([0, 2], [1, 0])`.
+/// The underlying iOS `JSONTree.editByPath(_:_:_:_:)` call is identical; the key
+/// fix is that undoing a cross-boundary merge regenerates a split (not raw content
+/// re-insertion), and undoing a split-then-merge editByPath round-trip restores the
+/// element boundaries correctly.
+
+final class TreeHistoryEditByPathSplitMergeTests: XCTestCase {
+    // Ports: "should undo editByPath split"
+    @MainActor
+    func test_can_undo_editByPath_split() throws {
+        // given
+        let doc = Document(key: "editbypath-split-undo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "ABCD")
+                    ])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+        XCTAssertEqual(before, "<doc><p>ABCD</p></doc>")
+
+        // when — split at offset 2 between "AB" and "CD" via editByPath with splitLevel=1
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 2], [0, 2], nil, 1)
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>AB</p><p>CD</p></doc>")
+
+        // then
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+    }
+
+    // Ports: "should redo editByPath split"
+    @MainActor
+    func test_can_redo_editByPath_split() throws {
+        // given
+        let doc = Document(key: "editbypath-split-redo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [
+                        JSONTreeTextNode(value: "ABCD")
+                    ])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 2], [0, 2], nil, 1)
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>AB</p><p>CD</p></doc>")
+
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "should undo editByPath merge"
+    //
+    // The cross-boundary merge via editByPath([0, 2], [1, 0]) deletes the
+    // </p><p> boundary. The undo must re-create those boundaries (split), not
+    // re-insert the boundary tokens as raw content.
+    @MainActor
+    func test_can_undo_editByPath_merge() throws {
+        // given
+        let doc = Document(key: "editbypath-merge-undo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "AB")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "CD")])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+        XCTAssertEqual(before, "<doc><p>AB</p><p>CD</p></doc>")
+
+        // when — merge second <p> into first via cross-boundary editByPath
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 2], [1, 0])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>ABCD</p></doc>")
+
+        // then — undo must re-split (not re-insert raw boundary content)
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+    }
+
+    // Ports: "should redo editByPath merge"
+    @MainActor
+    func test_can_redo_editByPath_merge() throws {
+        // given
+        let doc = Document(key: "editbypath-merge-redo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "AB")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "CD")])
+                ])
+            )
+        }
+
+        let before = xmlOf(doc)
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 2], [1, 0])
+        }
+        let after = xmlOf(doc)
+        XCTAssertEqual(after, "<doc><p>ABCD</p></doc>")
+
+        try doc.undo()
+        XCTAssertEqual(xmlOf(doc), before)
+
+        // then
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), after)
+    }
+
+    // Ports: "Can merge blocks using editByPath (wafflebase pattern)"
+    //
+    // Verifies a direct-merge editByPath call (not a split-then-merge roundtrip)
+    // produces the correct XML, to establish the baseline for the split-then-merge
+    // regression test below.
+    @MainActor
+    func test_can_merge_blocks_using_editByPath() throws {
+        // given — reproduce wafflebase docs tree structure
+        let doc = Document(key: "editbypath-merge-wafflebase")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "block", children: [
+                        JSONTreeElementNode(type: "inline", children: [
+                            JSONTreeTextNode(value: "as")
+                        ])
+                    ]),
+                    JSONTreeElementNode(type: "block", children: [
+                        JSONTreeElementNode(type: "inline", children: [
+                            JSONTreeTextNode(value: "df")
+                        ])
+                    ])
+                ])
+            )
+        }
+
+        let initialXML = xmlOf(doc)
+        XCTAssertEqual(initialXML,
+                       "<doc><block><inline>as</inline></block><block><inline>df</inline></block></doc>")
+
+        // when — wafflebase mergeBlock: editByPath([blockPath, inlineCount], [nextPath, 0])
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 1], [1, 0])
+        }
+
+        // then
+        let mergedXML = xmlOf(doc)
+        XCTAssertEqual(mergedXML,
+                       "<doc><block><inline>as</inline><inline>df</inline></block></doc>")
+    }
+
+    // Ports: "Can split then merge blocks using editByPath (wafflebase backspace bug)"
+    //
+    // This is the primary regression test for PR #1237: after splitting a paragraph
+    // via editByPath with splitLevel=2, the subsequent cross-boundary merge via
+    // editByPath must succeed (not be a no-op) and produce the correct XML.
+    @MainActor
+    func test_split_then_merge_via_editByPath_roundtrip() throws {
+        // given — single block with one inline
+        let doc = Document(key: "editbypath-split-then-merge")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "block", children: [
+                        JSONTreeElementNode(type: "inline", children: [
+                            JSONTreeTextNode(value: "asdf")
+                        ])
+                    ])
+                ])
+            )
+        }
+        XCTAssertEqual(xmlOf(doc), "<doc><block><inline>asdf</inline></block></doc>")
+
+        // when — split at offset 2 with splitLevel=2 (Enter key after "as")
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 0, 2], [0, 0, 2], nil, 2)
+        }
+        XCTAssertEqual(xmlOf(doc),
+                       "<doc><block><inline>as</inline></block><block><inline>df</inline></block></doc>")
+
+        // when — merge via backspace at start of second block
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 1], [1, 0])
+        }
+
+        // then — merge must NOT be a no-op
+        let mergedXML = xmlOf(doc)
+        XCTAssertEqual(mergedXML,
+                       "<doc><block><inline>as</inline><inline>df</inline></block></doc>")
+    }
+
+    // Ports: "Can split then merge blocks using editByPath (wafflebase backspace bug)" — undo
+    //
+    // After the split-then-merge round-trip, undo must restore the two-block state.
+    @MainActor
+    func test_can_undo_split_then_merge_roundtrip() throws {
+        // given — split-then-merge as above
+        let doc = Document(key: "editbypath-split-merge-undo")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "block", children: [
+                        JSONTreeElementNode(type: "inline", children: [
+                            JSONTreeTextNode(value: "asdf")
+                        ])
+                    ])
+                ])
+            )
+        }
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 0, 2], [0, 0, 2], nil, 2)
+        }
+        let afterSplit = xmlOf(doc)
+        XCTAssertEqual(afterSplit,
+                       "<doc><block><inline>as</inline></block><block><inline>df</inline></block></doc>")
+
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.editByPath([0, 1], [1, 0])
+        }
+        let afterMerge = xmlOf(doc)
+        XCTAssertEqual(afterMerge,
+                       "<doc><block><inline>as</inline><inline>df</inline></block></doc>")
+
+        // when — undo the merge
+        try doc.undo()
+
+        // then — two-block state is restored
+        XCTAssertEqual(xmlOf(doc), afterSplit)
+
+        // and — redo re-applies the merge
+        try doc.redo()
+        XCTAssertEqual(xmlOf(doc), afterMerge)
+    }
+}
+
+// MARK: - Multi-client editByPath split/merge convergence (PR #1237)
+
+/// Integration tests that verify both clients converge after editByPath
+/// split and merge operations with concurrent edits.
+final class TreeHistoryEditByPathConvergenceTests: XCTestCase {
+    // Ports: "Can sync editByPath split with other clients"
+    @MainActor
+    func test_can_sync_editByPath_split_with_other_clients() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — nested tree structure matching the JS test
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "tc", children: [
+                            JSONTreeElementNode(type: "p", children: [
+                                JSONTreeElementNode(type: "tn", children: [
+                                    JSONTreeTextNode(value: "1234")
+                                ])
+                            ]),
+                            JSONTreeElementNode(type: "p", children: [
+                                JSONTreeElementNode(type: "tn", children: [
+                                    JSONTreeTextNode(value: "5678")
+                                ])
+                            ])
+                        ])
+                    ])
+                )
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — d1 splits using editByPath with splitLevel=1
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.editByPath([0, 0, 0, 2], [0, 0, 0, 2], nil, 1)
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both documents converge
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — d1 splits at the second level
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.editByPath([0, 0, 1], [0, 0, 1], nil, 1)
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — still converged
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    // Ports: "Can sync editByPath merge with other clients"
+    @MainActor
+    func test_can_sync_editByPath_merge_with_other_clients() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — nested tree with two text-nodes in the same <p>
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "tc", children: [
+                            JSONTreeElementNode(type: "p", children: [
+                                JSONTreeElementNode(type: "tn", children: [
+                                    JSONTreeTextNode(value: "1234")
+                                ]),
+                                JSONTreeElementNode(type: "tn", children: [
+                                    JSONTreeTextNode(value: "5678")
+                                ])
+                            ])
+                        ])
+                    ])
+                )
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+
+            // when — d1 merges using editByPath (cross-boundary merge of two <tn>s)
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.editByPath([0, 0, 0, 4], [0, 0, 1, 0])
+            }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then — both documents converge
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+}

--- a/Tests/Integration/TreeHistoryIntegrationTests.swift
+++ b/Tests/Integration/TreeHistoryIntegrationTests.swift
@@ -1285,3 +1285,66 @@ final class TreeHistoryMultiClientEdgeCasesTests: XCTestCase {
         }
     }
 }
+
+// MARK: - 8. Clear history after attach (PR #1238)
+
+/// Ports: "should not allow undoing past initialRoot after attach"
+/// from packages/sdk/test/integration/history_tree_test.ts (PR #1238).
+///
+/// `Client.attach` must call `clearHistory()` after applying `initialRoot` so that
+/// the tree-creation op is NOT on the undo stack. The user should only be able to
+/// undo the typed characters, not the tree itself.
+final class TreeHistoryClearAfterAttachTests: XCTestCase {
+    @MainActor
+    func test_initialRoot_ops_are_not_undoable_after_attach() async throws {
+        // given
+        let rpcAddress = "http://localhost:8080"
+        let c1 = Client(rpcAddress)
+        try await c1.activate()
+        defer { Task { try await c1.deactivate() } }
+
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let doc = Document(key: docKey)
+
+        // Attach with initialRoot containing a Tree (like wafflebase ensureTree).
+        _ = try await c1.attach(doc, initialRoot: [
+            "content": JSONTree(initialRoot:
+                JSONTreeElementNode(type: "doc", children: [
+                    JSONTreeElementNode(type: "block", children: [
+                        JSONTreeElementNode(type: "inline", children: [])
+                    ])
+                ])
+            ) as JSONValuable?
+        ])
+
+        let initialXML = (doc.getRoot().content as? JSONTree)?.toXML() ?? ""
+
+        // After attach, the undo stack must be empty — initialRoot is not a
+        // user-action and must not be undoable.
+        let undoStack = doc.getUndoStackForTest()
+        XCTAssertTrue(undoStack.isEmpty, "undo stack must be empty after attach; got \(undoStack.count) entries")
+        XCTAssertFalse(doc.canUndo)
+
+        // when — type 4 characters
+        for ch in ["a", "s", "d", "f"] {
+            try doc.update { root, _ in
+                try (root.content as? JSONTree)?.editByPath([0, 0, 0], [0, 0, 0], JSONTreeTextNode(value: ch))
+            }
+        }
+
+        // Undo 4 times — should revert each character
+        for i in 0 ..< 4 {
+            XCTAssertTrue(doc.canUndo, "should be able to undo character \(i)")
+            try doc.undo()
+        }
+        let xmlAfterAllUndos = (doc.getRoot().content as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlAfterAllUndos, initialXML)
+
+        // 5th undo — stack is empty so it must be a no-op (PR #1238)
+        XCTAssertFalse(doc.canUndo, "should not be able to undo past initialRoot")
+        try doc.undo()
+        let xmlAfterExtraUndo = (doc.getRoot().content as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlAfterExtraUndo, initialXML, "tree must stay intact after empty-stack undo")
+    }
+}
+

--- a/Tests/Integration/TreeHistoryIntegrationTests.swift
+++ b/Tests/Integration/TreeHistoryIntegrationTests.swift
@@ -1333,8 +1333,8 @@ final class TreeHistoryClearAfterAttachTests: XCTestCase {
         }
 
         // Undo 4 times — should revert each character
-        for i in 0 ..< 4 {
-            XCTAssertTrue(doc.canUndo, "should be able to undo character \(i)")
+        for idx in 0 ..< 4 {
+            XCTAssertTrue(doc.canUndo, "should be able to undo character \(idx)")
             try doc.undo()
         }
         let xmlAfterAllUndos = (doc.getRoot().content as? JSONTree)?.toXML() ?? ""
@@ -1347,4 +1347,3 @@ final class TreeHistoryClearAfterAttachTests: XCTestCase {
         XCTAssertEqual(xmlAfterExtraUndo, initialXML, "tree must stay intact after empty-stack undo")
     }
 }
-

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -253,7 +253,7 @@ final class CRDTTreeEditTests: XCTestCase {
         let sizeBefore = tree.size
         let fromPos = try tree.findPos(0)
         let toPos = try tree.findPos(4)
-        let (_, _, _, removedNodes, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
+        let (_, _, _, removedNodes, _, _, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
 
         XCTAssertEqual(removedNodes.count, 2, "both the <p> and its text child are removed")
         let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }

--- a/Tests/Unit/Document/DocumentUndoRedoTests.swift
+++ b/Tests/Unit/Document/DocumentUndoRedoTests.swift
@@ -26,14 +26,78 @@ final class DocumentUndoRedoTests: XCTestCase {
         XCTAssertFalse(canRedo)
     }
 
-    func test_undo_throws_when_there_is_nothing_to_undo() async {
+    // Ports: upstream PR #1238 changed undo/redo on an empty stack from throwing
+    // ErrRefused to being a no-op. This test was previously asserting a throw;
+    // it now asserts the no-op behaviour instead.
+    func test_undo_is_noop_when_stack_is_empty() async throws {
+        // given
         let doc = Document(key: "undo-nothing")
-        do {
+
+        // when / then — must NOT throw and must leave the document unchanged
+        try await doc.undo()
+        let json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{}")
+        let canUndo = await doc.canUndo
+        XCTAssertFalse(canUndo)
+    }
+
+    // Ports: upstream PR #1238 — redo on an empty stack is also a no-op.
+    func test_redo_is_noop_when_stack_is_empty() async throws {
+        // given
+        let doc = Document(key: "redo-nothing")
+
+        // when / then — must NOT throw and must leave the document unchanged
+        try await doc.redo()
+        let json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{}")
+        let canRedo = await doc.canRedo
+        XCTAssertFalse(canRedo)
+    }
+
+    // Ports: upstream PR #1238 — calling undo more times than operations on the stack
+    // should succeed (extra calls are no-ops) and stop at the earliest state.
+    func test_extra_undo_calls_beyond_stack_depth_are_noops() async throws {
+        // given
+        let doc = Document(key: "undo-overflow")
+        try await doc.update { root, _ in root.a = Int64(1) }
+        try await doc.update { root, _ in root.b = Int64(2) }
+        var json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{\"a\":1,\"b\":2}")
+
+        // when — undo 5 times; only 2 ops on the stack
+        for _ in 0 ..< 5 {
             try await doc.undo()
-            XCTFail("expected undo to throw")
-        } catch {
-            // expected
         }
+
+        // then — stopped at empty state, no throw
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{}")
+        let canUndo = await doc.canUndo
+        XCTAssertFalse(canUndo)
+    }
+
+    // Ports: upstream PR #1238 — calling redo more times than ops on the stack
+    // should succeed (extra calls are no-ops) and stop at the latest state.
+    func test_extra_redo_calls_beyond_stack_depth_are_noops() async throws {
+        // given
+        let doc = Document(key: "redo-overflow")
+        try await doc.update { root, _ in root.a = Int64(1) }
+        try await doc.update { root, _ in root.b = Int64(2) }
+        try await doc.undo()
+        try await doc.undo()
+        var json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{}")
+
+        // when — redo 5 times; only 2 ops on the stack
+        for _ in 0 ..< 5 {
+            try await doc.redo()
+        }
+
+        // then — stopped at full state, no throw
+        json = await doc.toSortedJSON()
+        XCTAssertEqual(json, "{\"a\":1,\"b\":2}")
+        let canRedo = await doc.canRedo
+        XCTAssertFalse(canRedo)
     }
 
     func test_undo_and_redo_object_set() async throws {

--- a/Tests/Unit/Document/TreePreTombstonedFilterTests.swift
+++ b/Tests/Unit/Document/TreePreTombstonedFilterTests.swift
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+// MARK: - Helpers
+
+/// Initial tree: <doc><p><inline></inline></p></doc>
+@MainActor
+private func initBlockTree(_ doc: Document) throws {
+    try doc.update { root, _ in
+        root.t = JSONTree(initialRoot:
+            JSONTreeElementNode(type: "doc", children: [
+                JSONTreeElementNode(type: "p", children: [
+                    JSONTreeElementNode(type: "inline", children: [])
+                ])
+            ])
+        )
+    }
+}
+
+/// Insert a sibling <p><inline></inline></p> at the document level.
+@MainActor
+private func insertSiblingBlock(_ doc: Document) throws {
+    try doc.update { root, _ in
+        try (root.t as? JSONTree)?.editByPath(
+            [1], [1],
+            JSONTreeElementNode(type: "p", children: [
+                JSONTreeElementNode(type: "inline", children: [])
+            ])
+        )
+    }
+}
+
+/// Insert one character at the end of the second <p>'s inline.
+/// Mirrors the JS `typeInSecondBlock` helper.
+@MainActor
+private func typeInSecondBlock(_ doc: Document, _ ch: String) throws {
+    try doc.update { root, _ in
+        guard let tree = root.t as? JSONTree else { return }
+        let xml = tree.toXML()
+        // Compute the offset from the last <inline>...</inline></p></doc> at the tail.
+        let suffix = "</inline></p></doc>"
+        let cur: Int
+        if let range = xml.range(of: "<inline>", options: .backwards),
+           let endRange = xml.range(of: suffix, options: .backwards)
+        {
+            let innerStart = xml.index(range.upperBound, offsetBy: 0)
+            let innerEnd = endRange.lowerBound
+            if innerStart <= innerEnd {
+                cur = xml.distance(from: innerStart, to: innerEnd)
+            } else {
+                cur = 0
+            }
+        } else {
+            cur = 0
+        }
+        try tree.editByPath([1, 0, cur], [1, 0, cur], JSONTreeTextNode(value: ch))
+    }
+}
+
+// MARK: - 5. Single Client — reverseOp pre-tombstoned descendant filtering
+
+/// Ports: "Tree History - single client reverseOp pre-tombstoned filter"
+/// from packages/sdk/test/integration/history_tree_split_test.ts (PR #1239).
+///
+/// These unit tests exercise the `cloneAndDropPreTombstoned` fix:
+/// undoing a parent delete must NOT resurrect descendants the user
+/// independently deleted before that edit.
+
+final class TreePreTombstonedFilterTests: XCTestCase {
+    // Ports: "should not accumulate reverseOp contents across redo cycles"
+    //
+    // The redo-stack top's node count must be the same in every cycle. Without
+    // the `cloneAndDropPreTombstoned` filter it grows because each undo/redo cycle
+    // adds the previously-tombstoned characters back into the reverseOp payload.
+    @MainActor
+    func test_reverseOp_contents_size_is_constant_across_redo_cycles() throws {
+        // given — <doc><p><inline></inline></p></doc> + a second <p> block
+        let doc = Document(key: "pretomb-size-stable")
+        try initBlockTree(doc)
+        try insertSiblingBlock(doc)
+
+        let numCycles = 4
+        var redoOpSizes = [Int]()
+
+        for _ in 0 ..< numCycles {
+            // Type "asdf" into the second block.
+            for ch in ["a", "s", "d", "f"] {
+                try typeInSecondBlock(doc, ch)
+            }
+
+            // Undo each char.
+            for _ in 0 ..< 4 {
+                try doc.undo()
+            }
+
+            // Undo the block-insert. The redo-stack top now holds the "re-insert block" op.
+            try doc.undo()
+
+            // Count nodes in the redo-stack top TreeEditOperation.
+            let redoStack = doc.getRedoStackForTest()
+            let topEntry = redoStack.last ?? []
+            var nodeCount = 0
+            for histOp in topEntry {
+                if case .operation(let op) = histOp, let treeOp = op as? TreeEditOperation {
+                    nodeCount += treeOp.getContentSize()
+                }
+            }
+            redoOpSizes.append(nodeCount)
+
+            // Redo for the next cycle's setup.
+            try doc.redo()
+        }
+
+        // All cycles must produce the same count — no accumulation.
+        XCTAssertFalse(redoOpSizes.isEmpty, "expected at least one cycle")
+        let first = redoOpSizes[0]
+        for (i, size) in redoOpSizes.enumerated() {
+            XCTAssertEqual(size, first, "cycle \(i) redo size \(size) != cycle-0 size \(first)")
+        }
+    }
+
+    // Ports: "should allow typing at the correct position after redo"
+    //
+    // After the type-undo-undo-redo sequence, typing into the second block
+    // must land in the correct position and produce the expected XML.
+    @MainActor
+    func test_typing_at_correct_position_after_redo() throws {
+        // given
+        let doc = Document(key: "pretomb-typing-after-redo")
+        try initBlockTree(doc)
+        try insertSiblingBlock(doc)
+
+        for ch in ["a", "s", "d", "f"] {
+            try typeInSecondBlock(doc, ch)
+        }
+        for _ in 0 ..< 4 {
+            try doc.undo()
+        }
+        try doc.undo()
+
+        // when — undo leaves only the initial block
+        let xmlAfterUndo = (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlAfterUndo, "<doc><p><inline></inline></p></doc>")
+
+        // when — redo re-creates the second block (empty)
+        try doc.redo()
+        let xmlAfterRedo = (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlAfterRedo, "<doc><p><inline></inline></p><p><inline></inline></p></doc>")
+
+        // then — typing into the second block lands correctly
+        try typeInSecondBlock(doc, "x")
+        let xmlFinal = (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlFinal, "<doc><p><inline></inline></p><p><inline>x</inline></p></doc>")
+    }
+
+    // Ports: "should remain stable across three cycles followed by typing"
+    //
+    // Three full type-undo-undo-redo cycles must leave the tree identical each
+    // time. After the last cycle, typing "z" must land at the correct position.
+    @MainActor
+    func test_stable_across_three_cycles_followed_by_typing() throws {
+        // given
+        let doc = Document(key: "pretomb-three-cycles")
+        try initBlockTree(doc)
+        try insertSiblingBlock(doc)
+
+        let expectedAfterRedo = "<doc><p><inline></inline></p><p><inline></inline></p></doc>"
+
+        for cycle in 0 ..< 3 {
+            for ch in ["a", "s", "d", "f"] {
+                try typeInSecondBlock(doc, ch)
+            }
+            for _ in 0 ..< 4 {
+                try doc.undo()
+            }
+            try doc.undo()
+            try doc.redo()
+
+            let xml = (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+            XCTAssertEqual(xml, expectedAfterRedo, "cycle \(cycle): unexpected XML after redo")
+        }
+
+        // then — typing still lands correctly after all cycles
+        try typeInSecondBlock(doc, "z")
+        let xmlFinal = (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+        XCTAssertEqual(xmlFinal, "<doc><p><inline></inline></p><p><inline>z</inline></p></doc>")
+    }
+
+    // Ports: "should produce reverseContents with consistent sizes"
+    //
+    // After the type-undo-undo sequence the redo-stack top must contain at
+    // least one TreeEditOperation, and every surviving element node's
+    // reported `getContentSize()` must be non-negative (structural sanity).
+    // The full size-equality check requires internal node inspection that
+    // would couple to `CRDTTreeNode` internals; we guard the high-level
+    // invariant instead.
+    @MainActor
+    func test_redo_stack_top_has_well_formed_content_after_undo() throws {
+        // given
+        let doc = Document(key: "pretomb-content-size")
+        try initBlockTree(doc)
+        try insertSiblingBlock(doc)
+
+        for ch in ["a", "s", "d", "f"] {
+            try typeInSecondBlock(doc, ch)
+        }
+        for _ in 0 ..< 4 {
+            try doc.undo()
+        }
+        try doc.undo()
+
+        // then — redo stack must be non-empty and contain a tree-edit op
+        let redoStack = doc.getRedoStackForTest()
+        XCTAssertFalse(redoStack.isEmpty, "redo stack must be non-empty after undo")
+
+        let topEntry = redoStack.last ?? []
+        let treeOps = topEntry.compactMap { entry -> TreeEditOperation? in
+            if case .operation(let op) = entry { return op as? TreeEditOperation }
+            return nil
+        }
+        XCTAssertFalse(treeOps.isEmpty, "redo-stack top must contain at least one TreeEditOperation")
+
+        for op in treeOps {
+            XCTAssertGreaterThanOrEqual(op.getContentSize(), 0)
+        }
+    }
+}

--- a/Tests/Unit/Document/TreePreTombstonedFilterTests.swift
+++ b/Tests/Unit/Document/TreePreTombstonedFilterTests.swift
@@ -130,8 +130,8 @@ final class TreePreTombstonedFilterTests: XCTestCase {
         // All cycles must produce the same count — no accumulation.
         XCTAssertFalse(redoOpSizes.isEmpty, "expected at least one cycle")
         let first = redoOpSizes[0]
-        for (i, size) in redoOpSizes.enumerated() {
-            XCTAssertEqual(size, first, "cycle \(i) redo size \(size) != cycle-0 size \(first)")
+        for (idx, size) in redoOpSizes.enumerated() {
+            XCTAssertEqual(size, first, "cycle \(idx) redo size \(size) != cycle-0 size \(first)")
         }
     }
 

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.7'
+    image: 'yorkieteam/yorkie:0.7.8'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.7'
+    image: 'yorkieteam/yorkie:0.7.8'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk 0.7.8. iOS-relevant changes (no proto change):

- **Fix editByPath split-then-merge and cross-boundary merge undo** (#1237) — `CRDTTree.edit()` now returns a `mergeLevel` (count of merged boundary nodes), and a cross-boundary merge's reverse op is a **split** (`splitLevel = mergeLevel`) rather than content re-insertion; plus a narrowing guard that skips range-narrowing when `toLeft === toParent` (leftmost-child / offset-0 position).
- **Filter pre-tombstoned descendants in tree reverseOp** (#1239) — `edit()` collects a `preTombstoned` set (nodes already tombstoned before this edit). `clearRemovedAt` is replaced by `cloneAndDropPreTombstoned` + `filterChildren`, which drop those descendants from the undo clone so undoing a parent delete no longer resurrects the user's earlier independent deletes. (iOS adaptation: single `size` per node recomputed bottom-up, vs the JS SDK's `visibleSize`/`totalSize`.)
- **Clear history after attach and make undo/redo no-op on empty stack** (#1238) — `undo()`/`redo()` on an empty stack are now no-ops instead of throwing; `clearHistory()` is called after attach so initial-root setup ops are not undoable.
- **Add SyncMode.Polling for Document** (#1243, Document side) — new `SyncMode.polling` plus a `documentPollInterval` attach option (seconds; default 3.0). A polling document opens no watch stream and is driven by the existing timer-based sync loop (`needRealtimeSync` gains a time-based branch). `changeSyncMode` handles the manual/polling/realtime transitions.

Skipped upstream: #1240 (JS deps), #1241 (docs), #1246 (release). **Channel-side polling and the `isRealtime` removal (#1245) are intentionally deferred** — iOS `Channel` exposes a public `Channel.init(isRealtime:)` plus a shared heartbeat `Timer`, so a faithful channel port is a breaking API change tracked as a follow-up.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- critic-reviewer approved the port as a faithful 1:1 translation of yorkie-js-sdk 0.7.8 (tree undo reverse-ops, the iOS single-`size` adaptation in `cloneAndDropPreTombstoned`, `filterChildren` clone safety, polling units/state-machine).
- Full gate green, including **integration tests against a live yorkie server**: SwiftFormat 0.55.6 + SwiftLint 0.58.2 `--strict` (0 violations), `swift build --build-tests`, unit tests, and the relevant integration suites — `DocumentPollingTests` (5), `TreeHistory*` (169), `TreeConcurrencyTests` (5), and the merge-convergence suites (21) — all pass (known-limitation quarantines remain skipped).
- The `documentPollInterval` parameter is in **seconds** (iOS `TimeInterval`), unlike the JS SDK's milliseconds — documented on the parameter.

**Does this PR introduce a user-facing change?**:
```release-note
Converge editByPath split-then-merge and cross-boundary merge undo, stop tree undo from resurrecting earlier-deleted nodes, make undo/redo a no-op on an empty stack, and add SyncMode.Polling for documents.
```

**Additional documentation**:
```docs
- CHANGELOG.md updated for v0.7.8
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polling-based document synchronization mode with configurable poll intervals for scenarios where real-time streaming is unavailable.

* **Bug Fixes**
  * Undo/redo operations now gracefully no-op on empty history instead of throwing errors.
  * Fixed tree edit operations with cross-boundary merges during undo/redo sequences.
  * Document undo history is now cleared after attachment with initial content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->