### PR TITLE
Apply updates from yorkie-js-sdk 0.7.10

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.9
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/5bb7a1a38667087b21e96d534315cff444e12b7a/Formula/y/yorkie.rb"
+      # yorkie server v0.7.10
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/182b56ba1f1e8384cbec5e590a00c06dc26c7378/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.9
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/5bb7a1a38667087b21e96d534315cff444e12b7a/Formula/y/yorkie.rb"
+      # yorkie server v0.7.10
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/182b56ba1f1e8384cbec5e590a00c06dc26c7378/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.10] - 2026-06-26
+
+- Add disableGC attach option in https://github.com/yorkie-team/yorkie-ios-sdk/pull/PRNUM
+- Channel lifecycle via RefreshChannel only in https://github.com/yorkie-team/yorkie-ios-sdk/pull/PRNUM
+
 ## [v0.7.9] - 2026-06-23
 
 - Add PeekChannel client in https://github.com/yorkie-team/yorkie-ios-sdk/pull/262

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 
 ## [v0.7.10] - 2026-06-26
 
-- Add disableGC attach option in https://github.com/yorkie-team/yorkie-ios-sdk/pull/PRNUM
-- Channel lifecycle via RefreshChannel only in https://github.com/yorkie-team/yorkie-ios-sdk/pull/PRNUM
+- Add disableGC attach option in https://github.com/yorkie-team/yorkie-ios-sdk/pull/263
+- Channel lifecycle via RefreshChannel only in https://github.com/yorkie-team/yorkie-ios-sdk/pull/263
 
 ## [v0.7.9] - 2026-06-23
 

--- a/Examples/RichTextEditor/RichTextEditor/ContentView.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
         VStack(spacing: 0) {
             // Header with peers and version
             HStack(alignment: .top) {
-                Text("Participants: [\(self.viewModel.localUsername), \(self.viewModel.peers.filter { $0.name != self.viewModel.localUsername }.map { $0.name }.joined(separator: ", "))]")
+                Text("Participants: [\(self.viewModel.localUsername), \(self.viewModel.peers.map { $0.name }.joined(separator: ", "))]")
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.leading)
@@ -182,7 +182,7 @@ struct ContentView: View {
             .frame(height: 60)
             .background(Color(UIColor.systemGray6))
 
-            RTUITextField(text: self.viewModel.attributeString, textField: self.viewModel.uitextView, lastEditStyle: self.viewModel.lastEditStyle, didChangeSelection: { fromIndex, toIndex in
+            RTUITextField(text: self.viewModel.attributeString, textField: self.viewModel.uitextView, lastEditStyle: self.viewModel.lastEditStyle, preserveScrollPosition: self.viewModel.isRemoteUpdate, didChangeSelection: { fromIndex, toIndex in
                 self.viewModel.selection = NSRange(location: fromIndex, length: toIndex - fromIndex)
             }, didChangeText: { range, value in
                 let pendingFormats = self.viewModel.getPendingFormats()

--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -308,6 +308,18 @@ extension ContentViewModel {
             Log.log("custom range set style: [\(range.location):\(toIdx)] -> \(font), value: \(value)", level: .debug)
             content.setStyle(range.location, toIdx, [font.rawValue: value])
         }
+        // Reflect the just-applied style on the toolbar immediately. `custom` applies
+        // `value` uniformly across the range, so the selection now uniformly carries
+        // it. Without this the button state only refreshes on the next selection
+        // change ("reselect to activate"), and — worse — the next tap would send the
+        // same value again (e.g. bold:true on already-bold text), producing a
+        // same-value no-op style op that pollutes undo/redo and syncs needlessly.
+        switch font {
+        case .bold: self.isBold = value
+        case .italic: self.isItalic = value
+        case .underline: self.isUnderline = value
+        case .strike: self.isStrikethrough = value
+        }
     }
 
     /// Undoes the last local change and re-renders the editor from the document.
@@ -740,7 +752,6 @@ extension ContentViewModel {
         }
         if !force, self.didFinishSync {
             guard docString != self.attributeString.string else {
-                print("nothing todo here!")
                 return
             }
         }

--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -70,6 +70,10 @@ class ContentViewModel: ObservableObject {
     private var content: String = ""
     @Published var attributeString = NSMutableAttributedString(string: "")
     @Published var lastEditStyle: EditStyle?
+    /// True when the pending `attributeString` change came from a remote peer, so
+    /// the text view preserves the local scroll position instead of following the
+    /// caret. Set alongside `attributeString` so SwiftUI passes a consistent pair.
+    @Published var isRemoteUpdate = false
     @Published var isBold: Bool = false
     @Published var isItalic: Bool = false
     @Published var isUnderline: Bool = false
@@ -179,7 +183,7 @@ extension ContentViewModel {
             try await self.client.activate()
 
             try await self.client.attach(self.document, [
-                "username": self.localUsername,
+                "username": "iOS",
                 "color": self.localUserColor
             ])
 
@@ -223,6 +227,8 @@ extension ContentViewModel {
 
     func updateText(ranges: [NSValue], value: String, fonts: [CustomFont]) {
         Log.log("updateText: ranges: \(ranges), value: \(value), fonts: \(fonts.sorted(by: { $0.rawValue > $1.rawValue }).map { $0.rawValue }.joined(separator: ", "))", level: .info)
+        // Local edit: let the text view follow the caret (e.g. newline past bottom).
+        self.isRemoteUpdate = false
         try? self.document.update { [weak self] root, _ in
             guard let self, let content = root.content as? JSONText else {
                 Log.log("content not found: \(String(describing: root.content))", level: .warning)
@@ -354,33 +360,40 @@ extension ContentViewModel {
             self?.refreshUndoRedoState()
             if let event = event as? RemoteChangeEvent {
                 // adding text from FE and sync to iOS
-                // receive when peer changes text
+                // receive when peer changes text — preserve local scroll position
+                self?.isRemoteUpdate = true
                 let events = self?.decodeEvent(event)
                 self?.applyEvents(events)
             } else if let event = event as? PresenceChangedEvent {
-                // receive when peer change cursor
+                // peer changed cursor/selection — applying their selection highlight
+                // mutates attributeString, so preserve the local scroll position
+                self?.isRemoteUpdate = true
                 self?.decodeEvent(event.value)
             } else if let event = event as? LocalChangeEvent {
-                // apply local changes for style
+                // apply local changes for style — follow the local caret
+                self?.isRemoteUpdate = false
                 let events = self?.decodeEvent(event)
                 self?.applyEvents(events)
             } else if let _ = event as? SyncStatusChangedEvent {
                 self?.syncTextSnapShot()
             } else if let event = event as? UnwatchedEvent {
-                if let name = event.value.presence["username"] as? String {
-                    var peers = self?.peers ?? []
-                    let previous = peers.first(where: { $0.name == name })
-                    self?.updatePeerSelection(with: previous, peer: nil)
+                // peer left — removing their cursor/selection highlight re-styles the
+                // text, so preserve the local scroll position
+                self?.isRemoteUpdate = true
+                let clientID = event.value.clientID
+                var peers = self?.peers ?? []
+                let previous = peers.first(where: { $0.clientID == clientID })
+                self?.updatePeerSelection(with: previous, peer: nil)
 
-                    if let previous, let uitextView = self?.uitextView {
-                        self?.removePeerCursor(previous, in: uitextView)
-                    }
-                    peers.removeAll(where: { $0.name == name })
-                    self?.update(peers: peers)
-                } else {
-                    Log.log("Can not get this peer name :\(event.value.presence)", level: .error)
+                if let previous, let uitextView = self?.uitextView {
+                    self?.removePeerCursor(previous, in: uitextView)
                 }
+                peers.removeAll(where: { $0.clientID == clientID })
+                self?.update(peers: peers)
             } else if let event = event as? WatchedEvent {
+                // peer joined — applying their cursor/selection highlight re-styles the
+                // text, so preserve the local scroll position
+                self?.isRemoteUpdate = true
                 self?.decodeEvent(event.value)
             }
         }
@@ -410,9 +423,12 @@ extension ContentViewModel {
     func decodeEvent(_ peer: PeerElement) {
         // change selection
         // change cursors
-        let peerUsername = peer.presence["username"] as? String ?? "iOS"
-        if peerUsername == self.localUsername {
-            Log.log("Local change, no update", level: .debug)
+        // Identify self by clientID (actorID), not username: the published username
+        // may differ from `localUsername` and is not unique across clients, so a
+        // username comparison can fail to exclude self (self then shows up as a peer)
+        // or wrongly merge two peers that share a name.
+        if peer.clientID == self.client.id {
+            Log.log("Local presence, no update", level: .debug)
             return
         }
         guard let presencesChanges = peer.presence["selection"] as? [Any] else {
@@ -421,9 +437,9 @@ extension ContentViewModel {
             let color = peer.presence["color"] as? String ?? "anonymous"
             // cache previous peer selection for reuse
             var peers = self.peers
-            let previous = peers.first(where: { $0.name == name })
+            let previous = peers.first(where: { $0.clientID == peer.clientID })
 
-            peers.removeAll(where: { $0.name == name })
+            peers.removeAll(where: { $0.clientID == peer.clientID })
             let nextPeer = Peer(clientID: peer.clientID, name: name, position: .init(), color: color)
             peers.append(
                 nextPeer
@@ -459,9 +475,9 @@ extension ContentViewModel {
 
             // cache previous peer selection for reuse
             var peers = self.peers
-            let previous = peers.first(where: { $0.name == name })
+            let previous = peers.first(where: { $0.clientID == peer.clientID })
 
-            peers.removeAll(where: { $0.name == name })
+            peers.removeAll(where: { $0.clientID == peer.clientID })
             let nextPeer = Peer(clientID: peer.clientID, name: name, position: range, color: color)
             peers.append(
                 nextPeer
@@ -553,42 +569,24 @@ extension ContentViewModel {
     func decodeStyle(from atrributes: [String: Any]?) -> [Style] {
         guard let atrributes else { return [] }
         var styles = [Style]()
-        if let bold = atrributes["bold"] as? String {
-            if bold == "true" {
-                styles.append(.bold)
-            } else if bold == "null" || bold == "false" {
-                styles.append(.unBold)
+        /// A style attribute arrives with value "true" when a peer ADDED the
+        /// style, and with a removal marker when a peer REMOVED it. The removal
+        /// marker is JSON `null` (decoded as `NSNull`), not always the string
+        /// "null"/"false" — so match on the non-"true" case rather than `as? String`,
+        /// otherwise un-bold/italic/underline/strike from a peer is silently dropped.
+        func decode(_ key: String, add: Style, remove: Style) {
+            guard let value = atrributes[key] else { return }
+            if let string = value as? String, string == "true" {
+                styles.append(add)
             } else {
-                Log.log("can not decode style: \(String(describing: atrributes["bold"]))", level: .error)
+                styles.append(remove)
             }
         }
-        if let italic = atrributes["italic"] as? String {
-            if italic == "true" {
-                styles.append(.italic)
-            } else if italic == "null" || italic == "false" {
-                styles.append(.unItalic)
-            } else {
-                Log.log("can not decode style: \(String(describing: atrributes["italic"]))", level: .error)
-            }
-        }
-        if let underline = atrributes["underline"] as? String {
-            if underline == "true" {
-                styles.append(.underline)
-            } else if underline == "null" || underline == "false" {
-                styles.append(.nonUnderline)
-            } else {
-                Log.log("can not decode style: \(String(describing: atrributes["underline"]))", level: .error)
-            }
-        }
-        if let strike = atrributes["strike"] as? String {
-            if strike == "true" {
-                styles.append(.strike)
-            } else if strike == "null" || strike == "false" {
-                styles.append(.unStrike)
-            } else {
-                Log.log("can not decode style: \(String(describing: atrributes["strike"]))", level: .error)
-            }
-        }
+
+        decode("bold", add: .bold, remove: .unBold)
+        decode("italic", add: .italic, remove: .unItalic)
+        decode("underline", add: .underline, remove: .nonUnderline)
+        decode("strike", add: .strike, remove: .unStrike)
 
         Log.log("decoded styles: \(styles)", level: .debug)
         return styles
@@ -904,7 +902,7 @@ extension ContentViewModel {
     func update(peers: [Peer]) {
         Log.log("peers: \(peers.map { $0.name }.sorted().joined(separator: ", "))", level: .debug)
         self.peers = peers
-        for i in peers where i.name != self.localUsername {
+        for i in peers where i.clientID != self.client.id {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 // TODO: - Refactor this to wait until the text is updated after adding cursor without using DispatchQueueMain
                 self.placeCursor(at: i.position.location, in: self.uitextView, with: i)

--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -229,6 +229,9 @@ extension ContentViewModel {
         Log.log("updateText: ranges: \(ranges), value: \(value), fonts: \(fonts.sorted(by: { $0.rawValue > $1.rawValue }).map { $0.rawValue }.joined(separator: ", "))", level: .info)
         // Local edit: let the text view follow the caret (e.g. newline past bottom).
         self.isRemoteUpdate = false
+        // A delete replacing a selection shrinks the text under the still-selected
+        // multi-char range; collapse it to a caret afterwards (see below).
+        let deletedRange = value.isEmpty ? (ranges as? [NSRange])?.first : nil
         try? self.document.update { [weak self] root, _ in
             guard let self, let content = root.content as? JSONText else {
                 Log.log("content not found: \(String(describing: root.content))", level: .warning)
@@ -279,6 +282,20 @@ extension ContentViewModel {
                 att.insert(newAttribute, at: safeLocation)
                 self.updateAttribute(att)
             }
+        }
+        // After deleting a selected range, collapse the selection to a caret so
+        // RTUITextField doesn't re-apply the now-stale multi-char selection (a
+        // UITextRange from the pre-delete, longer text) onto the shortened text and
+        // highlight the wrong span. Collapse to the *end* of the selection, not the
+        // start: RTUITextField.updateUIView treats a delete like a backspace (caret
+        // sits after the removed text) and subtracts the length difference, which
+        // lands the caret back at the selection start — e.g. deleting 8...10 leaves
+        // the caret at 8. Collapsing to the start would double-subtract to 6.
+        if let deletedRange {
+            let end = deletedRange.location + deletedRange.length
+            let caret = min(end, self.uitextView.attributedText.length)
+            self.uitextView.selectedRange = NSRange(location: caret, length: 0)
+            self.selection = nil
         }
     }
 

--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -290,8 +290,10 @@ extension ContentViewModel {
     /// Undoes the last local change and re-renders the editor from the document.
     func undo() {
         guard self.document.canUndo else { return }
+        let textBefore = self.documentPlainText()
         do {
             try self.document.undo()
+            self.deselectIfTextChanged(from: textBefore)
             self.syncTextSnapShot(force: true)
         } catch {
             Log.log("undo failed: \(error.localizedDescription)", level: .warning)
@@ -302,13 +304,35 @@ extension ContentViewModel {
     /// Redoes the last undone local change and re-renders the editor from the document.
     func redo() {
         guard self.document.canRedo else { return }
+        let textBefore = self.documentPlainText()
         do {
             try self.document.redo()
+            self.deselectIfTextChanged(from: textBefore)
             self.syncTextSnapShot(force: true)
         } catch {
             Log.log("redo failed: \(error.localizedDescription)", level: .warning)
         }
         self.refreshUndoRedoState()
+    }
+
+    /// The document's current plain text (no attributes).
+    private func documentPlainText() -> String {
+        (self.document.getRoot().content as? JSONText)?.toString ?? ""
+    }
+
+    /// Collapses the editor selection to a caret when an undo/redo changed the
+    /// text. A style-only revert leaves the text unchanged, so the selection is
+    /// kept; a text revert shifts the characters under a stale selection range,
+    /// which would otherwise highlight the wrong text (e.g. selecting "SDK", then
+    /// undoing "SDK"→"SD" leaving "SD " selected). Android deselects in the same
+    /// case. Collapsing makes `RTUITextField` take its no-selection render path
+    /// instead of re-applying the stale range.
+    private func deselectIfTextChanged(from textBefore: String) {
+        guard self.documentPlainText() != textBefore else { return }
+        let currentLength = self.uitextView.attributedText.length
+        let caret = min(self.uitextView.selectedRange.location, currentLength)
+        self.uitextView.selectedRange = NSRange(location: caret, length: 0)
+        self.selection = nil
     }
 
     /// Syncs the undo/redo button state from the document's history.

--- a/Examples/RichTextEditor/RichTextEditor/RTUITextField.swift
+++ b/Examples/RichTextEditor/RichTextEditor/RTUITextField.swift
@@ -21,6 +21,10 @@ struct RTUITextField: UIViewRepresentable {
     var lastEditStyle: EditStyle?
     var text: NSMutableAttributedString
     let textField: UITextView
+    /// Preserve the scroll position across the re-render. True for remote (peer)
+    /// changes so they don't move the local viewport; false for local edits so the
+    /// view follows the caret (e.g. inserting a newline past the bottom).
+    var preserveScrollPosition: Bool
     var didChangeSelection: (Int, Int) -> Void
     var didChangeText: ([NSValue], String) -> Void
 
@@ -28,6 +32,7 @@ struct RTUITextField: UIViewRepresentable {
         text: NSMutableAttributedString,
         textField: UITextView,
         lastEditStyle: EditStyle?,
+        preserveScrollPosition: Bool,
         didChangeSelection: @escaping (Int, Int) -> Void,
         didChangeText: @escaping ([NSValue], String) -> Void
     ) {
@@ -36,6 +41,7 @@ struct RTUITextField: UIViewRepresentable {
         self.didChangeSelection = didChangeSelection
         self.didChangeText = didChangeText
         self.lastEditStyle = lastEditStyle
+        self.preserveScrollPosition = preserveScrollPosition
     }
 
     func makeUIView(context: Context) -> UITextView {
@@ -65,6 +71,12 @@ struct RTUITextField: UIViewRepresentable {
         }
 
         UIView.setAnimationsEnabled(false)
+        // Preserve the scroll position across this programmatic re-render. Setting
+        // `attributedText` / `selectedRange` makes UITextView scroll to the caret —
+        // for a remote (peer) change that yanks the viewport to wherever the local
+        // caret is (often the end → "jumps to the last line"). Restoring the offset
+        // afterwards keeps a peer's edit from moving what the local user is viewing.
+        let savedContentOffset = uiView.contentOffset
         if let selectedRange = context.coordinator.selectRange, !selectedRange.isEmpty {
             uiView.attributedText = self.text
 
@@ -113,6 +125,11 @@ struct RTUITextField: UIViewRepresentable {
             // Ensure cursor position doesn't exceed text bounds
             currentRange.location = min(currentRange.location, newText.length)
             uiView.selectedRange = currentRange
+        }
+        // Only restore the offset for remote changes. For local edits, let the
+        // text view follow the caret (e.g. a newline pushing past the bottom).
+        if self.preserveScrollPosition {
+            uiView.setContentOffset(savedContentOffset, animated: false)
         }
         UIView.setAnimationsEnabled(true)
     }

--- a/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
@@ -108,6 +108,12 @@ public struct Yorkie_V1_AttachDocumentRequest: Sendable {
 
   public var schemaKey: String = String()
 
+  /// disable_gc declares that this attachment will not produce or consume
+  /// tombstones. The server skips minVV tracking and omits the response
+  /// VersionVector for this client. Use only with Counter / primitive
+  /// workloads; misuse leads to undefined GC behavior on this client.
+  public var disableGc: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -517,6 +523,12 @@ public struct Yorkie_V1_PushPullChangesRequest: Sendable {
   public mutating func clearChangePack() {self._changePack = nil}
 
   public var pushOnly: Bool = false
+
+  /// disable_gc declares that this PushPull will not produce or consume
+  /// tombstones. The server skips minVV tracking and omits the response
+  /// VersionVector. Clients that attached with disableGC=true must keep
+  /// setting this on every subsequent PushPullChanges.
+  public var disableGc: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -945,7 +957,7 @@ extension Yorkie_V1_DeactivateClientResponse: SwiftProtobuf.Message, SwiftProtob
 
 extension Yorkie_V1_AttachDocumentRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AttachDocumentRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}change_pack\0\u{3}schema_key\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}change_pack\0\u{3}schema_key\0\u{3}disable_gc\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -956,6 +968,7 @@ extension Yorkie_V1_AttachDocumentRequest: SwiftProtobuf.Message, SwiftProtobuf.
       case 1: try { try decoder.decodeSingularStringField(value: &self.clientID) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._changePack) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.schemaKey) }()
+      case 4: try { try decoder.decodeSingularBoolField(value: &self.disableGc) }()
       default: break
       }
     }
@@ -975,6 +988,9 @@ extension Yorkie_V1_AttachDocumentRequest: SwiftProtobuf.Message, SwiftProtobuf.
     if !self.schemaKey.isEmpty {
       try visitor.visitSingularStringField(value: self.schemaKey, fieldNumber: 3)
     }
+    if self.disableGc != false {
+      try visitor.visitSingularBoolField(value: self.disableGc, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -982,6 +998,7 @@ extension Yorkie_V1_AttachDocumentRequest: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs.clientID != rhs.clientID {return false}
     if lhs._changePack != rhs._changePack {return false}
     if lhs.schemaKey != rhs.schemaKey {return false}
+    if lhs.disableGc != rhs.disableGc {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1745,7 +1762,7 @@ extension Yorkie_V1_RemoveDocumentResponse: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Yorkie_V1_PushPullChangesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".PushPullChangesRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}document_id\0\u{3}change_pack\0\u{3}push_only\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}document_id\0\u{3}change_pack\0\u{3}push_only\0\u{3}disable_gc\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1757,6 +1774,7 @@ extension Yorkie_V1_PushPullChangesRequest: SwiftProtobuf.Message, SwiftProtobuf
       case 2: try { try decoder.decodeSingularStringField(value: &self.documentID) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._changePack) }()
       case 4: try { try decoder.decodeSingularBoolField(value: &self.pushOnly) }()
+      case 5: try { try decoder.decodeSingularBoolField(value: &self.disableGc) }()
       default: break
       }
     }
@@ -1779,6 +1797,9 @@ extension Yorkie_V1_PushPullChangesRequest: SwiftProtobuf.Message, SwiftProtobuf
     if self.pushOnly != false {
       try visitor.visitSingularBoolField(value: self.pushOnly, fieldNumber: 4)
     }
+    if self.disableGc != false {
+      try visitor.visitSingularBoolField(value: self.disableGc, fieldNumber: 5)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1787,6 +1808,7 @@ extension Yorkie_V1_PushPullChangesRequest: SwiftProtobuf.Message, SwiftProtobuf
     if lhs.documentID != rhs.documentID {return false}
     if lhs._changePack != rhs._changePack {return false}
     if lhs.pushOnly != rhs.pushOnly {return false}
+    if lhs.disableGc != rhs.disableGc {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/yorkie.pb.swift
@@ -759,6 +759,14 @@ public struct Yorkie_V1_RefreshChannelRequest: Sendable {
 
   public var sessionID: String = String()
 
+  /// client_key and metadata are used only on the first call (when session_id
+  /// is empty). The server activates the client and attaches it to the channel
+  /// before refreshing, collapsing ActivateClient + AttachChannel +
+  /// RefreshChannel into a single round trip.
+  public var clientKey: String = String()
+
+  public var metadata: Dictionary<String,String> = [:]
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -770,6 +778,13 @@ public struct Yorkie_V1_RefreshChannelResponse: Sendable {
   // methods supported on all messages.
 
   public var sessionCount: Int64 = 0
+
+  /// client_id and session_id are populated only when the request was a
+  /// first-call (i.e. session_id was empty). Subsequent heartbeats leave
+  /// these empty.
+  public var clientID: String = String()
+
+  public var sessionID: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2282,7 +2297,7 @@ extension Yorkie_V1_DetachChannelResponse: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Yorkie_V1_RefreshChannelRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RefreshChannelRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}channel_key\0\u{3}session_id\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}client_id\0\u{3}channel_key\0\u{3}session_id\0\u{3}client_key\0\u{1}metadata\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2293,6 +2308,8 @@ extension Yorkie_V1_RefreshChannelRequest: SwiftProtobuf.Message, SwiftProtobuf.
       case 1: try { try decoder.decodeSingularStringField(value: &self.clientID) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.channelKey) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.sessionID) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.clientKey) }()
+      case 5: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.metadata) }()
       default: break
       }
     }
@@ -2308,6 +2325,12 @@ extension Yorkie_V1_RefreshChannelRequest: SwiftProtobuf.Message, SwiftProtobuf.
     if !self.sessionID.isEmpty {
       try visitor.visitSingularStringField(value: self.sessionID, fieldNumber: 3)
     }
+    if !self.clientKey.isEmpty {
+      try visitor.visitSingularStringField(value: self.clientKey, fieldNumber: 4)
+    }
+    if !self.metadata.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.metadata, fieldNumber: 5)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2315,6 +2338,8 @@ extension Yorkie_V1_RefreshChannelRequest: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs.clientID != rhs.clientID {return false}
     if lhs.channelKey != rhs.channelKey {return false}
     if lhs.sessionID != rhs.sessionID {return false}
+    if lhs.clientKey != rhs.clientKey {return false}
+    if lhs.metadata != rhs.metadata {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2322,7 +2347,7 @@ extension Yorkie_V1_RefreshChannelRequest: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Yorkie_V1_RefreshChannelResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RefreshChannelResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_count\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_count\0\u{3}client_id\0\u{3}session_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2331,6 +2356,8 @@ extension Yorkie_V1_RefreshChannelResponse: SwiftProtobuf.Message, SwiftProtobuf
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt64Field(value: &self.sessionCount) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.clientID) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.sessionID) }()
       default: break
       }
     }
@@ -2340,11 +2367,19 @@ extension Yorkie_V1_RefreshChannelResponse: SwiftProtobuf.Message, SwiftProtobuf
     if self.sessionCount != 0 {
       try visitor.visitSingularInt64Field(value: self.sessionCount, fieldNumber: 1)
     }
+    if !self.clientID.isEmpty {
+      try visitor.visitSingularStringField(value: self.clientID, fieldNumber: 2)
+    }
+    if !self.sessionID.isEmpty {
+      try visitor.visitSingularStringField(value: self.sessionID, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Yorkie_V1_RefreshChannelResponse, rhs: Yorkie_V1_RefreshChannelResponse) -> Bool {
     if lhs.sessionCount != rhs.sessionCount {return false}
+    if lhs.clientID != rhs.clientID {return false}
+    if lhs.sessionID != rhs.sessionID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/yorkie/v1/yorkie.proto
+++ b/Sources/API/V1/yorkie/v1/yorkie.proto
@@ -251,10 +251,21 @@ message RefreshChannelRequest {
   string client_id = 1;
   string channel_key = 2;
   string session_id = 3;
+  // client_key and metadata are used only on the first call (when session_id
+  // is empty). The server activates the client and attaches it to the channel
+  // before refreshing, collapsing ActivateClient + AttachChannel +
+  // RefreshChannel into a single round trip.
+  string client_key = 4;
+  map<string, string> metadata = 5;
 }
 
 message RefreshChannelResponse {
   int64 session_count = 1;
+  // client_id and session_id are populated only when the request was a
+  // first-call (i.e. session_id was empty). Subsequent heartbeats leave
+  // these empty.
+  string client_id = 2;
+  string session_id = 3;
 }
 
 // PeekChannel reads the current session_count of a channel without creating

--- a/Sources/API/V1/yorkie/v1/yorkie.proto
+++ b/Sources/API/V1/yorkie/v1/yorkie.proto
@@ -68,6 +68,11 @@ message AttachDocumentRequest {
   string client_id = 1;
   ChangePack change_pack = 2;
   string schema_key = 3;
+  // disable_gc declares that this attachment will not produce or consume
+  // tombstones. The server skips minVV tracking and omits the response
+  // VersionVector for this client. Use only with Counter / primitive
+  // workloads; misuse leads to undefined GC behavior on this client.
+  bool disable_gc = 4;
 }
 
 message AttachDocumentResponse {
@@ -169,6 +174,11 @@ message PushPullChangesRequest {
   string document_id = 2;
   ChangePack change_pack = 3;
   bool push_only = 4;
+  // disable_gc declares that this PushPull will not produce or consume
+  // tombstones. The server skips minVV tracking and omits the response
+  // VersionVector. Clients that attached with disableGC=true must keep
+  // setting this on every subsequent PushPullChanges.
+  bool disable_gc = 5;
 }
 
 message PushPullChangesResponse {

--- a/Sources/Core/Attachment.swift
+++ b/Sources/Core/Attachment.swift
@@ -29,6 +29,10 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
     var lastHeartbeatTime: TimeInterval
     var pollInterval: TimeInterval
     var pollIntervalPinned: Bool
+    /// Set when the document was attached with `disableGC: true`. The client sets the
+    /// matching wire field on every `PushPullChanges` so the server can skip minVV
+    /// tracking and omit the response version vector. Documents only.
+    var disableGC: Bool
     var remoteWatchStream: YorkieServerStream?
     var watchLoopReconnectTimer: Timer?
     var cancelled: Bool
@@ -42,7 +46,8 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
         watchLoopReconnectTimer: Timer? = nil,
         cancelled: Bool = false,
         pollInterval: TimeInterval = 0,
-        pollIntervalPinned: Bool = false
+        pollIntervalPinned: Bool = false,
+        disableGC: Bool = false
     ) {
         self.resource = resource
         self.resourceID = resourceID
@@ -51,6 +56,7 @@ final class Attachment<R: Attachable>: @unchecked Sendable {
         self.lastHeartbeatTime = Date().timeIntervalSince1970
         self.pollInterval = pollInterval
         self.pollIntervalPinned = pollIntervalPinned
+        self.disableGC = disableGC
         self.watchLoopReconnectTimer = watchLoopReconnectTimer
         self.isDisconnected = false
         self.cancelled = cancelled

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -1599,8 +1599,7 @@ extension Client {
 
         // Register the attachment locally with an empty session id; the first-call
         // refresh below populates it from the server response.
-        self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel,
-                                                                    resourceID: "")
+        self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel, resourceID: "")
 
         // Forward local broadcasts to the server. The Channel publishes a
         // local-broadcast event when its `broadcast` method is called; here we

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -715,249 +715,6 @@ public class Client {
         }
     }
 
-    // MARK: - Channel Methods
-
-    /**
-     * `attachChannel` attaches the given channel to this client.
-     *
-     * The channel is registered locally and the server is notified on the first
-     * ``refreshChannel(_:)`` (the "first-call", carrying `client_key` + `metadata`),
-     * which attaches the session and returns its id. There is no longer a dedicated
-     * AttachChannel RPC — the lifecycle is consolidated onto RefreshChannel
-     * (yorkie 0.7.10). Detach likewise needs no RPC: the server reclaims the session
-     * via TTL once heartbeats stop.
-     */
-    @discardableResult
-    public func attachChannel(_ channel: Channel) async throws -> Channel {
-        guard self.isActive else {
-            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
-        }
-
-        guard let clientID = self.id else {
-            throw YorkieError(code: .errUnexpected, message: "Invalid client ID! [\(self.id ?? "nil")]")
-        }
-
-        guard channel.getStatus() == .detached else {
-            throw YorkieError(code: .errNotDetached, message: "\(channel.getKey()) is not detached.")
-        }
-
-        channel.setActor(clientID)
-
-        // Register the attachment locally with an empty session id; the first-call
-        // refresh below populates it from the server response.
-        self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel,
-                                                                    resourceID: "")
-
-        // Forward local broadcasts to the server. The Channel publishes a
-        // local-broadcast event when its `broadcast` method is called; here we
-        // bridge that event to the Broadcast RPC. `detachInternal` clears this
-        // callback so a re-attach does not leave a stale forwarder installed.
-        channel.subscribeLocalBroadcast { [weak self, weak channel] event in
-            guard let channel else { return }
-            let topic = event.topic
-            let payload = event.payload
-            let errorFn = event.options?.error
-            let channelKey = channel.getKey()
-
-            Task { [weak self] in
-                guard let self else { return }
-                do {
-                    try await self.broadcast(channelKey, topic: topic, payload: payload, options: event.options)
-                } catch {
-                    errorFn?(error)
-                }
-            }
-        }
-
-        do {
-            // First-call refresh attaches the session on the server and populates
-            // the session id and session count.
-            try await self.refreshChannel(channel)
-
-            try self.runWatchLoop(channel.getKey())
-
-            // Start heartbeat timer if not already running
-            self.startHeartbeatTimer()
-
-            Logger.info("[AP] c:\"\(self.key)\" attaches p:\"\(channel.getKey())\"")
-
-            return channel
-        } catch {
-            // Roll back the local registration if the first-call attach failed.
-            try? self.detachInternal(channel.getKey())
-            channel.setStatus(.detached)
-            Logger.error("Failed to attach channel(\(channel.getKey())).", error: error)
-            await self.handleConnectError(error)
-            throw error
-        }
-    }
-
-    /**
-     * `detachChannel` detaches the given channel from this client.
-     *
-     * This is a local cleanup only: there is no DetachChannel RPC. The server
-     * reclaims the session via TTL once heartbeats stop (RefreshChannel-only
-     * lifecycle, yorkie 0.7.10).
-     */
-    @discardableResult
-    public func detachChannel(_ channel: Channel) async throws -> Channel {
-        guard self.isActive else {
-            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
-        }
-
-        guard self.getChannelAttachment(channel.getKey()) != nil else {
-            throw YorkieError(code: .errNotAttached, message: "\(channel.getKey()) is not attached when \(#function).")
-        }
-
-        // NOTE: JS awaits `attachment.waitForSyncComplete()` before tearing down so an
-        // in-flight first-call refresh cannot re-create the session after detach. iOS
-        // does not need that barrier: `Client`/`Channel` are `@MainActor`, and a refresh
-        // suspended at its await re-checks `getChannelAttachment` after resuming (see
-        // `refreshChannel`), so it cannot mutate channel state post-detach. The only
-        // residue is a server session reclaimed by TTL if detach lands inside the
-        // first-call window — heartbeats have already stopped, so it does expire.
-        try self.detachInternal(channel.getKey())
-        channel.setStatus(.detached)
-
-        Logger.info("[DP] c:\"\(self.key)\" detaches p:\"\(channel.getKey())\" (local)")
-
-        return channel
-    }
-
-    /**
-     * `refreshChannel` sends a heartbeat to keep the channel session alive, and on
-     * the first call (when no session id is held yet) attaches the session on the
-     * server by carrying `client_key` + `metadata`. It also recovers transparently
-     * when the server has reclaimed the session.
-     */
-    private func refreshChannel(_ channel: Channel) async throws {
-        guard let clientID = self.id else {
-            return
-        }
-
-        guard let attachment = getChannelAttachment(channel.getKey()) else {
-            return
-        }
-
-        // First call: no session id yet, so carry `client_key` + `metadata` so the
-        // server activates/attaches and returns a session id. The server ignores
-        // these fields once a session id is established.
-        let isFirstCall = attachment.resourceID.isEmpty
-
-        var refreshRequest = RefreshChannelRequest()
-        refreshRequest.clientID = clientID
-        refreshRequest.channelKey = channel.getKey()
-        refreshRequest.sessionID = attachment.resourceID
-        if isFirstCall {
-            refreshRequest.clientKey = self.key
-            refreshRequest.metadata = self.metadata
-        }
-
-        let refreshResponse = await self.yorkieService.refreshChannel(request: refreshRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
-
-        // A detach (or deactivate) may have run while the RPC was suspended at the
-        // await. Drop late responses/errors so we don't resurrect events on a channel
-        // the app considers gone. Mirrors the JS `!deactivating && !isDetaching` guard
-        // around both the success and error publishes.
-        let stillAttached = self.getChannelAttachment(channel.getKey()) != nil
-
-        if let error = refreshResponse.error {
-            // The server reclaimed our session (TTL expiry, restart, etc.). Clear the
-            // local session id so the next refresh re-enters the first-call branch and
-            // re-attaches transparently; do not surface this to the caller.
-            if isErrorCode(error, YorkieError.Code.errSessionNotFound.rawValue) {
-                Logger.info("[RP] c:\"\(self.key)\" session expired for p:\"\(channel.getKey())\", re-attaching")
-                channel.setSessionID("")
-                attachment.resourceID = ""
-                return
-            }
-            // Surface non-recoverable sync errors to channel subscribers so a UI layer
-            // can render an error state — but only while still attached, so a detach
-            // mid-flight doesn't flash a spurious error. A later successful event
-            // implies recovery (there is no separate "recovered" event).
-            if stillAttached {
-                channel.publish(ChannelSyncErrorEvent(error: error, method: "RefreshChannel"))
-            }
-            throw self.handleErrorResponse(error, defaultMessage: "Unknown refresh channel error")
-        }
-
-        // Tolerate an empty (non-error) heartbeat ack, and drop a late response whose
-        // channel was detached while the RPC was in flight.
-        guard stillAttached, let message = refreshResponse.message else {
-            return
-        }
-
-        if isFirstCall, !message.sessionID.isEmpty {
-            // Defer the Attached transition until a real session id arrives. An empty
-            // one (protocol drift / partial response) leaves the channel Detached so
-            // the next tick re-enters the first-call branch instead of flapping.
-            channel.setSessionID(message.sessionID)
-            attachment.resourceID = message.sessionID
-            channel.setStatus(.attached)
-        }
-
-        let previousSessionCount = channel.getSessionCount()
-        if channel.updateSessionCount(Int(message.sessionCount), 0), channel.getSessionCount() != previousSessionCount {
-            channel.publish(ChannelPresenceEvent(type: .presenceChanged, count: channel.getSessionCount()))
-        }
-        attachment.lastHeartbeatTime = Date().timeIntervalSince1970
-    }
-
-    /**
-     * `startHeartbeatTimer` starts the periodic heartbeat timer for all attached channels.
-     */
-    private func startHeartbeatTimer() {
-        guard self.channelHeartbeatTimer == nil else {
-            return // Timer already running
-        }
-
-        self.channelHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: self.channelHeartbeatInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                guard let self = self else { return }
-                await self.sendHeartbeats()
-            }
-        }
-    }
-
-    /**
-     * `sendHeartbeats` sends heartbeats for all attached channels.
-     */
-    private func sendHeartbeats() async {
-        for (_, attachment) in self.attachmentMap {
-            if let channelAttachment = attachment as? Attachment<Channel> {
-                // Only send heartbeats for realtime channels
-                if channelAttachment.resource.isRealtime() {
-                    let now = Date().timeIntervalSince1970
-                    if now - channelAttachment.lastHeartbeatTime >= self.channelHeartbeatInterval {
-                        do {
-                            try await self.refreshChannel(channelAttachment.resource)
-                        } catch {
-                            Logger.error("Failed heartbeat for channel(\(channelAttachment.resource.getKey())).", error: error)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * `syncChannel` manually refreshes the channel count for manual mode channels.
-     * Returns the updated count.
-     */
-    @discardableResult
-    public func syncChannel(_ channel: Channel) async throws -> Int {
-        guard self.isActive else {
-            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
-        }
-
-        guard let attachment = getChannelAttachment(channel.getKey()) else {
-            throw YorkieError(code: .errNotAttached, message: "\(channel.getKey()) is not attached")
-        }
-
-        try await self.refreshChannel(attachment.resource)
-        return attachment.resource.getSessionCount()
-    }
-
     /**
      * `getCondition` returns the condition of this client.
      */
@@ -1808,5 +1565,251 @@ private extension Client {
         }
         let reason = errorMetadataOf(error: connectError)["reason"] ?? ""
         channel.publish(ChannelAuthErrorEvent(reason: reason, method: method))
+    }
+}
+
+
+// MARK: - Channel Methods
+
+extension Client {
+    /**
+     * `attachChannel` attaches the given channel to this client.
+     *
+     * The channel is registered locally and the server is notified on the first
+     * ``refreshChannel(_:)`` (the "first-call", carrying `client_key` + `metadata`),
+     * which attaches the session and returns its id. There is no longer a dedicated
+     * AttachChannel RPC — the lifecycle is consolidated onto RefreshChannel
+     * (yorkie 0.7.10). Detach likewise needs no RPC: the server reclaims the session
+     * via TTL once heartbeats stop.
+     */
+    @discardableResult
+    public func attachChannel(_ channel: Channel) async throws -> Channel {
+        guard self.isActive else {
+            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
+        }
+
+        guard let clientID = self.id else {
+            throw YorkieError(code: .errUnexpected, message: "Invalid client ID! [\(self.id ?? "nil")]")
+        }
+
+        guard channel.getStatus() == .detached else {
+            throw YorkieError(code: .errNotDetached, message: "\(channel.getKey()) is not detached.")
+        }
+
+        channel.setActor(clientID)
+
+        // Register the attachment locally with an empty session id; the first-call
+        // refresh below populates it from the server response.
+        self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel,
+                                                                    resourceID: "")
+
+        // Forward local broadcasts to the server. The Channel publishes a
+        // local-broadcast event when its `broadcast` method is called; here we
+        // bridge that event to the Broadcast RPC. `detachInternal` clears this
+        // callback so a re-attach does not leave a stale forwarder installed.
+        channel.subscribeLocalBroadcast { [weak self, weak channel] event in
+            guard let channel else { return }
+            let topic = event.topic
+            let payload = event.payload
+            let errorFn = event.options?.error
+            let channelKey = channel.getKey()
+
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.broadcast(channelKey, topic: topic, payload: payload, options: event.options)
+                } catch {
+                    errorFn?(error)
+                }
+            }
+        }
+
+        do {
+            // First-call refresh attaches the session on the server and populates
+            // the session id and session count.
+            try await self.refreshChannel(channel)
+
+            try self.runWatchLoop(channel.getKey())
+
+            // Start heartbeat timer if not already running
+            self.startHeartbeatTimer()
+
+            Logger.info("[AP] c:\"\(self.key)\" attaches p:\"\(channel.getKey())\"")
+
+            return channel
+        } catch {
+            // Roll back the local registration if the first-call attach failed.
+            try? self.detachInternal(channel.getKey())
+            channel.setStatus(.detached)
+            Logger.error("Failed to attach channel(\(channel.getKey())).", error: error)
+            await self.handleConnectError(error)
+            throw error
+        }
+    }
+
+    /**
+     * `detachChannel` detaches the given channel from this client.
+     *
+     * This is a local cleanup only: there is no DetachChannel RPC. The server
+     * reclaims the session via TTL once heartbeats stop (RefreshChannel-only
+     * lifecycle, yorkie 0.7.10).
+     */
+    @discardableResult
+    public func detachChannel(_ channel: Channel) async throws -> Channel {
+        guard self.isActive else {
+            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
+        }
+
+        guard self.getChannelAttachment(channel.getKey()) != nil else {
+            throw YorkieError(code: .errNotAttached, message: "\(channel.getKey()) is not attached when \(#function).")
+        }
+
+        // NOTE: JS awaits `attachment.waitForSyncComplete()` before tearing down so an
+        // in-flight first-call refresh cannot re-create the session after detach. iOS
+        // does not need that barrier: `Client`/`Channel` are `@MainActor`, and a refresh
+        // suspended at its await re-checks `getChannelAttachment` after resuming (see
+        // `refreshChannel`), so it cannot mutate channel state post-detach. The only
+        // residue is a server session reclaimed by TTL if detach lands inside the
+        // first-call window — heartbeats have already stopped, so it does expire.
+        try self.detachInternal(channel.getKey())
+        channel.setStatus(.detached)
+
+        Logger.info("[DP] c:\"\(self.key)\" detaches p:\"\(channel.getKey())\" (local)")
+
+        return channel
+    }
+
+    /**
+     * `refreshChannel` sends a heartbeat to keep the channel session alive, and on
+     * the first call (when no session id is held yet) attaches the session on the
+     * server by carrying `client_key` + `metadata`. It also recovers transparently
+     * when the server has reclaimed the session.
+     */
+    private func refreshChannel(_ channel: Channel) async throws {
+        guard let clientID = self.id else {
+            return
+        }
+
+        guard let attachment = getChannelAttachment(channel.getKey()) else {
+            return
+        }
+
+        // First call: no session id yet, so carry `client_key` + `metadata` so the
+        // server activates/attaches and returns a session id. The server ignores
+        // these fields once a session id is established.
+        let isFirstCall = attachment.resourceID.isEmpty
+
+        var refreshRequest = RefreshChannelRequest()
+        refreshRequest.clientID = clientID
+        refreshRequest.channelKey = channel.getKey()
+        refreshRequest.sessionID = attachment.resourceID
+        if isFirstCall {
+            refreshRequest.clientKey = self.key
+            refreshRequest.metadata = self.metadata
+        }
+
+        let refreshResponse = await self.yorkieService.refreshChannel(request: refreshRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
+
+        // A detach (or deactivate) may have run while the RPC was suspended at the
+        // await. Drop late responses/errors so we don't resurrect events on a channel
+        // the app considers gone. Mirrors the JS `!deactivating && !isDetaching` guard
+        // around both the success and error publishes.
+        let stillAttached = self.getChannelAttachment(channel.getKey()) != nil
+
+        if let error = refreshResponse.error {
+            // The server reclaimed our session (TTL expiry, restart, etc.). Clear the
+            // local session id so the next refresh re-enters the first-call branch and
+            // re-attaches transparently; do not surface this to the caller.
+            if isErrorCode(error, YorkieError.Code.errSessionNotFound.rawValue) {
+                Logger.info("[RP] c:\"\(self.key)\" session expired for p:\"\(channel.getKey())\", re-attaching")
+                channel.setSessionID("")
+                attachment.resourceID = ""
+                return
+            }
+            // Surface non-recoverable sync errors to channel subscribers so a UI layer
+            // can render an error state — but only while still attached, so a detach
+            // mid-flight doesn't flash a spurious error. A later successful event
+            // implies recovery (there is no separate "recovered" event).
+            if stillAttached {
+                channel.publish(ChannelSyncErrorEvent(error: error, method: "RefreshChannel"))
+            }
+            throw self.handleErrorResponse(error, defaultMessage: "Unknown refresh channel error")
+        }
+
+        // Tolerate an empty (non-error) heartbeat ack, and drop a late response whose
+        // channel was detached while the RPC was in flight.
+        guard stillAttached, let message = refreshResponse.message else {
+            return
+        }
+
+        if isFirstCall, !message.sessionID.isEmpty {
+            // Defer the Attached transition until a real session id arrives. An empty
+            // one (protocol drift / partial response) leaves the channel Detached so
+            // the next tick re-enters the first-call branch instead of flapping.
+            channel.setSessionID(message.sessionID)
+            attachment.resourceID = message.sessionID
+            channel.setStatus(.attached)
+        }
+
+        let previousSessionCount = channel.getSessionCount()
+        if channel.updateSessionCount(Int(message.sessionCount), 0), channel.getSessionCount() != previousSessionCount {
+            channel.publish(ChannelPresenceEvent(type: .presenceChanged, count: channel.getSessionCount()))
+        }
+        attachment.lastHeartbeatTime = Date().timeIntervalSince1970
+    }
+
+    /**
+     * `startHeartbeatTimer` starts the periodic heartbeat timer for all attached channels.
+     */
+    private func startHeartbeatTimer() {
+        guard self.channelHeartbeatTimer == nil else {
+            return // Timer already running
+        }
+
+        self.channelHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: self.channelHeartbeatInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self = self else { return }
+                await self.sendHeartbeats()
+            }
+        }
+    }
+
+    /**
+     * `sendHeartbeats` sends heartbeats for all attached channels.
+     */
+    private func sendHeartbeats() async {
+        for (_, attachment) in self.attachmentMap {
+            if let channelAttachment = attachment as? Attachment<Channel> {
+                // Only send heartbeats for realtime channels
+                if channelAttachment.resource.isRealtime() {
+                    let now = Date().timeIntervalSince1970
+                    if now - channelAttachment.lastHeartbeatTime >= self.channelHeartbeatInterval {
+                        do {
+                            try await self.refreshChannel(channelAttachment.resource)
+                        } catch {
+                            Logger.error("Failed heartbeat for channel(\(channelAttachment.resource.getKey())).", error: error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * `syncChannel` manually refreshes the channel count for manual mode channels.
+     * Returns the updated count.
+     */
+    @discardableResult
+    public func syncChannel(_ channel: Channel) async throws -> Int {
+        guard self.isActive else {
+            throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
+        }
+
+        guard let attachment = getChannelAttachment(channel.getKey()) else {
+            throw YorkieError(code: .errNotAttached, message: "\(channel.getKey()) is not attached")
+        }
+
+        try await self.refreshChannel(attachment.resource)
+        return attachment.resource.getSessionCount()
     }
 }

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -1568,7 +1568,6 @@ private extension Client {
     }
 }
 
-
 // MARK: - Channel Methods
 
 extension Client {

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -719,7 +719,13 @@ public class Client {
 
     /**
      * `attachChannel` attaches the given channel to this client.
-     * It tells the server that this client will track the channel.
+     *
+     * The channel is registered locally and the server is notified on the first
+     * ``refreshChannel(_:)`` (the "first-call", carrying `client_key` + `metadata`),
+     * which attaches the session and returns its id. There is no longer a dedicated
+     * AttachChannel RPC — the lifecycle is consolidated onto RefreshChannel
+     * (yorkie 0.7.10). Detach likewise needs no RPC: the server reclaims the session
+     * via TTL once heartbeats stop.
      */
     @discardableResult
     public func attachChannel(_ channel: Channel) async throws -> Channel {
@@ -737,45 +743,36 @@ public class Client {
 
         channel.setActor(clientID)
 
-        var attachRequest = AttachChannelRequest()
-        attachRequest.clientID = clientID
-        attachRequest.channelKey = channel.getKey()
+        // Register the attachment locally with an empty session id; the first-call
+        // refresh below populates it from the server response.
+        self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel,
+                                                                    resourceID: "")
 
-        do {
-            let attachResponse = await self.yorkieService.attachChannel(request: attachRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
+        // Forward local broadcasts to the server. The Channel publishes a
+        // local-broadcast event when its `broadcast` method is called; here we
+        // bridge that event to the Broadcast RPC. `detachInternal` clears this
+        // callback so a re-attach does not leave a stale forwarder installed.
+        channel.subscribeLocalBroadcast { [weak self, weak channel] event in
+            guard let channel else { return }
+            let topic = event.topic
+            let payload = event.payload
+            let errorFn = event.options?.error
+            let channelKey = channel.getKey()
 
-            guard attachResponse.error == nil, let message = attachResponse.message else {
-                throw self.handleErrorResponse(attachResponse.error, defaultMessage: "Unknown attach channel error")
-            }
-
-            channel.setSessionID(message.sessionID)
-            channel.setStatus(.attached)
-
-            // Initialize count from server
-            _ = channel.updateSessionCount(Int(message.sessionCount), 0)
-
-            self.attachmentMap[channel.getKey()] = Attachment<Channel>(resource: channel,
-                                                                       resourceID: message.sessionID)
-
-            // Forward local broadcasts to the server. The Channel publishes a
-            // local-broadcast event when its `broadcast` method is called; here we
-            // bridge that event to the Broadcast RPC.
-            channel.subscribeLocalBroadcast { [weak self, weak channel] event in
-                guard let channel else { return }
-                let topic = event.topic
-                let payload = event.payload
-                let errorFn = event.options?.error
-                let channelKey = channel.getKey()
-
-                Task { [weak self] in
-                    guard let self else { return }
-                    do {
-                        try await self.broadcast(channelKey, topic: topic, payload: payload, options: event.options)
-                    } catch {
-                        errorFn?(error)
-                    }
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.broadcast(channelKey, topic: topic, payload: payload, options: event.options)
+                } catch {
+                    errorFn?(error)
                 }
             }
+        }
+
+        do {
+            // First-call refresh attaches the session on the server and populates
+            // the session id and session count.
+            try await self.refreshChannel(channel)
 
             try self.runWatchLoop(channel.getKey())
 
@@ -786,6 +783,9 @@ public class Client {
 
             return channel
         } catch {
+            // Roll back the local registration if the first-call attach failed.
+            try? self.detachInternal(channel.getKey())
+            channel.setStatus(.detached)
             Logger.error("Failed to attach channel(\(channel.getKey())).", error: error)
             await self.handleConnectError(error)
             throw error
@@ -794,7 +794,10 @@ public class Client {
 
     /**
      * `detachChannel` detaches the given channel from this client.
-     * It tells the server that this client will no longer track the channel.
+     *
+     * This is a local cleanup only: there is no DetachChannel RPC. The server
+     * reclaims the session via TTL once heartbeats stop (RefreshChannel-only
+     * lifecycle, yorkie 0.7.10).
      */
     @discardableResult
     public func detachChannel(_ channel: Channel) async throws -> Channel {
@@ -802,41 +805,30 @@ public class Client {
             throw YorkieError(code: .errClientNotActivated, message: "\(self.key) is not active")
         }
 
-        guard let clientID = self.id else {
-            throw YorkieError(code: .errUnexpected, message: "Invalid client ID! [\(self.id ?? "nil")]")
-        }
-
-        guard let attachment = getChannelAttachment(channel.getKey()) else {
+        guard self.getChannelAttachment(channel.getKey()) != nil else {
             throw YorkieError(code: .errNotAttached, message: "\(channel.getKey()) is not attached when \(#function).")
         }
 
-        var detachRequest = DetachChannelRequest()
-        detachRequest.clientID = clientID
-        detachRequest.channelKey = channel.getKey()
-        detachRequest.sessionID = attachment.resourceID
+        // NOTE: JS awaits `attachment.waitForSyncComplete()` before tearing down so an
+        // in-flight first-call refresh cannot re-create the session after detach. iOS
+        // does not need that barrier: `Client`/`Channel` are `@MainActor`, and a refresh
+        // suspended at its await re-checks `getChannelAttachment` after resuming (see
+        // `refreshChannel`), so it cannot mutate channel state post-detach. The only
+        // residue is a server session reclaimed by TTL if detach lands inside the
+        // first-call window — heartbeats have already stopped, so it does expire.
+        try self.detachInternal(channel.getKey())
+        channel.setStatus(.detached)
 
-        do {
-            let detachResponse = await self.yorkieService.detachChannel(request: detachRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
+        Logger.info("[DP] c:\"\(self.key)\" detaches p:\"\(channel.getKey())\" (local)")
 
-            guard detachResponse.error == nil else {
-                throw self.handleErrorResponse(detachResponse.error, defaultMessage: "Unknown detach channel error")
-            }
-
-            try self.detachInternal(channel.getKey())
-            channel.setStatus(.detached)
-
-            Logger.info("[DP] c:\"\(self.key)\" detaches p:\"\(channel.getKey())\"")
-
-            return channel
-        } catch {
-            Logger.error("Failed to detach channel(\(channel.getKey())).", error: error)
-            await self.handleConnectError(error)
-            throw error
-        }
+        return channel
     }
 
     /**
-     * `refreshChannel` sends a heartbeat to keep the channel session alive.
+     * `refreshChannel` sends a heartbeat to keep the channel session alive, and on
+     * the first call (when no session id is held yet) attaches the session on the
+     * server by carrying `client_key` + `metadata`. It also recovers transparently
+     * when the server has reclaimed the session.
      */
     private func refreshChannel(_ channel: Channel) async throws {
         guard let clientID = self.id else {
@@ -847,15 +839,61 @@ public class Client {
             return
         }
 
+        // First call: no session id yet, so carry `client_key` + `metadata` so the
+        // server activates/attaches and returns a session id. The server ignores
+        // these fields once a session id is established.
+        let isFirstCall = attachment.resourceID.isEmpty
+
         var refreshRequest = RefreshChannelRequest()
         refreshRequest.clientID = clientID
         refreshRequest.channelKey = channel.getKey()
         refreshRequest.sessionID = attachment.resourceID
+        if isFirstCall {
+            refreshRequest.clientKey = self.key
+            refreshRequest.metadata = self.metadata
+        }
 
         let refreshResponse = await self.yorkieService.refreshChannel(request: refreshRequest, headers: self.authHeader.makeHeader(channel.getFirstKeyPath()))
 
-        guard refreshResponse.error == nil, let message = refreshResponse.message else {
-            throw self.handleErrorResponse(refreshResponse.error, defaultMessage: "Unknown refresh channel error")
+        // A detach (or deactivate) may have run while the RPC was suspended at the
+        // await. Drop late responses/errors so we don't resurrect events on a channel
+        // the app considers gone. Mirrors the JS `!deactivating && !isDetaching` guard
+        // around both the success and error publishes.
+        let stillAttached = self.getChannelAttachment(channel.getKey()) != nil
+
+        if let error = refreshResponse.error {
+            // The server reclaimed our session (TTL expiry, restart, etc.). Clear the
+            // local session id so the next refresh re-enters the first-call branch and
+            // re-attaches transparently; do not surface this to the caller.
+            if isErrorCode(error, YorkieError.Code.errSessionNotFound.rawValue) {
+                Logger.info("[RP] c:\"\(self.key)\" session expired for p:\"\(channel.getKey())\", re-attaching")
+                channel.setSessionID("")
+                attachment.resourceID = ""
+                return
+            }
+            // Surface non-recoverable sync errors to channel subscribers so a UI layer
+            // can render an error state — but only while still attached, so a detach
+            // mid-flight doesn't flash a spurious error. A later successful event
+            // implies recovery (there is no separate "recovered" event).
+            if stillAttached {
+                channel.publish(ChannelSyncErrorEvent(error: error, method: "RefreshChannel"))
+            }
+            throw self.handleErrorResponse(error, defaultMessage: "Unknown refresh channel error")
+        }
+
+        // Tolerate an empty (non-error) heartbeat ack, and drop a late response whose
+        // channel was detached while the RPC was in flight.
+        guard stillAttached, let message = refreshResponse.message else {
+            return
+        }
+
+        if isFirstCall, !message.sessionID.isEmpty {
+            // Defer the Attached transition until a real session id arrives. An empty
+            // one (protocol drift / partial response) leaves the channel Detached so
+            // the next tick re-enters the first-call branch instead of flapping.
+            channel.setSessionID(message.sessionID)
+            attachment.resourceID = message.sessionID
+            channel.setStatus(.attached)
         }
 
         let previousSessionCount = channel.getSessionCount()
@@ -1449,6 +1487,9 @@ public class Client {
             attachment.resource.resetOnlineClients()
             try self.stopWatchLoop(key, with: attachment)
         } else if let attachment = getChannelAttachment(key) {
+            // Tear down the local-broadcast forwarder installed by `attachChannel`
+            // so a re-attach does not leave a stale forwarder behind.
+            attachment.resource.unsubscribeLocalBroadcast()
             try self.stopWatchLoop(key, with: attachment)
         }
 

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -338,7 +338,8 @@ public class Client {
                        _ syncMode: SyncMode = .realtime,
                        _ schema: String = "",
                        initialRoot: [String: JSONValuable?]? = nil,
-                       documentPollInterval: TimeInterval? = nil) async throws -> Document
+                       documentPollInterval: TimeInterval? = nil,
+                       disableGC: Bool = false) async throws -> Document
     {
         // 01. Check if the client is ready to attach documents.
         guard self.isActive else {
@@ -373,6 +374,7 @@ public class Client {
         attachRequest.clientID = clientID
         attachRequest.changePack = Converter.toChangePack(pack: doc.createChangePack())
         attachRequest.schemaKey = schema
+        attachRequest.disableGc = disableGC
         // 02. Attach the document to the client.
         do {
             let docKey = doc.getKey()
@@ -409,7 +411,8 @@ public class Client {
                                                                     syncMode: syncMode,
                                                                     changeEventReceived: false,
                                                                     pollInterval: pollInterval,
-                                                                    pollIntervalPinned: pollIntervalPinned)
+                                                                    pollIntervalPinned: pollIntervalPinned,
+                                                                    disableGC: disableGC)
 
             // Polling mode opens no watch stream; the timer-driven sync loop drives pushpull
             // via needRealtimeSync. Skip waitForInitialization too — no stream to wait for.
@@ -1468,6 +1471,7 @@ public class Client {
         pushPullRequest.changePack = Converter.toChangePack(pack: requestPack)
         pushPullRequest.documentID = attachment.resourceID
         pushPullRequest.pushOnly = syncMode == .realtimePushOnly
+        pushPullRequest.disableGc = attachment.disableGC
 
         do {
             let docKey = doc.getKey()

--- a/Sources/Util/Errors.swift
+++ b/Sources/Util/Errors.swift
@@ -97,6 +97,11 @@ struct YorkieError: Error, CustomStringConvertible {
 
         // ErrTooManySubscribers is returned when the number of subscribers exceeds the limit.
         case errTooManySubscribers = "ErrTooManySubscribers"
+
+        // ErrSessionNotFound is returned when the channel session is not found on the
+        // server (e.g. reclaimed via TTL). The client clears its local session id and
+        // re-attaches transparently on the next first-call RefreshChannel.
+        case errSessionNotFound = "ErrSessionNotFound"
     }
 }
 

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.9"
+let yorkieVersion = "0.7.10"

--- a/Tests/Integration/ChannelRefreshIntegrationTests.swift
+++ b/Tests/Integration/ChannelRefreshIntegrationTests.swift
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Connect
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// Integration tests for the RefreshChannel-only channel lifecycle introduced in
+// yorkie 0.7.10 (#1258). The full RPC round-trip is needed to verify:
+//   - `attachChannel` succeeds via the first-call RefreshChannel path (no AttachChannel RPC).
+//   - `detachChannel` is local-only (no DetachChannel RPC issued).
+//   - A non-recoverable RefreshChannel error publishes `ChannelSyncErrorEvent`.
+//   - `syncChannel` (the public manual-refresh wrapper) works correctly.
+//
+// These tests run against the local tunneled yorkie server (localhost:8080).
+final class ChannelRefreshIntegrationTests: XCTestCase {
+    private let rpcAddress = "http://localhost:8080"
+
+    // MARK: - First-call success path
+
+    // Port of yorkie-js-sdk channel_test.ts "should attach via first-call refresh".
+    //
+    // After `attachChannel` the channel must be `.attached` and hold a non-empty
+    // session id — the session was created by the implicit first-call RefreshChannel
+    // RPC rather than a dedicated AttachChannel call.
+    @MainActor
+    func test_attachChannel_sets_attached_status_and_sessionID_after_first_call_refresh() async throws {
+        // given
+        let channelKey = channelTestKey(self.description)
+        let c = Client(rpcAddress)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+
+        // when
+        _ = try await c.attachChannel(ch)
+        self.addTeardownBlock { try? await c.detachChannel(ch) }
+
+        // then — channel is attached with a real session id from the server
+        XCTAssertEqual(ch.getStatus(), .attached, "channel must be .attached after attachChannel")
+        XCTAssertNotNil(ch.getSessionID(), "channel must have a non-nil session id")
+        XCTAssertFalse(ch.getSessionID()?.isEmpty ?? true, "session id must not be empty")
+    }
+
+    // MARK: - detachChannel is local-only
+
+    // `detachChannel` must succeed without any network call; it only tears down
+    // the local attachment state. The channel transitions to `.detached`.
+    @MainActor
+    func test_detachChannel_transitions_channel_to_detached_without_rpc() async throws {
+        // given
+        let channelKey = channelTestKey(self.description)
+        let c = Client(rpcAddress)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+        _ = try await c.attachChannel(ch)
+
+        // when
+        _ = try await c.detachChannel(ch)
+
+        // then
+        XCTAssertEqual(ch.getStatus(), .detached)
+        // The client no longer tracks the channel
+        XCTAssertFalse(c.has(channelKey))
+    }
+
+    // MARK: - syncChannel (manual refresh)
+
+    // `syncChannel` is the public thin wrapper around `refreshChannel`. After a
+    // successful attach the session count must be >= 1.
+    @MainActor
+    func test_syncChannel_returns_positive_session_count_after_attach() async throws {
+        // given
+        let channelKey = channelTestKey(self.description)
+        let c = Client(rpcAddress)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+        _ = try await c.attachChannel(ch)
+        self.addTeardownBlock { try? await c.detachChannel(ch) }
+
+        // when
+        let count = try await c.syncChannel(ch)
+
+        // then
+        XCTAssertGreaterThanOrEqual(count, 1)
+    }
+
+    // MARK: - Non-recoverable error → ChannelSyncErrorEvent
+
+    // When `refreshChannel` encounters a non-recoverable error (simulated via
+    // mock injection), it must publish a `ChannelSyncErrorEvent` and throw.
+    // Uses `isMockingEnabled: true` + `setMockError` so no real server call is
+    // needed after the initial attach.
+    @MainActor
+    func test_syncChannel_publishes_syncErrorEvent_on_non_recoverable_error() async throws {
+        // given — activate and attach using a real server, then inject a mock error
+        let channelKey = channelTestKey(self.description)
+        let c = Client(rpcAddress, isMockingEnabled: true)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+        _ = try await c.attachChannel(ch)
+        self.addTeardownBlock { try? await c.detachChannel(ch) }
+
+        var capturedSyncError: ChannelSyncErrorEvent?
+        let errorExp = expectation(description: "ChannelSyncErrorEvent published")
+        ch.subscribeAll { event in
+            if let syncErr = event as? ChannelSyncErrorEvent {
+                capturedSyncError = syncErr
+                errorExp.fulfill()
+            }
+        }
+
+        // Inject a non-recoverable error for the next refreshChannel call.
+        // `failedPrecondition` is not in the retryable set and carries no
+        // Yorkie-specific metadata, so the state machine publishes the sync error.
+        c.setMockError(
+            for: YorkieServiceClient.Metadata.Methods.refreshChannel,
+            error: connectError(from: .failedPrecondition)
+        )
+
+        // when — manually trigger a refresh via the public syncChannel API
+        do {
+            _ = try await c.syncChannel(ch)
+            XCTFail("syncChannel must throw when refreshChannel returns an error")
+        } catch {
+            // expected
+        }
+
+        // then — the sync-error event was published
+        await fulfillment(of: [errorExp], timeout: 2.0)
+        XCTAssertEqual(capturedSyncError?.method, "RefreshChannel")
+    }
+
+    // MARK: - Presence count via syncChannel
+
+    // When two clients are attached to the same channel, `syncChannel` on one
+    // of them must return a session count >= 2.
+    @MainActor
+    func test_syncChannel_reflects_second_client_in_session_count() async throws {
+        // given — two clients on the same channel
+        let channelKey = channelTestKey(self.description)
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        self.addTeardownBlock {
+            try? await c1.deactivate()
+            try? await c2.deactivate()
+        }
+
+        let ch1 = try Channel(key: channelKey)
+        let ch2 = try Channel(key: channelKey)
+        _ = try await c1.attachChannel(ch1)
+        self.addTeardownBlock { try? await c1.detachChannel(ch1) }
+        _ = try await c2.attachChannel(ch2)
+        self.addTeardownBlock { try? await c2.detachChannel(ch2) }
+
+        // when — manually poll until c1 sees both sessions
+        var count = 0
+        let deadline = Date().addingTimeInterval(5.0)
+        while Date() < deadline {
+            count = try await c1.syncChannel(ch1)
+            if count >= 2 { break }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        // then
+        XCTAssertGreaterThanOrEqual(count, 2, "syncChannel must return >= 2 when two clients are attached")
+    }
+}
+
+// MARK: - Helpers
+
+/// Builds a unique, server-safe channel key from the test description.
+/// Mirrors the helper in ChannelPollingTests.swift.
+private func channelTestKey(_ description: String) -> String {
+    let uniqueSuffix = UUID().uuidString.lowercased().prefix(8)
+    return String(uniqueSuffix)
+        .appending("-ch-")
+        .appending(
+            description
+                .lowercased()
+                .replacingOccurrences(of: " ", with: "-")
+                .filter { $0.isLetter || $0.isNumber || $0 == "-" }
+                .prefix(40)
+                .description
+        )
+}

--- a/Tests/Integration/ChannelRefreshIntegrationTests.swift
+++ b/Tests/Integration/ChannelRefreshIntegrationTests.swift
@@ -190,6 +190,197 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
         // then
         XCTAssertGreaterThanOrEqual(count, 2, "syncChannel must return >= 2 when two clients are attached")
     }
+
+    // MARK: - Guard / error-branch coverage
+
+    // `attachChannel` must throw `errClientNotActivated` when the client has not
+    // been activated. (~line 1587 in Client.swift)
+    @MainActor
+    func test_attachChannel_throws_errClientNotActivated_when_client_is_not_active() async throws {
+        // given — a client that has never been activated
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress)
+        let ch = try Channel(key: channelKey)
+
+        // when / then
+        do {
+            _ = try await client.attachChannel(ch)
+            XCTFail("attachChannel must throw when the client is not activated")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errClientNotActivated)
+        } catch {
+            XCTFail("expected YorkieError, got \(error)")
+        }
+    }
+
+    // `attachChannel` must throw `errNotDetached` when the channel is already
+    // in the `.attached` state. (~line 1595 in Client.swift)
+    @MainActor
+    func test_attachChannel_throws_errNotDetached_when_channel_is_already_attached() async throws {
+        // given — an active client with an already-attached channel
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+        _ = try await client.attachChannel(ch)
+        self.addTeardownBlock { try? await client.detachChannel(ch) }
+
+        // when — attempt to attach the same channel a second time
+        do {
+            _ = try await client.attachChannel(ch)
+            XCTFail("attachChannel must throw for an already-attached channel")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errNotDetached)
+        } catch {
+            XCTFail("expected YorkieError, got \(error)")
+        }
+    }
+
+    // `detachChannel` must throw `errNotAttached` when the channel has never
+    // been attached to this client. (~line 1662 in Client.swift)
+    @MainActor
+    func test_detachChannel_throws_errNotAttached_for_never_attached_channel() async throws {
+        // given — an active client and a channel that was never attached
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+
+        // when / then
+        do {
+            _ = try await client.detachChannel(ch)
+            XCTFail("detachChannel must throw for a never-attached channel")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errNotAttached)
+        } catch {
+            XCTFail("expected YorkieError, got \(error)")
+        }
+    }
+
+    // `syncChannel` must throw `errNotAttached` when the channel has never been
+    // attached to this client. (~line 1807 in Client.swift)
+    @MainActor
+    func test_syncChannel_throws_errNotAttached_for_never_attached_channel() async throws {
+        // given — an active client and a channel that was never attached
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+
+        // when / then
+        do {
+            _ = try await client.syncChannel(ch)
+            XCTFail("syncChannel must throw for a never-attached channel")
+        } catch let error as YorkieError {
+            XCTAssertEqual(error.code, .errNotAttached)
+        } catch {
+            XCTFail("expected YorkieError, got \(error)")
+        }
+    }
+
+    // When `attachChannel`'s first-call `refreshChannel` fails (simulated via
+    // mock injection), the client must roll back the local registration so the
+    // channel ends up `.detached` and `client.has(channelKey)` returns `false`.
+    // (~lines 1639-1645 in Client.swift)
+    @MainActor
+    func test_attachChannel_rolls_back_on_first_call_refresh_failure() async throws {
+        // given — a mock-enabled client that will reject the first refreshChannel call
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress, isMockingEnabled: true)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+
+        // Inject the error BEFORE attachChannel so the first-call refresh fails immediately.
+        client.setMockError(
+            for: YorkieServiceClient.Metadata.Methods.refreshChannel,
+            error: connectError(from: .failedPrecondition)
+        )
+
+        // when
+        do {
+            _ = try await client.attachChannel(ch)
+            XCTFail("attachChannel must throw when the first-call refresh fails")
+        } catch {
+            // expected — any error is acceptable here
+        }
+
+        // then — the rollback must have run: channel is detached and not tracked
+        XCTAssertEqual(ch.getStatus(), .detached, "channel must be rolled back to .detached")
+        XCTAssertFalse(client.has(channelKey), "client must not track the channel after rollback")
+    }
+
+    // `refreshChannel` must silently clear the session id and return (no throw, no
+    // ChannelSyncErrorEvent) when the server signals `ErrSessionNotFound`. The next
+    // refresh then re-enters the first-call branch to re-attach. (~lines 1722-1725)
+    //
+    // The mock error is built by packing an `ErrorInfo` proto whose `metadata`
+    // carries `"code": "ErrSessionNotFound"` — the same structure the real server
+    // sends and that `isErrorCode(_:_:)` inspects.
+    @MainActor
+    func test_syncChannel_clears_session_and_does_not_throw_on_ErrSessionNotFound() async throws {
+        // given — activate, attach (real server populates the session id), then
+        // swap in a mock that returns ErrSessionNotFound on the next refresh.
+        let channelKey = channelTestKey(self.description)
+        let client = Client(rpcAddress, isMockingEnabled: true)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let ch = try Channel(key: channelKey)
+        _ = try await client.attachChannel(ch)
+        self.addTeardownBlock { try? await client.detachChannel(ch) }
+
+        // Confirm a session id was established by the real first-call refresh.
+        XCTAssertFalse(ch.getSessionID()?.isEmpty ?? true, "session id must be set after attach")
+
+        // Build a ConnectError whose unpacked ErrorInfo carries the Yorkie code.
+        var errorInfo = ErrorInfo()
+        errorInfo.metadata = ["code": YorkieError.Code.errSessionNotFound.rawValue]
+        let payload = try errorInfo.serializedData()
+        let detail = ConnectError.Detail(type: ErrorInfo.protoMessageName, payload: payload)
+        let sessionNotFoundError = ConnectError(code: .notFound, message: "session not found", details: [detail])
+
+        // Verify the helper recognises the injected error as ErrSessionNotFound.
+        XCTAssertTrue(
+            isErrorCode(sessionNotFoundError, YorkieError.Code.errSessionNotFound.rawValue),
+            "pre-condition: isErrorCode must match ErrSessionNotFound"
+        )
+
+        // Subscribe to detect whether a ChannelSyncErrorEvent is incorrectly published.
+        var unexpectedSyncError: ChannelSyncErrorEvent?
+        ch.subscribeAll { event in
+            if let syncErr = event as? ChannelSyncErrorEvent {
+                unexpectedSyncError = syncErr
+            }
+        }
+
+        client.setMockError(
+            for: YorkieServiceClient.Metadata.Methods.refreshChannel,
+            error: sessionNotFoundError
+        )
+
+        // when — syncChannel calls refreshChannel which returns ErrSessionNotFound
+        // The recoverable path must NOT throw and must NOT publish a sync-error event.
+        do {
+            _ = try await client.syncChannel(ch)
+        } catch {
+            XCTFail("syncChannel must not throw for ErrSessionNotFound; got \(error)")
+        }
+
+        // then — session id cleared (re-attach will happen on next heartbeat)
+        XCTAssertTrue(
+            ch.getSessionID()?.isEmpty ?? true,
+            "session id must be cleared so the next refresh re-attaches"
+        )
+        XCTAssertNil(unexpectedSyncError, "ErrSessionNotFound must not publish a ChannelSyncErrorEvent")
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/Integration/ChannelRefreshIntegrationTests.swift
+++ b/Tests/Integration/ChannelRefreshIntegrationTests.swift
@@ -43,15 +43,15 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
     func test_attachChannel_sets_attached_status_and_sessionID_after_first_call_refresh() async throws {
         // given
         let channelKey = channelTestKey(self.description)
-        let c = Client(rpcAddress)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         let ch = try Channel(key: channelKey)
 
         // when
-        _ = try await c.attachChannel(ch)
-        self.addTeardownBlock { try? await c.detachChannel(ch) }
+        _ = try await client.attachChannel(ch)
+        self.addTeardownBlock { try? await client.detachChannel(ch) }
 
         // then — channel is attached with a real session id from the server
         XCTAssertEqual(ch.getStatus(), .attached, "channel must be .attached after attachChannel")
@@ -67,20 +67,20 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
     func test_detachChannel_transitions_channel_to_detached_without_rpc() async throws {
         // given
         let channelKey = channelTestKey(self.description)
-        let c = Client(rpcAddress)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         let ch = try Channel(key: channelKey)
-        _ = try await c.attachChannel(ch)
+        _ = try await client.attachChannel(ch)
 
         // when
-        _ = try await c.detachChannel(ch)
+        _ = try await client.detachChannel(ch)
 
         // then
         XCTAssertEqual(ch.getStatus(), .detached)
         // The client no longer tracks the channel
-        XCTAssertFalse(c.has(channelKey))
+        XCTAssertFalse(client.has(channelKey))
     }
 
     // MARK: - syncChannel (manual refresh)
@@ -91,16 +91,16 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
     func test_syncChannel_returns_positive_session_count_after_attach() async throws {
         // given
         let channelKey = channelTestKey(self.description)
-        let c = Client(rpcAddress)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         let ch = try Channel(key: channelKey)
-        _ = try await c.attachChannel(ch)
-        self.addTeardownBlock { try? await c.detachChannel(ch) }
+        _ = try await client.attachChannel(ch)
+        self.addTeardownBlock { try? await client.detachChannel(ch) }
 
         // when
-        let count = try await c.syncChannel(ch)
+        let count = try await client.syncChannel(ch)
 
         // then
         XCTAssertGreaterThanOrEqual(count, 1)
@@ -116,13 +116,13 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
     func test_syncChannel_publishes_syncErrorEvent_on_non_recoverable_error() async throws {
         // given — activate and attach using a real server, then inject a mock error
         let channelKey = channelTestKey(self.description)
-        let c = Client(rpcAddress, isMockingEnabled: true)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress, isMockingEnabled: true)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         let ch = try Channel(key: channelKey)
-        _ = try await c.attachChannel(ch)
-        self.addTeardownBlock { try? await c.detachChannel(ch) }
+        _ = try await client.attachChannel(ch)
+        self.addTeardownBlock { try? await client.detachChannel(ch) }
 
         var capturedSyncError: ChannelSyncErrorEvent?
         let errorExp = expectation(description: "ChannelSyncErrorEvent published")
@@ -136,14 +136,14 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
         // Inject a non-recoverable error for the next refreshChannel call.
         // `failedPrecondition` is not in the retryable set and carries no
         // Yorkie-specific metadata, so the state machine publishes the sync error.
-        c.setMockError(
+        client.setMockError(
             for: YorkieServiceClient.Metadata.Methods.refreshChannel,
             error: connectError(from: .failedPrecondition)
         )
 
         // when — manually trigger a refresh via the public syncChannel API
         do {
-            _ = try await c.syncChannel(ch)
+            _ = try await client.syncChannel(ch)
             XCTFail("syncChannel must throw when refreshChannel returns an error")
         } catch {
             // expected

--- a/Tests/Integration/DisableGCIntegrationTests.swift
+++ b/Tests/Integration/DisableGCIntegrationTests.swift
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+// Port of yorkie-js-sdk packages/sdk/test/integration/disable_gc_test.ts at v0.7.10.
+//
+// Server-side semantics (skip minVV write, omit response VV) are validated in
+// the yorkie server's own tests. These tests verify the SDK-side contract:
+//   - The option is accepted by `attach`.
+//   - Push-pull succeeds, and counter values converge when the flag is mixed.
+//   - Re-attach without the flag restores normal sync behavior.
+//
+// Tests run against the local tunneled server (localhost:8080). They are
+// structured as @MainActor to match every other integration test in this repo.
+final class DisableGCIntegrationTests: XCTestCase {
+    let rpcAddress = "http://localhost:8080"
+
+    // Ports: "Can attach a Counter document with disableGC and sync without error"
+    @MainActor
+    func test_can_attach_with_disableGC_true_and_sync_without_error() async throws {
+        // given
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let c = Client(rpcAddress)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        // when
+        let doc = Document(key: docKey)
+        try await c.attach(doc, [:], .manual, disableGC: true)
+        self.addTeardownBlock { try? await c.detach(doc) }
+
+        try doc.update { root, _ in
+            root.counter = JSONCounter(value: Int64(0))
+        }
+        try await c.sync()
+
+        // then — document synced successfully; the counter is reachable
+        let value = (doc.getRoot().counter as? JSONCounter<Int64>)?.value
+        XCTAssertEqual(value, 0)
+    }
+
+    // Ports: "Mixed opt-in and opt-out clients converge on the Counter value"
+    @MainActor
+    func test_mixed_disableGC_clients_converge_on_counter_value() async throws {
+        // given
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        self.addTeardownBlock {
+            try? await c1.deactivate()
+            try? await c2.deactivate()
+        }
+
+        // c1 attaches without disableGC (normal GC)
+        let d1 = Document(key: docKey)
+        try await c1.attach(d1, [:], .manual)
+        self.addTeardownBlock { try? await c1.detach(d1) }
+
+        try d1.update { root, _ in
+            root.counter = JSONCounter(value: Int64(0))
+        }
+        try await c1.sync()
+
+        // c2 attaches with disableGC = true
+        let d2 = Document(key: docKey)
+        try await c2.attach(d2, [:], .manual, disableGC: true)
+        self.addTeardownBlock { try? await c2.detach(d2) }
+
+        // when — both clients increment independently
+        try d1.update { root, _ in
+            (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
+        }
+        try d2.update { root, _ in
+            (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
+        }
+
+        try await c1.sync()
+        try await c2.sync()
+        try await c1.sync()
+
+        // then — both converge to 2
+        let v1 = (d1.getRoot().counter as? JSONCounter<Int64>)?.value
+        let v2 = (d2.getRoot().counter as? JSONCounter<Int64>)?.value
+        XCTAssertEqual(v1, 2, "c1 counter must converge to 2")
+        XCTAssertEqual(v2, 2, "c2 counter must converge to 2")
+    }
+
+    // Ports: "Re-attach without disableGC restores normal sync behavior"
+    @MainActor
+    func test_reattach_without_disableGC_restores_normal_sync() async throws {
+        // given
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let c = Client(rpcAddress)
+        try await c.activate()
+        self.addTeardownBlock { try? await c.deactivate() }
+
+        // when — first attach with disableGC = true
+        let d1 = Document(key: docKey)
+        try await c.attach(d1, [:], .manual, disableGC: true)
+        try d1.update { root, _ in
+            root.counter = JSONCounter(value: Int64(0))
+            (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
+        }
+        try await c.sync()
+        try await c.detach(d1)
+
+        // re-attach on a fresh document without the option
+        let d2 = Document(key: docKey)
+        try await c.attach(d2, [:], .manual)
+        self.addTeardownBlock { try? await c.detach(d2) }
+        try d2.update { root, _ in
+            (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
+        }
+        try await c.sync()
+
+        // then — counter accumulated across both sessions
+        let value = (d2.getRoot().counter as? JSONCounter<Int64>)?.value
+        XCTAssertEqual(value, 2, "counter must be 2 after both increments sync")
+    }
+
+    // Additional: the disableGC flag does not prevent remote changes from landing.
+    @MainActor
+    func test_disableGC_client_receives_remote_changes_correctly() async throws {
+        // given
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        self.addTeardownBlock {
+            try? await c1.deactivate()
+            try? await c2.deactivate()
+        }
+
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+
+        // c2 opts out of GC
+        try await c1.attach(d1, [:], .manual)
+        self.addTeardownBlock { try? await c1.detach(d1) }
+        try await c2.attach(d2, [:], .manual, disableGC: true)
+        self.addTeardownBlock { try? await c2.detach(d2) }
+
+        // when — c1 sets a key, then c2 syncs
+        try d1.update { root, _ in
+            root.message = "hello"
+        }
+        try await c1.sync()
+        try await c2.sync()
+
+        // then — c2 received the remote change despite GC being disabled
+        let msg = d2.getRoot().message as? String
+        XCTAssertEqual(msg, "hello")
+    }
+}

--- a/Tests/Integration/DisableGCIntegrationTests.swift
+++ b/Tests/Integration/DisableGCIntegrationTests.swift
@@ -38,19 +38,19 @@ final class DisableGCIntegrationTests: XCTestCase {
     func test_can_attach_with_disableGC_true_and_sync_without_error() async throws {
         // given
         let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
-        let c = Client(rpcAddress)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         // when
         let doc = Document(key: docKey)
-        try await c.attach(doc, [:], .manual, disableGC: true)
-        self.addTeardownBlock { try? await c.detach(doc) }
+        try await client.attach(doc, [:], .manual, disableGC: true)
+        self.addTeardownBlock { try? await client.detach(doc) }
 
         try doc.update { root, _ in
             root.counter = JSONCounter(value: Int64(0))
         }
-        try await c.sync()
+        try await client.sync()
 
         // then — document synced successfully; the counter is reachable
         let value = (doc.getRoot().counter as? JSONCounter<Int64>)?.value
@@ -110,28 +110,28 @@ final class DisableGCIntegrationTests: XCTestCase {
     func test_reattach_without_disableGC_restores_normal_sync() async throws {
         // given
         let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
-        let c = Client(rpcAddress)
-        try await c.activate()
-        self.addTeardownBlock { try? await c.deactivate() }
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
 
         // when — first attach with disableGC = true
         let d1 = Document(key: docKey)
-        try await c.attach(d1, [:], .manual, disableGC: true)
+        try await client.attach(d1, [:], .manual, disableGC: true)
         try d1.update { root, _ in
             root.counter = JSONCounter(value: Int64(0))
             (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
         }
-        try await c.sync()
-        try await c.detach(d1)
+        try await client.sync()
+        try await client.detach(d1)
 
         // re-attach on a fresh document without the option
         let d2 = Document(key: docKey)
-        try await c.attach(d2, [:], .manual)
-        self.addTeardownBlock { try? await c.detach(d2) }
+        try await client.attach(d2, [:], .manual)
+        self.addTeardownBlock { try? await client.detach(d2) }
         try d2.update { root, _ in
             (root.counter as? JSONCounter<Int64>)?.increase(value: 1)
         }
-        try await c.sync()
+        try await client.sync()
 
         // then — counter accumulated across both sessions
         let value = (d2.getRoot().counter as? JSONCounter<Int64>)?.value

--- a/Tests/Unit/Channel/RefreshChannelStateTests.swift
+++ b/Tests/Unit/Channel/RefreshChannelStateTests.swift
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+// Unit tests for the RefreshChannel lifecycle state machine introduced in
+// yorkie 0.7.10 (#1258). `refreshChannel` is a private method on `Client`;
+// these tests exercise the `Channel` state it drives via the public
+// `Channel` API (the observable surface of the state machine).
+//
+// Tests that require the full RPC round-trip (mocked or live) live in
+// `ChannelRefreshIntegrationTests`.
+final class RefreshChannelStateTests: XCTestCase {
+    // MARK: - Initial state
+
+    // After attachChannel registers the channel locally (but before the
+    // first-call RefreshChannel RPC completes) the channel is still
+    // `.detached` with an empty session id.
+    @MainActor
+    func test_channel_is_detached_with_empty_sessionID_before_first_refresh() throws {
+        // given
+        let ch = try Channel(key: "room")
+
+        // then — initial state mirrors the pre-first-call registration
+        XCTAssertEqual(ch.getStatus(), .detached)
+        XCTAssertNil(ch.getSessionID())
+    }
+
+    // MARK: - First-call success → sessionID set + status .attached
+
+    // The `refreshChannel` implementation calls `channel.setSessionID` and
+    // `channel.setStatus(.attached)` on success when `isFirstCall` is true.
+    @MainActor
+    func test_first_call_success_sets_sessionID_and_transitions_to_attached() throws {
+        // given
+        let ch = try Channel(key: "room")
+        XCTAssertEqual(ch.getStatus(), .detached)
+
+        // when — simulate what refreshChannel does after a successful first-call response
+        ch.setSessionID("session-abc")
+        ch.setStatus(.attached)
+
+        // then
+        XCTAssertEqual(ch.getSessionID(), "session-abc")
+        XCTAssertEqual(ch.getStatus(), .attached)
+        XCTAssertTrue(ch.isAttached())
+    }
+
+    // MARK: - ErrSessionNotFound → sessionID cleared, stays locally registered
+
+    // On `ErrSessionNotFound` the server has reclaimed the session. The client
+    // clears the local session id so the next refresh re-enters the first-call
+    // branch. The channel status remains as-is (the attachment is not torn down).
+    @MainActor
+    func test_errSessionNotFound_clears_sessionID_without_changing_status() throws {
+        // given — channel is attached with a known session
+        let ch = try Channel(key: "room")
+        ch.setSessionID("session-xyz")
+        ch.setStatus(.attached)
+
+        // when — simulate what refreshChannel does when errSessionNotFound arrives
+        ch.setSessionID("")
+
+        // then — session cleared, status unchanged
+        XCTAssertEqual(ch.getSessionID(), "")
+        XCTAssertEqual(ch.getStatus(), .attached, "status must not be cleared by session expiry alone")
+    }
+
+    // MARK: - Empty sessionID on first-call response → stays .detached (no flap)
+
+    // When the server returns a success response carrying an empty sessionID
+    // (protocol drift / partial response), the channel must NOT transition to
+    // `.attached`. The next heartbeat tick re-enters the first-call branch.
+    @MainActor
+    func test_empty_sessionID_in_first_call_response_leaves_channel_detached() throws {
+        // given — fresh channel, just like the state between local registration
+        // and the first refresh RPC completing
+        let ch = try Channel(key: "room")
+        XCTAssertEqual(ch.getStatus(), .detached)
+
+        // when — simulate refreshChannel guard: `isFirstCall && !message.sessionID.isEmpty`
+        // The guard is NOT entered because sessionID is empty.
+        let sessionID = ""
+        let isFirstCall = true
+        if isFirstCall, !sessionID.isEmpty {
+            ch.setSessionID(sessionID)
+            ch.setStatus(.attached)
+        }
+
+        // then — channel stays detached; no flap to .attached
+        XCTAssertEqual(ch.getStatus(), .detached)
+        XCTAssertNil(ch.getSessionID(), "session id must remain nil when empty response arrives")
+    }
+
+    // MARK: - Non-recoverable error → ChannelSyncErrorEvent published
+
+    // `refreshChannel` publishes `ChannelSyncErrorEvent` for any error that is
+    // not `errSessionNotFound`, provided the channel is still attached.
+    @MainActor
+    func test_non_recoverable_error_publishes_syncErrorEvent_while_attached() throws {
+        // given — attached channel with a presence subscriber
+        let ch = try Channel(key: "room")
+        ch.setActor("actor-1")
+        ch.setStatus(.attached)
+
+        var capturedError: ChannelSyncErrorEvent?
+        ch.subscribeAll { event in
+            if let syncErr = event as? ChannelSyncErrorEvent {
+                capturedError = syncErr
+            }
+        }
+
+        // when — simulate what refreshChannel does for a non-recoverable error
+        // while `stillAttached` is true
+        let fakeError = YorkieError(code: .errRPC, message: "server exploded")
+        ch.publish(ChannelSyncErrorEvent(error: fakeError, method: "RefreshChannel"))
+
+        // then
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError?.method, "RefreshChannel")
+    }
+
+    // `ChannelSyncErrorEvent` must NOT be published when the channel has
+    // already been detached (stillAttached is false) — a detach mid-flight
+    // must not produce a spurious error event.
+    @MainActor
+    func test_syncErrorEvent_not_published_after_detach() throws {
+        // given — channel is detached
+        let ch = try Channel(key: "room")
+        XCTAssertEqual(ch.getStatus(), .detached)
+
+        var eventCount = 0
+        ch.subscribeAll { _ in eventCount += 1 }
+
+        // when — simulate the `stillAttached` guard: the guard is false, so
+        // refreshChannel skips the publish entirely
+        let stillAttached = false // matches: self.getChannelAttachment(channel.getKey()) != nil
+        if stillAttached {
+            ch.publish(ChannelSyncErrorEvent(
+                error: YorkieError(code: .errRPC, message: "stale error"),
+                method: "RefreshChannel"
+            ))
+        }
+
+        // then
+        XCTAssertEqual(eventCount, 0, "no event should be dispatched after channel is detached")
+    }
+
+    // MARK: - Session count update
+
+    // A successful refresh publishes `ChannelPresenceEvent` when the session
+    // count changes. `updateSessionCount` with seq=0 always accepts the new value.
+    @MainActor
+    func test_presence_event_published_when_session_count_changes() throws {
+        // given
+        let ch = try Channel(key: "room")
+        ch.setStatus(.attached)
+        _ = ch.updateSessionCount(1, 0)
+
+        var presenceEvents: [ChannelPresenceEvent] = []
+        ch.subscribePresenceChange { presenceEvents.append($0) }
+
+        // when — simulate what refreshChannel does on a successful heartbeat
+        // where the count changed from 1 to 2
+        let previousCount = ch.getSessionCount()
+        if ch.updateSessionCount(2, 0), ch.getSessionCount() != previousCount {
+            ch.publish(ChannelPresenceEvent(type: .presenceChanged, count: ch.getSessionCount()))
+        }
+
+        // then
+        XCTAssertEqual(presenceEvents.count, 1)
+        XCTAssertEqual(presenceEvents.first?.count, 2)
+    }
+
+    @MainActor
+    func test_presence_event_not_published_when_session_count_unchanged() throws {
+        // given
+        let ch = try Channel(key: "room")
+        ch.setStatus(.attached)
+        _ = ch.updateSessionCount(2, 0)
+
+        var presenceEvents: [ChannelPresenceEvent] = []
+        ch.subscribePresenceChange { presenceEvents.append($0) }
+
+        // when — same count arrives again (seq=0 triggers update, but count is the same)
+        let previousCount = ch.getSessionCount()
+        if ch.updateSessionCount(2, 0), ch.getSessionCount() != previousCount {
+            ch.publish(ChannelPresenceEvent(type: .presenceChanged, count: ch.getSessionCount()))
+        }
+
+        // then — no event because count didn't change
+        XCTAssertEqual(presenceEvents.count, 0)
+    }
+}

--- a/Tests/Unit/Core/AttachmentDisableGCTests.swift
+++ b/Tests/Unit/Core/AttachmentDisableGCTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+// Unit coverage for the `disableGC` flag introduced in yorkie 0.7.10 (#1265).
+// These tests verify the flag's default value, storage on `Attachment`, and that
+// it propagates through the init path — without touching the network.
+final class AttachmentDisableGCTests: XCTestCase {
+    // MARK: - disableGC default
+
+    @MainActor
+    func test_disableGC_defaults_to_false() {
+        // given
+        let attachment = Attachment(resource: FakeAttachableForGC(), resourceID: "r-1")
+
+        // then
+        XCTAssertFalse(attachment.disableGC)
+    }
+
+    @MainActor
+    func test_disableGC_stores_true_when_set_at_init() {
+        // given / when
+        let attachment = Attachment(resource: FakeAttachableForGC(), resourceID: "r-1", disableGC: true)
+
+        // then
+        XCTAssertTrue(attachment.disableGC)
+    }
+
+    @MainActor
+    func test_disableGC_stores_false_when_explicitly_set_to_false_at_init() {
+        // given / when
+        let attachment = Attachment(resource: FakeAttachableForGC(), resourceID: "r-1", disableGC: false)
+
+        // then
+        XCTAssertFalse(attachment.disableGC)
+    }
+
+    @MainActor
+    func test_disableGC_is_independent_of_syncMode() {
+        // given — realtime mode with disableGC = true
+        let attachment = Attachment(
+            resource: FakeAttachableForGC(),
+            resourceID: "r-1",
+            syncMode: .realtime,
+            disableGC: true
+        )
+
+        // then — the flag is carried independently of sync mode
+        XCTAssertTrue(attachment.disableGC)
+        XCTAssertEqual(attachment.syncMode, .realtime)
+    }
+
+    @MainActor
+    func test_disableGC_is_mutable() {
+        // given
+        let attachment = Attachment(resource: FakeAttachableForGC(), resourceID: "r-1", disableGC: false)
+
+        // when
+        attachment.disableGC = true
+
+        // then
+        XCTAssertTrue(attachment.disableGC)
+    }
+}
+
+// MARK: - Test double
+
+@MainActor
+private final class FakeAttachableForGC: Attachable, @unchecked Sendable {
+    nonisolated func getKey() -> String { "fake-gc" }
+    func getStatus() -> ResourceStatus { .attached }
+    func setActor(_: ActorID) {}
+    func hasLocalChanges() async -> Bool { false }
+    func publish(_: any DocEvent) {}
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.9'
+    image: 'yorkieteam/yorkie:0.7.10'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.9'
+    image: 'yorkieteam/yorkie:0.7.10'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies updates from yorkie-js-sdk v0.7.10.

- **Add disableGC attach option** (js-sdk#1265) — new `disableGC` attach-time flag wired onto `AttachDocumentRequest` and every `PushPullChangesRequest`, stored on `Attachment`. Distinct from the local `DocumentOptions.disableGC` GC toggle.
- **Channel lifecycle via RefreshChannel only** (js-sdk#1258) — channel attach/detach consolidated onto `RefreshChannel`: `attachChannel` registers locally and the server is notified by a first-call refresh (carrying `client_key` + `metadata`, receiving `client_id` + `session_id`); `detachChannel` is local-only (server reclaims the session via TTL); transparent re-attach on `ErrSessionNotFound`; non-recoverable refresh errors surface as a `SyncError` channel event. The proto keeps `AttachChannel`/`DetachChannel` RPCs, so this is wire-compatible with a 0.7.10 server.
- js-sdk#1263 (silence connect-rpc post-success AbortError) is intentionally **skipped** — it's a browser-fetch concern with no Connect-Swift/URLSession analog.

Also included: a refactor moving the `Client` channel methods into an `extension Client` (behaviour-preserving; keeps the class body under SwiftLint's `type_body_length` limit), and a few RichTextEditor example fixes (undo/redo selection handling, remote-collaboration rendering, delete-caret placement, formatting-toolbar state on apply).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Proto regenerated via `buf generate` (pinned plugins); only the intended fields changed.
- Gates: critic review **approved** (wire/CRDT/GC verified against v0.7.10; extension move confirmed semantic-identical); `swift build` + **571 unit tests** green; integration suite green against a live server (the only failures are the environment-only `WebhookIntegrationTests`, which need the `:3004` auth-webhook fixture CI provides). `type_body_length` is 861/1000 after the extension move.
- Lint: CI runs the pinned SwiftFormat 0.55.6 / SwiftLint 0.58.2 (couldn't be fetched in the authoring environment); relying on CI for the authoritative lint pass.
- Follow-ups (non-blocking, from review): tighten the RefreshChannel unit tests to exercise the real path; add a wire round-trip test for the new fields; add a per-attachment in-flight guard to avoid a rare duplicate first-call when a second channel attaches within the heartbeat window.
- Separately tracking a set of pre-existing, upstream (iOS == JS) `JSONText` undo-vs-style limitations; not part of this PR.

**Does this PR introduce a user-facing change?**:

```release-note
Add a `disableGC` option to `Client.attach`, and consolidate the channel lifecycle onto RefreshChannel (channels attach/detach without dedicated AttachChannel/DetachChannel calls and recover transparently from a lost session).
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to attach documents without garbage collection for supported workflows.
  * Improved channel refresh behavior for more reliable realtime connections.
* **Bug Fixes**
  * Fixed participant and peer display updates so names and selections stay accurate.
  * Improved editor scrolling and caret behavior during document updates, undo/redo, and remote edits.
* **Documentation**
  * Updated the changelog with the latest release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->