### PR TITLE
Apply updates from yorkie-js-sdk 0.7.11

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.10
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/182b56ba1f1e8384cbec5e590a00c06dc26c7378/Formula/y/yorkie.rb"
+      # yorkie server v0.7.11
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/93907a8b60d9f97dba0663446d6bebf196779842/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.10
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/182b56ba1f1e8384cbec5e590a00c06dc26c7378/Formula/y/yorkie.rb"
+      # yorkie server v0.7.11
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/93907a8b60d9f97dba0663446d6bebf196779842/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.11] - 2026-07-07
+
+- Introduce treelist to optimize random access in Array in https://github.com/yorkie-team/yorkie-ios-sdk/pull/265
+- Stop accumulating per-Change VV under disableGC in https://github.com/yorkie-team/yorkie-ios-sdk/pull/265
+- Skip bare position nodes in RGATreeList.getLast in https://github.com/yorkie-team/yorkie-ios-sdk/pull/265
+
 ## [v0.7.10] - 2026-06-26
 
 - Add disableGC attach option in https://github.com/yorkie-team/yorkie-ios-sdk/pull/263

--- a/Sources/Core/Client.swift
+++ b/Sources/Core/Client.swift
@@ -397,6 +397,11 @@ public class Client {
                 doc.setSchemaRules(Converter.fromSchemaRules(schemaRules))
             }
 
+            // Record the opt-out decision before applying the attach response so the
+            // first applyChangePack already routes remote changes through the
+            // lamport-only sync path.
+            doc.setDisableGC(disableGC)
+
             let pack = try Converter.fromChangePack(message.changePack)
             try doc.applyChangePack(pack)
 

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -628,9 +628,15 @@ class RGATreeList {
         return previousNode?.positionCreatedAt ?? self.dummyHead.positionCreatedAt
     }
 
-    /// Returns the last element.
+    /// Returns the last element, skipping bare position nodes (created by
+    /// `moveAfter`/`addDeadPosition`) that have no element.
     func getLast() -> CRDTElement {
-        return self.last.value
+        var node = self.last
+        while node.elementEntry == nil, node !== self.dummyHead {
+            guard let prev = node.previous else { break }
+            node = prev
+        }
+        return node.value
     }
 
     /// Returns the POSITION `createdAt` of the last node.

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -50,8 +50,19 @@ final class RGATreeListElementEntry {
 ///
 /// Each node represents a *position slot* in the list, not necessarily a live element.
 /// A *dead position node* has `elementEntry == nil` and its `positionRemovedAt` is set;
-/// it contributes zero to the splay-tree length and is a GC target.
-final class RGATreeListNode: SplayNode<CRDTElement> {
+/// it contributes zero to the index-tree weight and is a GC target.
+final class RGATreeListNode {
+    /// The element value carried by this position slot.
+    ///
+    /// Dead position nodes carry a `null` placeholder; callers must check
+    /// `elementEntry == nil` to detect them rather than inspecting `value`.
+    let value: CRDTElement
+
+    /// The order-statistic index node backing this position in ``RGATreeList``'s
+    /// `nodeMapByIndex`. Created once at construction and cleared when the
+    /// position is physically purged (see ``RGATreeList``).
+    var indexNode: TreeListNode<RGATreeListNode>!
+
     fileprivate var previous: RGATreeListNode?
     fileprivate var next: RGATreeListNode?
 
@@ -73,8 +84,11 @@ final class RGATreeListNode: SplayNode<CRDTElement> {
 
     /// Creates a node wrapping a live element.
     fileprivate init(value: CRDTElement, positionCreatedAt: TimeTicket) {
+        self.value = value
         self.positionCreatedAt = positionCreatedAt
-        super.init(value)
+        // `indexNode` is implicitly nil here, so `self` is fully initialised and
+        // may be captured by its backing index node.
+        self.indexNode = TreeListNode(self)
     }
 
     /// Creates the sentinel dummy-head node.
@@ -84,17 +98,6 @@ final class RGATreeListNode: SplayNode<CRDTElement> {
         let node = RGATreeListNode(value: dummyValue, positionCreatedAt: .initial)
         // Dummy head has no entry; it is never a GC target.
         return node
-    }
-
-    // MARK: SplayNode overrides
-
-    /// Zero for removed elements *and* for dead position nodes.
-    override var length: Int {
-        if self.elementEntry == nil {
-            // Dead position node — contributes no length.
-            return 0
-        }
-        return self.value.isRemoved ? 0 : 1
     }
 
     // MARK: Internal helpers
@@ -111,9 +114,24 @@ final class RGATreeListNode: SplayNode<CRDTElement> {
         return self.positionCreatedAt
     }
 
-    /// Returns `true` when the underlying element has been removed.
-    fileprivate var isRemoved: Bool {
-        return self.value.isRemoved
+    /// Returns `true` for a dead position node (no element) *or* when the
+    /// underlying element has been removed.
+    ///
+    /// This is the weight predicate for ``TreeList``: such nodes contribute
+    /// zero to the live (logical) index. It mirrors the JS `RGATreeListNode.isRemoved`.
+    var isRemoved: Bool {
+        guard let entry = self.elementEntry else {
+            return true
+        }
+        return entry.element.isRemoved
+    }
+
+    /// A debug representation of the node's element, used by ``TreeList/toTestString``.
+    var toTestString: String {
+        guard let entry = self.elementEntry else {
+            return ""
+        }
+        return entry.element.toJSON()
     }
 
     /// Removes the underlying element value at the given time.
@@ -163,6 +181,10 @@ final class RGATreeListNode: SplayNode<CRDTElement> {
     }
 }
 
+// MARK: TreeListValue conformance
+
+extension RGATreeListNode: TreeListValue {}
+
 // MARK: GCChild conformance
 
 extension RGATreeListNode: GCChild {
@@ -199,7 +221,7 @@ extension RGATreeListNode: GCChild {
 class RGATreeList {
     private let dummyHead: RGATreeListNode
     private var last: RGATreeListNode
-    private let nodeMapByIndex: SplayTree<CRDTElement>
+    private let nodeMapByIndex: TreeList<RGATreeListNode>
 
     /// Maps a position node's `positionCreatedAt` to the node itself.
     private var nodeMapByPositionCreatedAt: [TimeTicket: RGATreeListNode]
@@ -210,8 +232,7 @@ class RGATreeList {
     init() {
         self.dummyHead = RGATreeListNode.createDummy()
         self.last = self.dummyHead
-        self.nodeMapByIndex = SplayTree()
-        self.nodeMapByIndex.insert(self.dummyHead)
+        self.nodeMapByIndex = TreeList(self.dummyHead.indexNode)
         self.nodeMapByPositionCreatedAt = [self.dummyHead.positionCreatedAt: self.dummyHead]
         self.elementMapByCreatedAt = [:]
     }
@@ -237,23 +258,25 @@ class RGATreeList {
         return current
     }
 
-    /// Removes `node` from the splay tree and position map, updating `last` if needed.
+    /// Removes `node` from the index tree and position map, updating `last` if needed.
     private func release(node: RGATreeListNode) {
         if self.last === node, let prev = node.previous {
             self.last = prev
         }
 
         node.release()
-        self.nodeMapByIndex.delete(node)
+        self.nodeMapByIndex.delete(node.indexNode)
+        // Break the node <-> index-node cycle so the purged position deallocates.
+        node.indexNode = nil
         self.nodeMapByPositionCreatedAt.removeValue(forKey: node.positionCreatedAt)
     }
 
     // MARK: Core insertion (private)
 
-    /// Inserts a node into the linked list and splay tree after the anchor.
+    /// Inserts a node into the linked list and index tree after the anchor.
     ///
     /// The `node` must have its `elementEntry` set before this call if it is a live node,
-    /// so that `SplayTree.updateWeight` sees the correct `length` during insertion.
+    /// so that ``TreeList`` sees the correct `isRemoved` weight during insertion.
     private func insertNodeIntoStructures(node: RGATreeListNode, after anchor: RGATreeListNode) {
         // Link into doubly-linked list.
         let anchorNext = anchor.next
@@ -266,7 +289,7 @@ class RGATreeList {
             self.last = node
         }
 
-        self.nodeMapByIndex.insert(previousNode: anchor, newNode: node)
+        self.nodeMapByIndex.insertAfter(anchor.indexNode, node.indexNode)
         self.nodeMapByPositionCreatedAt[node.positionCreatedAt] = node
     }
 
@@ -274,7 +297,7 @@ class RGATreeList {
     ///
     /// This is used by `moveAfter` for both the winning and losing LWW paths to create a
     /// new position slot. The node is inserted using RGA ordering (skipping concurrent nodes
-    /// with later timestamps) and added to the splay tree and position map.
+    /// with later timestamps) and added to the index tree and position map.
     ///
     /// - Parameters:
     ///   - prevPositionCreatedAt: The `positionCreatedAt` of the node to insert after.
@@ -286,7 +309,7 @@ class RGATreeList {
             throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(prevPositionCreatedAt)")
         }
         let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: executedAt)
-        // Use a null placeholder as the SplayNode value — callers must check `elementEntry == nil`
+        // Use a null placeholder as the node value — callers must check `elementEntry == nil`
         // to detect bare position nodes rather than accessing `.value` directly.
         let placeholder = Primitive(value: .null, createdAt: executedAt)
         let node = RGATreeListNode(value: placeholder, positionCreatedAt: executedAt)
@@ -326,8 +349,8 @@ class RGATreeList {
         let anchor = self.findNextBeforeExecutedAt(node: anchorNode, executedAt: et)
         let newNode = RGATreeListNode(value: value, positionCreatedAt: value.createdAt)
 
-        // Create and attach the entry BEFORE splay-tree insertion so that `newNode.length`
-        // returns 1 when `updateWeight` is called during `insertNodeIntoStructures`.
+        // Create and attach the entry BEFORE index-tree insertion so that `newNode.isRemoved`
+        // is false (weight 1) when the node is inserted in `insertNodeIntoStructures`.
         let entry = RGATreeListElementEntry(element: value, positionNode: newNode)
         newNode.setElementEntry(entry)
         self.elementMapByCreatedAt[value.createdAt] = entry
@@ -351,7 +374,7 @@ class RGATreeList {
     /// - **LWW winner**: Creates a new position node at `prevCreatedAt`, wires up the entry,
     ///   kills the old position node (sets `positionRemovedAt`), and returns it for GC.
     /// - **LWW loser**: Creates a bare dead position node at `prevCreatedAt` (no entry,
-    ///   `positionRemovedAt = executedAt`), splays it, and returns it for GC.
+    ///   `positionRemovedAt = executedAt`), refreshes its index weight, and returns it for GC.
     ///   Returns `nil` only when the node was already processed (idempotency check).
     ///
     /// No cascade re-linking is performed — that is not in the JS specification.
@@ -382,7 +405,7 @@ class RGATreeList {
             // Still create a bare dead position node so GC pairs are complete.
             let deadPosNode = try self.insertPositionAfter(prevPositionCreatedAt: prevCreatedAt, executedAt: executedAt)
             deadPosNode.markDead(at: executedAt)
-            self.nodeMapByIndex.splayNode(deadPosNode)
+            self.nodeMapByIndex.updateWeight(deadPosNode.indexNode)
             return deadPosNode
         }
 
@@ -396,7 +419,7 @@ class RGATreeList {
         let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: executedAt)
         let newPosNode = RGATreeListNode(value: entry.element, positionCreatedAt: executedAt)
 
-        // Wire the entry BEFORE splay-tree insertion so `newPosNode.length == 1`.
+        // Wire the entry BEFORE index-tree insertion so `newPosNode.isRemoved` is false (weight 1).
         newPosNode.setElementEntry(entry)
         entry.positionNode = newPosNode
         entry.posMovedAt = executedAt
@@ -404,14 +427,14 @@ class RGATreeList {
 
         self.insertNodeIntoStructures(node: newPosNode, after: anchor)
 
-        // Kill the old position node. Keep it in the splay tree with length 0
-        // (re-splay to refresh weights) rather than deleting it — JS keeps dead
-        // position nodes splayed until GC purge, and a subsequent insert/append
-        // may still use this node as its anchor (e.g. when it is `last` after a
+        // Kill the old position node. Keep it in the index tree with weight 0
+        // (refresh weights) rather than deleting it — JS keeps dead position
+        // nodes in the tree until GC purge, and a subsequent insert/append may
+        // still use this node as its anchor (e.g. when it is `last` after a
         // tail move). Deleting it here would leave that anchor unresolvable in
         // the index tree, so the appended element would never be indexed.
         oldPosNode.markDead(at: executedAt)
-        self.nodeMapByIndex.splayNode(oldPosNode)
+        self.nodeMapByIndex.updateWeight(oldPosNode.indexNode)
         // NOTE: do NOT reassign `last` here. JS leaves `last` pointing at the
         // now-dead slot when the moved element was the tail, so that subsequent
         // ops emit the same position-identity anchor as JS/Go peers. The
@@ -427,7 +450,7 @@ class RGATreeList {
     ///
     /// Called by `fromArray` when decoding a node that has `positionCreatedAt` +
     /// `positionRemovedAt` but **no** element (the JS wire format for dead nodes).
-    /// Inserts the node into the splay tree and updates `last`, exactly as JS `addDeadPosition` does.
+    /// Inserts the node into the index tree and updates `last`, exactly as JS `addDeadPosition` does.
     func addDeadPosition(
         positionCreatedAt: TimeTicket,
         positionRemovedAt: TimeTicket
@@ -442,8 +465,8 @@ class RGATreeList {
         node.previous = prevNode
         // Update last (mirrors JS: `this.last = node`).
         self.last = node
-        // Insert into splay tree (mirrors JS: `this.nodeMapByIndex.insertAfter(prevNode, node)`).
-        self.nodeMapByIndex.insert(previousNode: prevNode, newNode: node)
+        // Insert into index tree (mirrors JS: `this.nodeMapByIndex.insertAfter(prevNode.indexNode, node.indexNode)`).
+        self.nodeMapByIndex.insertAfter(prevNode.indexNode, node.indexNode)
         self.nodeMapByPositionCreatedAt[positionCreatedAt] = node
     }
 
@@ -462,7 +485,7 @@ class RGATreeList {
         let anchor = self.findNextBeforeExecutedAt(node: prevNode, executedAt: positionCreatedAt)
         let node = RGATreeListNode(value: value, positionCreatedAt: positionCreatedAt)
 
-        // Set entry BEFORE splay-tree insertion so `node.length == 1`.
+        // Set entry BEFORE index-tree insertion so `node.isRemoved` is false (weight 1).
         let entry = RGATreeListElementEntry(element: value, positionNode: node)
         entry.posMovedAt = positionMovedAt
         node.setElementEntry(entry)
@@ -498,7 +521,7 @@ class RGATreeList {
         guard let entry = self.elementMapByCreatedAt[createdAt] else {
             throw YorkieError(code: .errInvalidArgument, message: "can't find the given node: \(createdAt)")
         }
-        return String(self.nodeMapByIndex.indexOf(entry.positionNode))
+        return String(self.nodeMapByIndex.indexOf(entry.positionNode.indexNode))
     }
 
     // MARK: Deletion
@@ -512,7 +535,7 @@ class RGATreeList {
         let node = entry.positionNode
         let alreadyRemoved = node.isRemoved
         if node.remove(executedAt), !alreadyRemoved {
-            self.nodeMapByIndex.splayNode(node)
+            self.nodeMapByIndex.updateWeight(node.indexNode)
         }
         return node.value
     }
@@ -522,7 +545,7 @@ class RGATreeList {
     func deleteByIndex(index: Int, executedAt: TimeTicket) throws -> CRDTElement {
         let node = try self.getNode(index: index)
         if node.remove(executedAt) {
-            self.nodeMapByIndex.splayNode(node)
+            self.nodeMapByIndex.updateWeight(node.indexNode)
         }
         return node.value
     }
@@ -544,12 +567,13 @@ class RGATreeList {
         guard let node = self.nodeMapByPositionCreatedAt[positionCreatedAt] else {
             return
         }
-        // Dead nodes may or may not be in nodeMapByIndex; use delete which is safe either way.
         if self.last === node, let prev = node.previous {
             self.last = prev
         }
         node.release()
-        self.nodeMapByIndex.delete(node)
+        self.nodeMapByIndex.delete(node.indexNode)
+        // Break the node <-> index-node cycle so the purged position deallocates.
+        node.indexNode = nil
         self.nodeMapByPositionCreatedAt.removeValue(forKey: positionCreatedAt)
     }
 
@@ -575,16 +599,12 @@ class RGATreeList {
 
     // MARK: Node access by index
 
-    /// Returns the position node at `index` in the splay tree.
+    /// Returns the position node at `index` in the index tree.
     func getNode(index: Int) throws -> RGATreeListNode {
         guard index < self.length else {
             throw YorkieError(code: .errInvalidArgument, message: "length is smaller than or equal to: \(index)")
         }
-        let node = try self.nodeMapByIndex.findForArray(index)
-        guard let rgaNode = node as? RGATreeListNode else {
-            throw YorkieError(code: .errInvalidArgument, message: "failed to find the given index: \(index)")
-        }
-        return rgaNode
+        return try self.nodeMapByIndex.find(index).getValue()
     }
 
     // MARK: Previous / last

--- a/Sources/Document/CRDT/RGATreeList.swift
+++ b/Sources/Document/CRDT/RGATreeList.swift
@@ -237,6 +237,22 @@ class RGATreeList {
         self.elementMapByCreatedAt = [:]
     }
 
+    deinit {
+        // ARC cannot collect the intra-node reference cycles on its own: the
+        // doubly-linked list (`previous`/`next`) and each node's `indexNode`
+        // (which strongly holds the node back via `TreeListNode.value`) are all
+        // strong. Walk the list once at teardown and clear these so the whole
+        // node graph deallocates with the list rather than leaking.
+        var node: RGATreeListNode? = self.dummyHead
+        while let current = node {
+            let next = current.next
+            current.previous = nil
+            current.next = nil
+            current.indexNode = nil
+            node = next
+        }
+    }
+
     // MARK: Length
 
     /// The number of live (non-removed) elements in this list.

--- a/Sources/Document/Change/ChangeID.swift
+++ b/Sources/Document/Change/ChangeID.swift
@@ -101,6 +101,32 @@ struct ChangeID {
     }
 
     /**
+     * `syncLamport` advances the lamport clock against the given ID without
+     * merging its version vector into the receiver's. It is the counterpart of
+     * `syncClocks` for attachments that have opted out of GC participation: the
+     * receiver does not need other actors' entries in its VV because it never
+     * produces or consumes tombstones, and dropping them keeps each subsequent
+     * local Change's VV at O(1) instead of O(num_actors). Lamport must still
+     * advance so that TimeTickets produced locally remain ordered against
+     * remote operations.
+     */
+    @discardableResult
+    func syncLamport(with other: ChangeID) -> ChangeID {
+        if other.hasClocks() == false {
+            return self
+        }
+        let lamport = other.lamport > self.lamport ? other.lamport + 1 : self.lamport + 1
+
+        var vector = self.versionVector.deepcopy()
+        vector.set(actorID: self.actor, lamport: lamport)
+
+        return ChangeID(clientSeq: self.clientSeq,
+                        lamport: lamport,
+                        actor: self.actor,
+                        versionVector: vector)
+    }
+
+    /**
      * `setClocks` sets the given clocks to this ID. This is used when the snapshot
      * is given from the server.
      */

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -86,7 +86,14 @@ public class Document: Attachable {
 
     private let key: DocKey
     private(set) var status: DocStatus = .detached
-    private let disableGC: Bool
+    /// The construction-time GC opt-out from ``DocumentOptions``. Gates whether
+    /// ``garbageCollect(minSyncedVersionVector:)`` runs. Immutable — mirrors the JS
+    /// `opts.disableGC`.
+    private let optionDisableGC: Bool
+    /// Whether this document uses the lamport-only sync path in ``applyChanges(_:source:)``.
+    /// Starts `false` and is set authoritatively by the client on attach via
+    /// ``setDisableGC(_:)`` — mirrors the JS `disableGC` field (distinct from `opts.disableGC`).
+    private var disableGC: Bool = false
     private let enableDevtools: Bool
 
     /// Records replayable events into a ring buffer when `enableDevtools` is set.
@@ -132,7 +139,7 @@ public class Document: Attachable {
 
     public nonisolated init(key: DocKey, opts: DocumentOptions) {
         self.key = key
-        self.disableGC = opts.disableGC
+        self.optionDisableGC = opts.disableGC
         self.enableDevtools = opts.enableDevtools
         self.maxSizeLimit = 0
     }
@@ -663,12 +670,21 @@ public class Document: Attachable {
     }
 
     /**
+     * `setDisableGC` records whether this document participates in GC. The
+     * client calls this on attach so subsequent `applyChanges` runs use the
+     * lamport-only sync path and GC is skipped.
+     */
+    func setDisableGC(_ disableGC: Bool) {
+        self.disableGC = disableGC
+    }
+
+    /**
      * `garbageCollect` purges elements that were removed before the given time.
      *
      */
     @discardableResult
     func garbageCollect(minSyncedVersionVector: VersionVector) -> Int {
-        if self.disableGC {
+        if self.optionDisableGC {
             return 0
         }
 
@@ -877,7 +893,12 @@ public class Document: Attachable {
                 }
             }
 
-            self.changeID = self.changeID.syncClocks(with: change.id)
+            // Opt-out (disableGC) documents advance only the lamport clock and do
+            // not merge remote actors' version vectors, keeping each subsequent
+            // local Change's VV at O(1). See ``setDisableGC(_:)``.
+            self.changeID = self.disableGC
+                ? self.changeID.syncLamport(with: change.id)
+                : self.changeID.syncClocks(with: change.id)
 
             if change.hasOperations {
                 changeInfo = ChangeInfo(message: change.message ?? "",

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -670,9 +670,10 @@ public class Document: Attachable {
     }
 
     /**
-     * `setDisableGC` records whether this document participates in GC. The
-     * client calls this on attach so subsequent `applyChanges` runs use the
-     * lamport-only sync path and GC is skipped.
+     * `setDisableGC` records whether this document should use the lamport-only
+     * sync path in `applyChanges`. The client calls this on attach. This is
+     * distinct from `optionDisableGC`, which independently gates local
+     * `garbageCollect` — setting this flag does NOT disable garbage collection.
      */
     func setDisableGC(_ disableGC: Bool) {
         self.disableGC = disableGC

--- a/Sources/Document/Operation/RemoveOperation.swift
+++ b/Sources/Document/Operation/RemoveOperation.swift
@@ -113,14 +113,17 @@ struct RemoveOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
+        // Compute the sub-path (the index, for arrays) BEFORE deleting: once the
+        // element is tombstoned, `subPath` -> `TreeList.indexOf` returns -1 for the
+        // now-removed node. Mirrors yorkie-js-sdk `RemoveOperation.execute`, which
+        // reads `subPathOf` before `container.delete`.
+        let key = try object.subPath(createdAt: self.createdAt)
+        let index = Int(key)
+
         let element = try object.delete(createdAt: self.createdAt, executedAt: self.executedAt)
         root.registerRemovedElement(element)
 
         let path = try root.createPath(createdAt: self.parentCreatedAt)
-
-        let key = try object.subPath(createdAt: self.createdAt)
-
-        let index = Int(key)
 
         return [parent is CRDTArray ? RemoveOpInfo(path: path, key: nil, index: index) : RemoveOpInfo(path: path, key: key, index: nil)]
     }

--- a/Sources/Util/TreeList.swift
+++ b/Sources/Util/TreeList.swift
@@ -1,0 +1,447 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents the data stored in the nodes of ``TreeList``.
+protocol TreeListValue: AnyObject {
+    /// Whether this value is a tombstone that must not count toward the live (logical) index.
+    var isRemoved: Bool { get }
+
+    /// A debug representation of the value, used by ``TreeList/toTestString``.
+    var toTestString: String { get }
+}
+
+/// A node of ``TreeList``.
+///
+/// It tracks two aggregates over its subtree:
+///   - `weight`: number of non-removed (live) nodes (logical index)
+///   - `count`: total nodes including tombstones (structural index)
+final class TreeListNode<V: TreeListValue> {
+    /// The value carried by this node.
+    ///
+    /// The reference is strong: for the RGATreeList integration the value
+    /// (`RGATreeListNode`) owns its index node, and this back-reference is
+    /// released via `TreeList.delete` when the position is physically purged.
+    let value: V
+
+    fileprivate var left: TreeListNode<V>?
+    fileprivate var right: TreeListNode<V>?
+    fileprivate weak var parent: TreeListNode<V>?
+
+    fileprivate var weight: Int
+    fileprivate var count: Int
+
+    fileprivate var red: Bool
+
+    init(_ value: V) {
+        self.value = value
+        self.red = true
+        self.weight = value.isRemoved ? 0 : 1
+        self.count = 1
+    }
+
+    /// Returns the value of this node.
+    func getValue() -> V {
+        return self.value
+    }
+
+    /// Returns 1 if the node is live, 0 if removed (tombstone).
+    fileprivate var size: Int {
+        return self.value.isRemoved ? 0 : 1
+    }
+
+    /// The cached live-node weight of the left subtree, or 0 if absent.
+    fileprivate var leftWeight: Int {
+        return self.left?.weight ?? 0
+    }
+
+    /// The cached live-node weight of the right subtree, or 0 if absent.
+    fileprivate var rightWeight: Int {
+        return self.right?.weight ?? 0
+    }
+
+    /// The cached total node count of the left subtree, or 0 if absent.
+    fileprivate var leftCount: Int {
+        return self.left?.count ?? 0
+    }
+
+    /// The cached total node count of the right subtree, or 0 if absent.
+    fileprivate var rightCount: Int {
+        return self.right?.count ?? 0
+    }
+}
+
+/// Reports whether the given node is a red link. An absent node is treated as
+/// black, matching the standard LLRB convention.
+private func isRed<V: TreeListValue>(_ node: TreeListNode<V>?) -> Bool {
+    return node?.red ?? false
+}
+
+/// Recomputes the cached weight and count aggregates of `node` from its
+/// children. Call this whenever the structure or liveness of a child changes.
+private func updateNode<V: TreeListValue>(_ node: TreeListNode<V>) {
+    node.weight = node.leftWeight + node.size + node.rightWeight
+    node.count = node.leftCount + 1 + node.rightCount
+}
+
+/// Performs a standard LLRB left rotation around `node`, promoting its right
+/// child. Parent pointers and aggregate counters are refreshed and the new
+/// subtree root is returned.
+private func rotateLeft<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    let right = node.right!
+
+    node.right = right.left
+    node.right?.parent = node
+
+    right.left = node
+    right.parent = node.parent
+    node.parent = right
+
+    right.red = node.red
+    node.red = true
+
+    updateNode(node)
+    updateNode(right)
+    return right
+}
+
+/// Performs a standard LLRB right rotation around `node`, promoting its left
+/// child. Parent pointers and aggregate counters are refreshed and the new
+/// subtree root is returned.
+private func rotateRight<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    let left = node.left!
+
+    node.left = left.right
+    node.left?.parent = node
+
+    left.right = node
+    left.parent = node.parent
+    node.parent = left
+
+    left.red = node.red
+    node.red = true
+
+    updateNode(node)
+    updateNode(left)
+    return left
+}
+
+/// Toggles the colors of `node` and both of its children, used during LLRB
+/// splits and merges.
+private func flipColors<V: TreeListValue>(_ node: TreeListNode<V>) {
+    node.red.toggle()
+    node.left?.red.toggle()
+    node.right?.red.toggle()
+}
+
+/// Ensures the left child or one of its children is red so a deletion
+/// descending to the left can proceed without violating LLRB invariants. The
+/// new subtree root is returned.
+private func moveRedLeft<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    var node = node
+    flipColors(node)
+    if isRed(node.right!.left) {
+        node.right = rotateRight(node.right!)
+        node.right?.parent = node
+        node = rotateLeft(node)
+        flipColors(node)
+    }
+    return node
+}
+
+/// Ensures the right child or one of its children is red so a deletion
+/// descending to the right can proceed without violating LLRB invariants. The
+/// new subtree root is returned.
+private func moveRedRight<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    var node = node
+    flipColors(node)
+    if isRed(node.left!.left) {
+        node = rotateRight(node)
+        flipColors(node)
+    }
+    return node
+}
+
+/// Removes the minimum (left-most) node from the subtree rooted at `node` and
+/// returns the rebalanced subtree root. Used by `delete` when splicing in the
+/// in-order successor.
+private func removeMin<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V>? {
+    var node = node
+    if node.left == nil {
+        return nil
+    }
+
+    if !isRed(node.left), !isRed(node.left!.left) {
+        node = moveRedLeft(node)
+    }
+
+    node.left = removeMin(node.left!)
+    node.left?.parent = node
+
+    return fixUp(node)
+}
+
+/// Returns the left-most node of the subtree rooted at `node`, which is the
+/// in-order successor used during deletion.
+private func minNode<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    var node = node
+    while let left = node.left {
+        node = left
+    }
+    return node
+}
+
+/// Restores LLRB invariants on the way back up after an insertion or deletion:
+/// it leans right-red links left, splits 4-nodes, and refreshes the node's
+/// aggregate counters.
+private func fixUp<V: TreeListValue>(_ node: TreeListNode<V>) -> TreeListNode<V> {
+    var node = node
+    if isRed(node.right), !isRed(node.left) {
+        node = rotateLeft(node)
+    }
+    if isRed(node.left), isRed(node.left!.left) {
+        node = rotateRight(node)
+    }
+    if isRed(node.left), isRed(node.right) {
+        flipColors(node)
+    }
+    updateNode(node)
+    return node
+}
+
+/// Walks the subtree rooted at `node` in left-root-right order, invoking `body`
+/// on every node (live and tombstoned).
+private func traverseInOrder<V: TreeListValue>(_ node: TreeListNode<V>?, _ body: (TreeListNode<V>) -> Void) {
+    guard let node else {
+        return
+    }
+    traverseInOrder(node.left, body)
+    body(node)
+    traverseInOrder(node.right, body)
+}
+
+/// An order-statistic tree based on a Left-leaning Red-Black Tree.
+///
+/// It is used by ``RGATreeList`` to support index-based operations on a list
+/// with tombstones, guaranteeing O(log N) worst-case for all operations.
+///
+/// It maintains two weights per node:
+///   - `weight`: count of non-removed nodes (for index-based lookup)
+///   - `count`: total nodes including tombstones (for structural operations)
+final class TreeList<V: TreeListValue> {
+    private var root: TreeListNode<V>?
+
+    init(_ root: TreeListNode<V>? = nil) {
+        root?.red = false
+        self.root = root
+    }
+
+    /// The number of non-removed (live) nodes.
+    var length: Int {
+        return self.root?.weight ?? 0
+    }
+
+    /// Inserts `target` right after `prev` in the in-order traversal.
+    ///
+    /// It uses structural (count-based) indexing to correctly handle tombstone
+    /// nodes.
+    func insertAfter(_ prev: TreeListNode<V>, _ target: TreeListNode<V>) {
+        target.left = nil
+        target.right = nil
+        target.parent = nil
+        target.red = true
+        target.weight = target.size
+        target.count = 1
+
+        let idx = self.structuralIndexOf(prev)
+        self.root = self.insertByCount(self.root, idx + 1, target)
+        self.root?.red = false
+        self.root?.parent = nil
+    }
+
+    /// Inserts `newNode` at the given structural index within the subtree
+    /// rooted at `node`, descending using each node's left count (tombstones
+    /// included) and rebalancing on the way back up.
+    private func insertByCount(_ node: TreeListNode<V>?, _ index: Int, _ newNode: TreeListNode<V>) -> TreeListNode<V> {
+        guard let node else {
+            return newNode
+        }
+
+        if index <= node.leftCount {
+            node.left = self.insertByCount(node.left, index, newNode)
+            node.left?.parent = node
+        } else {
+            node.right = self.insertByCount(node.right, index - node.leftCount - 1, newNode)
+            node.right?.parent = node
+        }
+
+        return fixUp(node)
+    }
+
+    /// Returns the node at the given logical index (among non-removed nodes).
+    ///
+    /// - Throws: ``YorkieError`` when the index is out of range.
+    func find(_ index: Int) throws -> TreeListNode<V> {
+        guard let root = self.root, index >= 0, index < self.length else {
+            throw YorkieError(code: .errInvalidArgument, message: "out of index: tree size \(self.length), index \(index)")
+        }
+
+        var node = root
+        var index = index
+        while true {
+            if index < node.leftWeight {
+                node = node.left!
+            } else if index < node.leftWeight + node.size {
+                break
+            } else {
+                index -= node.leftWeight + node.size
+                node = node.right!
+            }
+        }
+        return node
+    }
+
+    /// Physically removes `node` from the tree.
+    ///
+    /// Unlike tombstoning, this completely removes the node from the tree
+    /// structure. It uses structural (count-based) indexing and swaps the node
+    /// structure (not values) with its successor to preserve node identity.
+    func delete(_ node: TreeListNode<V>) {
+        guard let root = self.root else {
+            return
+        }
+
+        if !isRed(root.left), !isRed(root.right) {
+            root.red = true
+        }
+
+        let idx = self.structuralIndexOf(node)
+        self.root = self.deleteByCount(root, idx)
+
+        if let root = self.root {
+            root.red = false
+            root.parent = nil
+        }
+    }
+
+    /// Removes the node at the given structural index within the subtree rooted
+    /// at `node`.
+    ///
+    /// When deleting an internal node, it swaps in the in-order successor by
+    /// re-parenting rather than copying values so external references to the
+    /// surviving node remain valid.
+    private func deleteByCount(_ node: TreeListNode<V>, _ index: Int) -> TreeListNode<V>? {
+        var node = node
+
+        if index < node.leftCount {
+            if !isRed(node.left), !isRed(node.left!.left) {
+                node = moveRedLeft(node)
+            }
+            node.left = self.deleteByCount(node.left!, index)
+            node.left?.parent = node
+        } else {
+            if isRed(node.left) {
+                node = rotateRight(node)
+            }
+
+            if index == node.leftCount, node.right == nil {
+                return nil
+            }
+
+            if !isRed(node.right), !isRed(node.right!.left) {
+                node = moveRedRight(node)
+            }
+
+            if index == node.leftCount {
+                // Swap the successor into this position instead of copying
+                // values. This preserves node identity so external references
+                // remain valid.
+                let successor = minNode(node.right!)
+                let newRight = removeMin(node.right!)
+
+                successor.left = node.left
+                successor.right = newRight
+                successor.red = node.red
+                successor.left?.parent = successor
+                successor.right?.parent = successor
+
+                node.left = nil
+                node.right = nil
+                node.parent = nil
+
+                node = successor
+            } else {
+                node.right = self.deleteByCount(node.right!, index - node.leftCount - 1)
+                node.right?.parent = node
+            }
+        }
+
+        return fixUp(node)
+    }
+
+    /// Propagates weight changes from `node` up to the root.
+    ///
+    /// Call this after a node's `isRemoved` status changes (i.e., after
+    /// tombstoning).
+    func updateWeight(_ node: TreeListNode<V>) {
+        var cur: TreeListNode<V>? = node
+        while let current = cur {
+            current.weight = current.leftWeight + current.size + current.rightWeight
+            cur = current.parent
+        }
+    }
+
+    /// Returns a string containing the metadata of the nodes for debugging.
+    var toTestString: String {
+        var result = ""
+        traverseInOrder(self.root) { node in
+            result += "[\(node.weight),\(node.size)]\(node.value.toTestString)"
+        }
+        return result
+    }
+
+    /// Returns the logical (live-node) index of `node`, or -1 if the node is a
+    /// tombstone.
+    func indexOf(_ node: TreeListNode<V>) -> Int {
+        if node.size == 0 {
+            return -1
+        }
+        var index = node.leftWeight
+        var cur = node
+        while let parent = cur.parent {
+            if cur === parent.right {
+                index += parent.leftWeight + parent.size
+            }
+            cur = parent
+        }
+        return index
+    }
+
+    /// Returns the structural position of `node`, counting all nodes including
+    /// tombstones.
+    private func structuralIndexOf(_ node: TreeListNode<V>) -> Int {
+        var index = node.leftCount
+        var cur = node
+        while let parent = cur.parent {
+            if cur === parent.right {
+                index += parent.leftCount + 1
+            }
+            cur = parent
+        }
+        return index
+    }
+}

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.10"
+let yorkieVersion = "0.7.11"

--- a/Tests/Integration/DisableGCIntegrationTests.swift
+++ b/Tests/Integration/DisableGCIntegrationTests.swift
@@ -172,4 +172,102 @@ final class DisableGCIntegrationTests: XCTestCase {
         let msg = d2.getRoot().message as? String
         XCTAssertEqual(msg, "hello")
     }
+
+    // Ports (v0.7.11 #1270): "Opt-out clients keep per-Change VV at size 1 under multi-actor fanout"
+    //
+    // Regression for the bug where each opt-out client's Change.ID.versionVector accumulated
+    // O(num_actors) entries because applyChanges -> syncClocks merged every remote actor. After
+    // the syncLamport fix the per-Change VV must stay at size 1.
+    @MainActor
+    func test_optout_clients_keep_per_change_vv_at_size_1_under_multi_actor_fanout() async throws {
+        // given
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        let c3 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        try await c3.activate()
+        self.addTeardownBlock {
+            try? await c1.deactivate()
+            try? await c2.deactivate()
+            try? await c3.deactivate()
+        }
+
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+        let d3 = Document(key: docKey)
+        try await c1.attach(d1, [:], .manual, disableGC: true)
+        try await c2.attach(d2, [:], .manual, disableGC: true)
+        try await c3.attach(d3, [:], .manual, disableGC: true)
+        self.addTeardownBlock {
+            try? await c1.detach(d1)
+            try? await c2.detach(d2)
+            try? await c3.detach(d3)
+        }
+
+        try d1.update { root, _ in
+            root.counter = JSONCounter(value: Int64(0))
+        }
+        try await c1.sync()
+        try await c2.sync()
+        try await c3.sync()
+
+        // when — every client increments independently for three rounds
+        for _ in 0 ..< 3 {
+            try d1.update { root, _ in (root.counter as? JSONCounter<Int64>)?.increase(value: 1) }
+            try d2.update { root, _ in (root.counter as? JSONCounter<Int64>)?.increase(value: 1) }
+            try d3.update { root, _ in (root.counter as? JSONCounter<Int64>)?.increase(value: 1) }
+            try await c1.sync()
+            try await c2.sync()
+            try await c3.sync()
+        }
+        // Drain remaining pushed changes so every client sees them.
+        try await c1.sync()
+        try await c2.sync()
+        try await c3.sync()
+        try await c1.sync()
+
+        // then — all converge to 9 ...
+        XCTAssertEqual((d1.getRoot().counter as? JSONCounter<Int64>)?.value, 9)
+        XCTAssertEqual((d2.getRoot().counter as? JSONCounter<Int64>)?.value, 9)
+        XCTAssertEqual((d3.getRoot().counter as? JSONCounter<Int64>)?.value, 9)
+
+        // ... and every opt-out doc's per-Change VV stays at size 1.
+        for (idx, doc) in [d1, d2, d3].enumerated() {
+            XCTAssertEqual(doc.getVersionVector().size(), 1, "opt-out doc[\(idx)] versionVector must stay at size 1")
+        }
+    }
+
+    // Attaching with `disableGC: true` selects the lamport-only sync path but must NOT disable
+    // local garbage collection when the document was constructed with GC enabled — mirroring the
+    // JS split between `opts.disableGC` (gates GC) and the attach-time `disableGC` (gates sync).
+    @MainActor
+    func test_disableGC_attach_does_not_disable_local_garbage_collection() async throws {
+        // given — a normally constructed document (GC enabled) attached with disableGC = true
+        let docKey = "\(Date().timeIntervalSince1970)-\(self.description)".toDocKey
+        let client = Client(rpcAddress)
+        try await client.activate()
+        self.addTeardownBlock { try? await client.deactivate() }
+
+        let doc = Document(key: docKey)
+        try await client.attach(doc, [:], .manual, disableGC: true)
+        self.addTeardownBlock { try? await client.detach(doc) }
+
+        // when — create then remove an element, producing tombstones
+        try doc.update { root, _ in
+            root.point = ["x": Int64(0), "y": Int64(0)]
+        }
+        try await client.sync()
+        try doc.update { root, _ in
+            root.remove(key: "point")
+        }
+        try await client.sync()
+
+        XCTAssertEqual(doc.getGarbageLength(), 3, "point, x, y are pending purge")
+
+        // then — GC still runs (returns > 0) despite the disableGC attach option
+        let purged = doc.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [client.id]))
+        XCTAssertEqual(purged, 3, "local GC must still purge for a GC-enabled document")
+    }
 }

--- a/Tests/Unit/Document/CRDT/RGATreeListTests.swift
+++ b/Tests/Unit/Document/CRDT/RGATreeListTests.swift
@@ -323,6 +323,38 @@ class RGATreeListTests: XCTestCase {
         XCTAssertEqual(target.getLast().toJSON(), "\"C123\"")
     }
 
+    // Ported from yorkie-js-sdk (PR #1272): getLast skips trailing bare position nodes.
+    // When the tail element is moved elsewhere, `moveAfter` leaves the old tail position
+    // node in place as `last` (dead, no `elementEntry`) rather than reassigning it —
+    // mirroring JS, which keeps dead position nodes around until GC purge. `getLast()`
+    // must walk back over that bare node and return the last LIVE element instead.
+    func test_getLast_skips_trailing_bare_position_node() throws {
+        // given — list [A, B, C], C is the tail
+        let target = RGATreeList()
+        let e1 = Primitive(value: .string("A"), createdAt: TimeTicket(lamport: 1, delimiter: 0, actorID: actorId))
+        let e2 = Primitive(value: .string("B"), createdAt: TimeTicket(lamport: 2, delimiter: 0, actorID: actorId))
+        let e3 = Primitive(value: .string("C"), createdAt: TimeTicket(lamport: 3, delimiter: 0, actorID: actorId))
+        try target.insert(e1)
+        try target.insert(e2)
+        try target.insert(e3)
+
+        XCTAssertEqual(target.getLast().toJSON(), "\"C\"")
+
+        // when — move the tail element (C) elsewhere; the old tail position node becomes
+        // a bare/dead position node, and `last` keeps pointing at it (JS-faithful).
+        let moveAt = TimeTicket(lamport: 4, delimiter: 0, actorID: actorId)
+        let deadNode = try target.moveAfter(createdAt: e3.createdAt, prevCreatedAt: e1.createdAt, executedAt: moveAt)
+
+        // then — the physically last node is still the bare/dead position node left behind
+        XCTAssertNotNil(deadNode)
+        XCTAssertNil(deadNode?.getElementEntry())
+        XCTAssertEqual(target.getLastCreatedAt(), deadNode?.positionCreatedAt)
+
+        // and — getLast() skips it, returning the last LIVE element ("B", now at the tail
+        // of the live sequence [A, C, B]) instead of the bare position node.
+        XCTAssertEqual(target.getLast().toJSON(), "\"B\"")
+    }
+
     func test_getLastCreatedAt() throws {
         let target = RGATreeList()
         let e1 = Primitive(value: .string("A1"), createdAt: TimeTicket(lamport: 1, delimiter: 0, actorID: actorId))

--- a/Tests/Unit/Document/Change/ChangeIDTests.swift
+++ b/Tests/Unit/Document/Change/ChangeIDTests.swift
@@ -64,4 +64,64 @@ class ChangeIDTests: XCTestCase {
 
         XCTAssertEqual(result.toTestString, "2:actor-1:3")
     }
+
+    // syncLamport (v0.7.11): advances the lamport clock like syncClocks, but does NOT
+    // merge the other ID's version vector entries into the receiver's — only the
+    // receiver's own actor entry is set. This keeps VV size O(1) for attachments that
+    // opt out of GC participation.
+    func test_syncLamport_advances_lamport_without_merging_the_other_actors_vv_entry() {
+        let actor = "actor-1"
+        let otherActor = "actor-2"
+
+        let currentVector = VersionVector(vector: [actor: 2])
+        let otherVector = VersionVector(vector: [otherActor: 10])
+
+        let current = ChangeID(clientSeq: 1, lamport: 2, actor: actor, versionVector: currentVector)
+        let other = ChangeID(clientSeq: 2, lamport: 10, actor: otherActor, versionVector: otherVector)
+
+        let synced = current.syncLamport(with: other)
+
+        // Lamport advances to other.lamport + 1, same as syncClocks would.
+        XCTAssertEqual(synced.getLamport(), other.getLamport() + 1)
+
+        // But the version vector keeps only the receiver's own actor entry —
+        // the other actor's entry is NOT merged in.
+        XCTAssertEqual(synced.getVersionVector().size(), 1)
+        XCTAssertEqual(synced.getVersionVector().get(actor), other.getLamport() + 1)
+        XCTAssertNil(synced.getVersionVector().get(otherActor))
+    }
+
+    // Contrast with syncClocks: given the same inputs, syncClocks DOES merge the other
+    // actor's version-vector entry, growing the vector to size 2.
+    func test_syncClocks_merges_the_other_actors_vv_entry_unlike_syncLamport() {
+        let actor = "actor-1"
+        let otherActor = "actor-2"
+
+        let currentVector = VersionVector(vector: [actor: 2])
+        let otherVector = VersionVector(vector: [otherActor: 10])
+
+        let current = ChangeID(clientSeq: 1, lamport: 2, actor: actor, versionVector: currentVector)
+        let other = ChangeID(clientSeq: 2, lamport: 10, actor: otherActor, versionVector: otherVector)
+
+        let synced = current.syncClocks(with: other)
+
+        XCTAssertEqual(synced.getVersionVector().size(), 2)
+        XCTAssertEqual(synced.getVersionVector().get(otherActor), 10)
+    }
+
+    func test_syncLamport_returns_self_unchanged_when_other_has_no_clocks() {
+        let actor = "actor-1"
+        let currentVector = VersionVector(vector: [actor: 2])
+        let current = ChangeID(clientSeq: 1, lamport: 2, actor: actor, versionVector: currentVector)
+
+        // ChangeID.initial has lamport == initialLamport and an empty version vector,
+        // so hasClocks() is false.
+        let other = ChangeID.initial
+
+        let synced = current.syncLamport(with: other)
+
+        XCTAssertEqual(synced.toTestString, current.toTestString)
+        XCTAssertEqual(synced.getVersionVector().size(), current.getVersionVector().size())
+        XCTAssertEqual(synced.getVersionVector().get(actor), current.getVersionVector().get(actor))
+    }
 }

--- a/Tests/Unit/Util/TreeListTests.swift
+++ b/Tests/Unit/Util/TreeListTests.swift
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Ported from yorkie-js-sdk `packages/sdk/src/util/treelist.spec.ts`.
+private final class TestValue: TreeListValue {
+    var isRemoved: Bool
+    var content: String
+
+    init(_ content: String, removed: Bool = false) {
+        self.content = content
+        self.isRemoved = removed
+    }
+
+    var toTestString: String {
+        return self.content
+    }
+}
+
+private func newNode(_ content: String) -> TreeListNode<TestValue> {
+    return TreeListNode(TestValue(content))
+}
+
+private func newRemovedNode(_ content: String) -> TreeListNode<TestValue> {
+    return TreeListNode(TestValue(content, removed: true))
+}
+
+private func rebuildLiveList(_ tree: TreeList<TestValue>) throws -> [TreeListNode<TestValue>] {
+    var result = [TreeListNode<TestValue>]()
+    for index in 0 ..< tree.length {
+        try result.append(tree.find(index))
+    }
+    return result
+}
+
+/// Simple seeded LCG so the stress test is deterministic across runs/platforms.
+private func makeRng(_ seed: UInt32) -> () -> Double {
+    var state = seed
+    return {
+        state = state &* 1_664_525 &+ 1_013_904_223
+        return Double(state) / Double(0x1_0000_0000)
+    }
+}
+
+class TreeListTests: XCTestCase {
+    func test_insert_and_find() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        XCTAssertEqual(tree.length, 0)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        XCTAssertEqual(tree.length, 1)
+
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        XCTAssertEqual(tree.length, 2)
+
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        XCTAssertEqual(tree.length, 3)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeB)
+        XCTAssertTrue(try tree.find(2) === nodeC)
+    }
+
+    func test_insert_in_the_middle() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeA, nodeC)
+
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        XCTAssertEqual(tree.length, 3)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeB)
+        XCTAssertTrue(try tree.find(2) === nodeC)
+    }
+
+    func test_insert_after_tombstone() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        nodeA.getValue().isRemoved = true
+        tree.updateWeight(nodeA)
+        XCTAssertEqual(tree.length, 1)
+
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeA, nodeC)
+        XCTAssertEqual(tree.length, 2)
+
+        XCTAssertTrue(try tree.find(0) === nodeC)
+        XCTAssertTrue(try tree.find(1) === nodeB)
+    }
+
+    func test_delete() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        XCTAssertEqual(tree.length, 3)
+
+        tree.delete(nodeB)
+        XCTAssertEqual(tree.length, 2)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeC)
+    }
+
+    func test_delete_preserves_node_identity() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        var nodes = [TreeListNode<TestValue>]()
+        var prev = dummyHead
+        for index in 0 ..< 5 {
+            let content = String(UnicodeScalar(UInt8(Character("A").asciiValue! + UInt8(index))))
+            let node = newNode(content)
+            tree.insertAfter(prev, node)
+            nodes.append(node)
+            prev = node
+        }
+        XCTAssertEqual(tree.length, 5)
+
+        tree.delete(nodes[2]) // Delete C
+        XCTAssertEqual(tree.length, 4)
+
+        XCTAssertTrue(try tree.find(0) === nodes[0]) // A
+        XCTAssertTrue(try tree.find(1) === nodes[1]) // B
+        XCTAssertTrue(try tree.find(2) === nodes[3]) // D
+        XCTAssertTrue(try tree.find(3) === nodes[4]) // E
+    }
+
+    func test_delete_first_and_last_nodes() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        tree.delete(nodeA)
+        XCTAssertEqual(tree.length, 2)
+        XCTAssertTrue(try tree.find(0) === nodeB)
+
+        tree.delete(nodeC)
+        XCTAssertEqual(tree.length, 1)
+        XCTAssertTrue(try tree.find(0) === nodeB)
+    }
+
+    func test_delete_tombstoned_node() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        nodeB.getValue().isRemoved = true
+        tree.updateWeight(nodeB)
+        XCTAssertEqual(tree.length, 2)
+
+        tree.delete(nodeB)
+        XCTAssertEqual(tree.length, 2)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeC)
+    }
+
+    func test_delete_all_nodes() {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        tree.delete(nodeA)
+        tree.delete(nodeB)
+        tree.delete(dummyHead)
+
+        XCTAssertEqual(tree.length, 0)
+    }
+
+    func test_tombstone_and_update_weight() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        XCTAssertEqual(tree.length, 3)
+
+        nodeB.getValue().isRemoved = true
+        tree.updateWeight(nodeB)
+        XCTAssertEqual(tree.length, 2)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeC)
+        XCTAssertThrowsError(try tree.find(2))
+    }
+
+    func test_multiple_tombstones() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        var nodes = [TreeListNode<TestValue>]()
+        var prev = dummyHead
+        for index in 0 ..< 6 {
+            let content = String(UnicodeScalar(UInt8(Character("A").asciiValue! + UInt8(index))))
+            let node = newNode(content)
+            tree.insertAfter(prev, node)
+            nodes.append(node)
+            prev = node
+        }
+        XCTAssertEqual(tree.length, 6)
+
+        nodes[1].getValue().isRemoved = true // B
+        tree.updateWeight(nodes[1])
+        nodes[3].getValue().isRemoved = true // D
+        tree.updateWeight(nodes[3])
+        nodes[5].getValue().isRemoved = true // F
+        tree.updateWeight(nodes[5])
+        XCTAssertEqual(tree.length, 3)
+
+        XCTAssertTrue(try tree.find(0) === nodes[0]) // A
+        XCTAssertTrue(try tree.find(1) === nodes[2]) // C
+        XCTAssertTrue(try tree.find(2) === nodes[4]) // E
+    }
+
+    func test_find_out_of_bounds() {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        XCTAssertThrowsError(try tree.find(0))
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+
+        XCTAssertThrowsError(try tree.find(-1))
+        XCTAssertThrowsError(try tree.find(1))
+    }
+
+    func test_single_live_node_tree() throws {
+        let node = newNode("A")
+        let tree = TreeList<TestValue>(node)
+        XCTAssertEqual(tree.length, 1)
+
+        XCTAssertTrue(try tree.find(0) === node)
+
+        tree.delete(node)
+        XCTAssertEqual(tree.length, 0)
+    }
+
+    func test_large_sequential_insert_and_find() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let count = 100
+        var nodes = [TreeListNode<TestValue>]()
+        var prev = dummyHead
+        for index in 0 ..< count {
+            let node = newNode("\(index)")
+            tree.insertAfter(prev, node)
+            nodes.append(node)
+            prev = node
+        }
+        XCTAssertEqual(tree.length, count)
+
+        for index in 0 ..< count {
+            XCTAssertTrue(try tree.find(index) === nodes[index])
+        }
+    }
+
+    func test_large_sequential_insert_tombstone_and_find() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let count = 100
+        var nodes = [TreeListNode<TestValue>]()
+        var prev = dummyHead
+        for index in 0 ..< count {
+            let node = newNode("\(index)")
+            tree.insertAfter(prev, node)
+            nodes.append(node)
+            prev = node
+        }
+
+        var step = 0
+        while step < count {
+            nodes[step].getValue().isRemoved = true
+            tree.updateWeight(nodes[step])
+            step += 2
+        }
+        XCTAssertEqual(tree.length, count / 2)
+
+        var idx = 0
+        step = 1
+        while step < count {
+            XCTAssertTrue(try tree.find(idx) === nodes[step])
+            idx += 1
+            step += 2
+        }
+    }
+
+    func test_large_sequential_insert_and_delete() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let count = 100
+        var nodes = [TreeListNode<TestValue>]()
+        var prev = dummyHead
+        for index in 0 ..< count {
+            let node = newNode("\(index)")
+            tree.insertAfter(prev, node)
+            nodes.append(node)
+            prev = node
+        }
+
+        var step = 0
+        while step < count {
+            tree.delete(nodes[step])
+            step += 2
+        }
+        XCTAssertEqual(tree.length, count / 2)
+
+        var idx = 0
+        step = 1
+        while step < count {
+            XCTAssertTrue(try tree.find(idx) === nodes[step])
+            idx += 1
+            step += 2
+        }
+    }
+
+    func test_interleaved_insert_and_delete() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        tree.delete(nodeB)
+        let nodeD = newNode("D")
+        tree.insertAfter(nodeA, nodeD)
+        XCTAssertEqual(tree.length, 3)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeD)
+        XCTAssertTrue(try tree.find(2) === nodeC)
+    }
+
+    func test_insert_after_dummy_head_with_existing_nodes() throws {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeB = newNode("B")
+        tree.insertAfter(dummyHead, nodeB)
+        let nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        XCTAssertEqual(tree.length, 3)
+
+        XCTAssertTrue(try tree.find(0) === nodeA)
+        XCTAssertTrue(try tree.find(1) === nodeB)
+        XCTAssertTrue(try tree.find(2) === nodeC)
+    }
+
+    func test_toTestString() {
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        let nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        let nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        let str = tree.toTestString
+        XCTAssertTrue(str.contains("dummy"))
+        XCTAssertTrue(str.contains("A"))
+        XCTAssertTrue(str.contains("B"))
+    }
+
+    func test_stress_test_with_random_operations() throws {
+        let rng = makeRng(42)
+        let dummyHead = newRemovedNode("dummy")
+        let tree = TreeList<TestValue>(dummyHead)
+
+        var liveNodes = [TreeListNode<TestValue>]()
+        var allNodes = [dummyHead]
+
+        let ops = 500
+        for step in 0 ..< ops {
+            let op = Int(rng() * 3)
+
+            if op == 0 || allNodes.count < 3 {
+                let prevIdx = Int(rng() * Double(allNodes.count))
+                let prev = allNodes[prevIdx]
+                let node = newNode("n\(step)")
+                tree.insertAfter(prev, node)
+                allNodes.append(node)
+                liveNodes = try rebuildLiveList(tree)
+            } else if op == 1, !liveNodes.isEmpty {
+                let idx = Int(rng() * Double(liveNodes.count))
+                liveNodes[idx].getValue().isRemoved = true
+                tree.updateWeight(liveNodes[idx])
+                liveNodes = try rebuildLiveList(tree)
+            } else if op == 2, allNodes.count > 1 {
+                let delIdx = 1 + Int(rng() * Double(allNodes.count - 1))
+                tree.delete(allNodes[delIdx])
+                allNodes.remove(at: delIdx)
+                liveNodes = try rebuildLiveList(tree)
+            }
+
+            XCTAssertEqual(tree.length, liveNodes.count, "iteration \(step)")
+
+            for pos in 0 ..< liveNodes.count {
+                XCTAssertTrue(try tree.find(pos) === liveNodes[pos], "iteration \(step), find index \(pos)")
+            }
+        }
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.10'
+    image: 'yorkieteam/yorkie:0.7.11'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.10'
+    image: 'yorkieteam/yorkie:0.7.11'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs `yorkie-ios-sdk` with `yorkie-js-sdk` **v0.7.11**. Three of the four upstream changes are iOS-relevant and ported here (one commit each, subject = the upstream PR title); the React-only change is skipped.

- **Introduce treelist to optimize random access in Array** (js#1269) — new `Sources/Util/TreeList.swift`, a Swift port of the upstream Left-leaning Red-Black order-statistic tree (per-node `weight` = live count, `count` = total incl. tombstones). `RGATreeList` is rewired off `SplayTree` onto `TreeList`. As part of this change, `RemoveOperation` now reads the element's sub-path/index **before** deleting it — required because `TreeList.indexOf` returns `-1` for tombstones (matching JS), which also fixes a latent iOS index reporting bug the old `SplayTree` had masked.
- **Stop disableGC clients from accumulating per-Change VV** (js#1270) — adds `ChangeID.syncLamport`; opt-out documents advance only the lamport clock instead of merging every remote actor's version vector, keeping each local Change's VV at O(1). `opts.disableGC` (construction, gates GC) and the attach-time `disableGC` (gates the sync path) are kept as two independent fields, mirroring JS.
- **Skip bare position nodes in RGATreeList.getLast** (js#1272).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Reviewed by the `critic-reviewer` agent against `refs/tags/v0.7.11`; its one High finding (initially conflating the two `disableGC` fields) was fixed and is guarded by a new integration test.
- Lint clean with the CI-pinned toolchain: **SwiftFormat 0.55.6** and **SwiftLint 0.58.2 `--strict`** (0 violations).
- `swift build` + full unit suite green (**594 tests**); the array / GC / Document / disableGC **integration** suites also run green against a local server (incl. the js#1270 "opt-out VV stays size 1" parity test and a new "disableGC attach does not disable local GC" regression test).
- The CI `yorkie` server pin is bumped to **0.7.11** (`swift.yml`, `swift-integration.yml`, both `docker-compose` files); `Sources/Version.swift` → `0.7.11`.

**Does this PR introduce a user-facing change?**:

```release-note
Clients attaching with `disableGC: true` no longer accumulate per-Change version-vector entries under multi-actor workloads (O(1) instead of O(num_actors)).
```

**Additional documentation**:

```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved synchronization behavior for documents when garbage collection is disabled.
  * Introduced an optimized order-statistics list structure to improve indexing and move/remove behavior.

* **Bug Fixes**
  * Fixed list tail reporting after move operations by skipping dead/bare trailing positions.
  * Corrected element removal bookkeeping to ensure indices/path info stays consistent.

* **Tests**
  * Added unit and integration coverage for disableGC synchronization and list/index edge cases.

* **Chores**
  * Updated CI and Docker images to the latest 0.7.11 release and refreshed the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->