### PR TITLE
Address CodeRabbit review comments on the 0.7.10 channel lifecycle

### DIFF
--- a/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
+++ b/Examples/RichTextEditor/RichTextEditor/ContentViewModel.swift
@@ -939,14 +939,14 @@ extension ContentViewModel {
     }
 
     func removePeerCursor(_ peer: Peer, in textView: UITextView) {
-        let subviews = textView.subviews.filter { $0.accessibilityLabel == peer.name }
+        let subviews = textView.subviews.filter { $0.accessibilityLabel == peer.clientID }
         for subview in subviews {
             subview.removeFromSuperview()
         }
     }
 
     func placeCursor(at index: Int, in textView: UITextView, with peer: Peer) {
-        let subviews = textView.subviews.filter { $0.accessibilityLabel == peer.name }
+        let subviews = textView.subviews.filter { $0.accessibilityLabel == peer.clientID }
         for subview in subviews {
             subview.removeFromSuperview()
         }
@@ -965,7 +965,9 @@ extension ContentViewModel {
                 frame: CGRect(x: caretRect.origin.x, y: caretRect.origin.y, width: 2, height: caretRect.height),
                 color: color
             )
-            cursor.accessibilityLabel = peer.name
+            // Identify cursor subviews by clientID (unique) so duplicate display
+            // names (e.g. every iOS client shows "iOS") don't collide on removal.
+            cursor.accessibilityLabel = peer.clientID
 
             // Remove old cursor if needed
             textView.subviews.filter { $0.accessibilityLabel == peer.clientID }.forEach { $0.removeFromSuperview() }
@@ -988,7 +990,7 @@ extension ContentViewModel {
                 width: contentView.frame.width + 12,
                 height: contentView.frame.height + 6
             )
-            contentView.accessibilityLabel = peer.name
+            contentView.accessibilityLabel = peer.clientID
             textView.addSubview(contentView)
         }
     }

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -1627,6 +1627,13 @@ extension Client {
             // the session id and session count.
             try await self.refreshChannel(channel)
 
+            // A first-call refresh that returns without a session leaves the channel
+            // `.detached`; treat that as a failed attach (the catch below rolls back)
+            // so callers never receive a "successful" channel without an active session.
+            guard channel.getStatus() == .attached, !(channel.getSessionID()?.isEmpty ?? true) else {
+                throw YorkieError(code: .errUnexpected, message: "RefreshChannel did not establish a session for \(channel.getKey())")
+            }
+
             try self.runWatchLoop(channel.getKey())
 
             // Start heartbeat timer if not already running
@@ -1722,6 +1729,13 @@ extension Client {
                 Logger.info("[RP] c:\"\(self.key)\" session expired for p:\"\(channel.getKey())\", re-attaching")
                 channel.setSessionID("")
                 attachment.resourceID = ""
+                // Re-attach immediately rather than waiting for the next heartbeat. The
+                // retry re-enters as a first-call (session id is now empty); only retry
+                // from a heartbeat refresh (`!isFirstCall`) and while still attached, so a
+                // failing first-call can't recurse and a detached channel is left alone.
+                if !isFirstCall, stillAttached {
+                    try await self.refreshChannel(channel)
+                }
                 return
             }
             // Surface non-recoverable sync errors to channel subscribers so a UI layer

--- a/Tests/Integration/ChannelRefreshIntegrationTests.swift
+++ b/Tests/Integration/ChannelRefreshIntegrationTests.swift
@@ -317,9 +317,12 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
         XCTAssertFalse(client.has(channelKey), "client must not track the channel after rollback")
     }
 
-    // `refreshChannel` must silently clear the session id and return (no throw, no
-    // ChannelSyncErrorEvent) when the server signals `ErrSessionNotFound`. The next
-    // refresh then re-enters the first-call branch to re-attach. (~lines 1722-1725)
+    // `refreshChannel` recovers from `ErrSessionNotFound` without throwing or
+    // publishing a ChannelSyncErrorEvent: it clears the local session id and, when the
+    // error hit a heartbeat refresh, immediately re-attaches via a first-call refresh.
+    // Here the mock returns ErrSessionNotFound for BOTH the heartbeat refresh and the
+    // immediate first-call retry (count: 2), so the channel stays cleared and the
+    // bounded retry does not recurse. (~lines 1728-1740)
     //
     // The mock error is built by packing an `ErrorInfo` proto whose `metadata`
     // carries `"code": "ErrSessionNotFound"` — the same structure the real server
@@ -361,23 +364,27 @@ final class ChannelRefreshIntegrationTests: XCTestCase {
             }
         }
 
+        // Fail both the heartbeat refresh and its immediate first-call retry so the
+        // channel stays cleared (otherwise the retry re-attaches against the server).
         client.setMockError(
             for: YorkieServiceClient.Metadata.Methods.refreshChannel,
-            error: sessionNotFoundError
+            error: sessionNotFoundError,
+            count: 2
         )
 
-        // when — syncChannel calls refreshChannel which returns ErrSessionNotFound
-        // The recoverable path must NOT throw and must NOT publish a sync-error event.
+        // when — syncChannel's refresh and its immediate re-attach retry both hit
+        // ErrSessionNotFound. The recoverable path must NOT throw and must NOT publish
+        // a sync-error event.
         do {
             _ = try await client.syncChannel(ch)
         } catch {
             XCTFail("syncChannel must not throw for ErrSessionNotFound; got \(error)")
         }
 
-        // then — session id cleared (re-attach will happen on next heartbeat)
+        // then — session id stays cleared (both attempts failed; bounded retry didn't recurse)
         XCTAssertTrue(
             ch.getSessionID()?.isEmpty ?? true,
-            "session id must be cleared so the next refresh re-attaches"
+            "session id must be cleared after ErrSessionNotFound"
         )
         XCTAssertNil(unexpectedSyncError, "ErrSessionNotFound must not publish a ChannelSyncErrorEvent")
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses the CodeRabbit review comments left on #263 after it merged.

- **Peer cursor identity (Major)** — cursor subviews were keyed by `Peer.name` for placement/removal, so clients that share a display name (every iOS client publishes `"iOS"`) collided and could remove/show the wrong peer's cursor. Cursor and label subviews are now keyed by `clientID` end-to-end; `name` remains only as the visible label text. (Keeps the intended `"iOS"` display name.)
- **attachChannel without a session (Minor)** — if the first-call `RefreshChannel` returned without a session id, `attachChannel` still started the watch loop and returned a `.detached` channel as "success". It now treats that as a failed attach and rolls back.
- **ErrSessionNotFound recovery (Minor)** — on a session-not-found during a heartbeat refresh, the client now re-attaches immediately via a first-call refresh instead of waiting for the next heartbeat. Bounded: the retry re-enters as a first-call, so it cannot recurse.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Follow-up to the merged 0.7.10 sync (#263). `swift build` + 571 unit tests green; channel integration tests (incl. the updated ErrSessionNotFound recovery test, now mocking both the heartbeat refresh and the immediate retry) green against a live server; example app builds.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
