### PR TITLE
chore: bump CI Xcode to 26.0.1 (macos-latest dropped 16.2)

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
+        xcode-version: '26.0.1'
     - uses: actions/checkout@v4
     - name: Update Brew
       run: brew update

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
+        xcode-version: '26.0.1'
     - uses: actions/checkout@v4
     - name: SwiftLint and SwiftFormat install
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

CI and Integration tests are failing on `main` because the `macos-latest` GitHub Actions runner image rotated and **no longer provides Xcode 16.2**. The `setup-xcode@v1` step fails with:

```
Switching Xcode to version '16.2'...
##[error]Could not find Xcode version that satisfied version spec: '16.2'
```

The image now offers Xcode 26.0.1–26.5.0 only. This bumps the pinned Xcode in both workflows (`swift.yml`, `swift-integration.yml`) from `16.2` to `26.0.1`, a stable version present on the current image. The same commit passed on PR #260 yesterday (pre-rotation); only the post-merge `push` runs on `main` failed.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Workflow-only change; no source changes. The package builds/tests on the Swift 6.2 toolchain (Xcode 26 era) locally.
- Follow-up option: switching the pin to `latest-stable` would prevent this recurring whenever the runner image drops a specific Xcode version — flagged for your preference rather than changed here.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation**:
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build environment to use a newer toolchain version for improved build and testing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->