### PR TITLE
Apply updates from yorkie-js-sdk 0.7.14

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.13
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/7d7f94f7511e98389ec886d69f2fd05095a2b996/Formula/y/yorkie.rb"
+      # yorkie server v0.7.14
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/d34c1e8459b1bf78612849852673fbf5148a2982/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.13
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/7d7f94f7511e98389ec886d69f2fd05095a2b996/Formula/y/yorkie.rb"
+      # yorkie server v0.7.14
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/d34c1e8459b1bf78612849852673fbf5148a2982/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 
 ## [v0.7.14] - 2026-08-19
 
-- Add identity-preserving restore for Tree undo/redo
-- Recreate purged text runs in order on restore, not reversed
-- Keep style ranges from crossing a concurrent merge anchor
-- Flatten chained merge to converge an anchored concurrent insert
-- Move tombstones with merge to preserve tree RGA anchors
-- Promote out-of-int32 integers to Long in Primitive (no-op on iOS; `Int32` typing makes the JS bug unrepresentable, guarded by a parity test)
+- Add identity-preserving restore for Tree undo/redo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
+- Recreate purged text runs in order on restore, not reversed in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
+- Keep style ranges from crossing a concurrent merge anchor in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
+- Flatten chained merge to converge an anchored concurrent insert in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
+- Move tombstones with merge to preserve tree RGA anchors in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
+- Promote out-of-int32 integers to Long in Primitive (no-op on iOS; `Int32` typing makes the JS bug unrepresentable, guarded by a parity test) in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268
 
 ## [v0.7.13] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.14] - 2026-08-19
+
+- Add identity-preserving restore for Tree undo/redo
+- Recreate purged text runs in order on restore, not reversed
+- Keep style ranges from crossing a concurrent merge anchor
+- Flatten chained merge to converge an anchored concurrent insert
+- Move tombstones with merge to preserve tree RGA anchors
+- Promote out-of-int32 integers to Long in Primitive
+
 ## [v0.7.13] - 2026-08-18
 
 - Identity-preserving restore for Text undo/redo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/267

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 - Keep style ranges from crossing a concurrent merge anchor
 - Flatten chained merge to converge an anchored concurrent insert
 - Move tombstones with merge to preserve tree RGA anchors
-- Promote out-of-int32 integers to Long in Primitive
+- Promote out-of-int32 integers to Long in Primitive (no-op on iOS; `Int32` typing makes the JS bug unrepresentable, guarded by a parity test)
 
 ## [v0.7.13] - 2026-08-18
 

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -560,6 +560,17 @@ extension Converter {
             pbTreeEditOperation.contents = toTreeNodesWhenEdit(treeEditOperation.contents)
             pbTreeEditOperation.splitLevel = treeEditOperation.splitLevel
             pbTreeEditOperation.executedAt = toTimeTicket(treeEditOperation.executedAt)
+            let treeRestoreSpans = treeEditOperation.restoreSpans
+            let treeRetombstoneSpans = treeEditOperation.retombstoneSpans
+            if !(treeRestoreSpans?.isEmpty ?? true) || !(treeRetombstoneSpans?.isEmpty ?? true) {
+                pbTreeEditOperation.restoreSpans = (treeRestoreSpans ?? []).map { toTreeRestoreSpan($0) }
+                pbTreeEditOperation.retombstoneSpans = (treeRetombstoneSpans ?? []).map { toTreeRestoreSpan($0) }
+                if case .retombstone = treeEditOperation.restoreMode {
+                    pbTreeEditOperation.restoreMode = .retombstone
+                } else {
+                    pbTreeEditOperation.restoreMode = .restore
+                }
+            }
             pbOperation.treeEdit = pbTreeEditOperation
         } else if let treeStyleOperation = operation as? TreeStyleOperation {
             var pbTreeStyleOperation = PbOperation.TreeStyle()
@@ -653,12 +664,24 @@ extension Converter {
                                          executedAt: fromTimeTicket(pbIncreaseOperation.executedAt),
                                          actor: pbIncreaseOperation.actor)
             } else if case let .treeEdit(pbTreeEditOperation) = pbOperation.body {
+                var treeRestoreSpans: [TreeRestoreSpan]?
+                var treeRetombstoneSpans: [TreeRestoreSpan]?
+                var treeRestoreMode: RestoreMode?
+                if !pbTreeEditOperation.restoreSpans.isEmpty || !pbTreeEditOperation.retombstoneSpans.isEmpty {
+                    treeRestoreSpans = try pbTreeEditOperation.restoreSpans.map { try fromTreeRestoreSpan($0) }
+                    treeRetombstoneSpans = try pbTreeEditOperation.retombstoneSpans.map { try fromTreeRestoreSpan($0) }
+                    treeRestoreMode = pbTreeEditOperation.restoreMode == .retombstone ? .retombstone : .restore
+                }
                 return TreeEditOperation(parentCreatedAt: fromTimeTicket(pbTreeEditOperation.parentCreatedAt),
                                          fromPos: fromTreePos(pbTreeEditOperation.from),
                                          toPos: fromTreePos(pbTreeEditOperation.to),
                                          contents: fromTreeNodesWhenEdit(pbTreeEditOperation.contents),
                                          splitLevel: pbTreeEditOperation.splitLevel,
-                                         executedAt: fromTimeTicket(pbTreeEditOperation.executedAt))
+                                         executedAt: fromTimeTicket(pbTreeEditOperation.executedAt),
+                                         isUndoOp: treeRestoreMode != nil,
+                                         restoreSpans: treeRestoreSpans,
+                                         restoreMode: treeRestoreMode,
+                                         retombstoneSpans: treeRetombstoneSpans)
             } else if case let .treeStyle(pbTreeStyleOperation) = pbOperation.body {
                 if !pbTreeStyleOperation.attributesToRemove.isEmpty {
                     return TreeStyleOperation(parentCreatedAt: fromTimeTicket(pbTreeStyleOperation.parentCreatedAt),
@@ -1178,6 +1201,77 @@ extension Converter {
      */
     static func fromTreeNodeID(_ pbTreeNodeID: PbTreeNodeID) -> CRDTTreeNodeID {
         CRDTTreeNodeID(createdAt: fromTimeTicket(pbTreeNodeID.createdAt), offset: pbTreeNodeID.offset)
+    }
+
+    /**
+     * `toTreeRestoreSpan` converts a ``TreeRestoreSpan`` to Protobuf format.
+     */
+    static func toTreeRestoreSpan(_ span: TreeRestoreSpan) -> PbTreeRestoreSpan {
+        var pbSpan = PbTreeRestoreSpan()
+        pbSpan.id = toTreeNodeID(span.id)
+        pbSpan.nodeType = span.nodeType
+        pbSpan.isText = span.isText
+        pbSpan.length = span.length
+        if let value = span.value {
+            pbSpan.value = value as String
+        }
+        span.attrs?.forEach { rhtNode in
+            var attr = PbNodeAttr()
+            attr.value = rhtNode.value
+            attr.updatedAt = toTimeTicket(rhtNode.updatedAt)
+            attr.isRemoved = rhtNode.isRemoved
+            pbSpan.attributes[rhtNode.key] = attr
+        }
+        if let parentID = span.parentID {
+            pbSpan.parentID = toTreeNodeID(parentID)
+        }
+        if let leftSiblingID = span.leftSiblingID {
+            pbSpan.leftSiblingID = toTreeNodeID(leftSiblingID)
+        }
+        if let rightSiblingID = span.rightSiblingID {
+            pbSpan.rightSiblingID = toTreeNodeID(rightSiblingID)
+        }
+        return pbSpan
+    }
+
+    /**
+     * `fromTreeRestoreSpan` converts the given Protobuf format to model format.
+     *
+     * A span addresses content by insertion identity, so every node ID it carries
+     * is malformed without a `createdAt`, and the attribute snapshot is malformed
+     * without an `updatedAt`. Both are rejected here because the decoders below
+     * would otherwise yield a `CRDTTreeNodeID` with a default `createdAt` and an
+     * RHT node with a default `updatedAt` — neither failing until deep inside the
+     * restore path. Mirrors the server's `fromTreeRestoreSpans`.
+     */
+    static func fromTreeRestoreSpan(_ pbSpan: PbTreeRestoreSpan) throws -> TreeRestoreSpan {
+        let anchorsValid = (!pbSpan.hasParentID || pbSpan.parentID.hasCreatedAt)
+            && (!pbSpan.hasLeftSiblingID || pbSpan.leftSiblingID.hasCreatedAt)
+            && (!pbSpan.hasRightSiblingID || pbSpan.rightSiblingID.hasCreatedAt)
+        guard pbSpan.hasID, pbSpan.id.hasCreatedAt, anchorsValid,
+              pbSpan.attributes.values.allSatisfy({ $0.hasUpdatedAt })
+        else {
+            throw YorkieError(code: .errInvalidArgument, message: "malformed tree restore span: missing timestamp")
+        }
+
+        var attrs: RHT?
+        if !pbSpan.attributes.isEmpty {
+            let rht = RHT()
+            pbSpan.attributes.forEach { key, value in
+                rht.setInternal(key: key, value: value.value, executedAt: fromTimeTicket(value.updatedAt), removed: value.isRemoved)
+            }
+            attrs = rht
+        }
+
+        return TreeRestoreSpan(id: fromTreeNodeID(pbSpan.id),
+                               nodeType: pbSpan.nodeType,
+                               isText: pbSpan.isText,
+                               length: pbSpan.length,
+                               value: pbSpan.isText ? pbSpan.value as NSString : nil,
+                               attrs: attrs,
+                               parentID: pbSpan.hasParentID ? fromTreeNodeID(pbSpan.parentID) : nil,
+                               leftSiblingID: pbSpan.hasLeftSiblingID ? fromTreeNodeID(pbSpan.leftSiblingID) : nil,
+                               rightSiblingID: pbSpan.hasRightSiblingID ? fromTreeNodeID(pbSpan.rightSiblingID) : nil)
     }
     
     /**

--- a/Sources/API/GRPCTypeAlias.swift
+++ b/Sources/API/GRPCTypeAlias.swift
@@ -97,6 +97,7 @@ typealias PbTreePos = Yorkie_V1_TreePos
 typealias PbTreeNodes = Yorkie_V1_TreeNodes
 typealias PbSnapshot = Yorkie_V1_Snapshot
 typealias PbTreeNodeID = Yorkie_V1_TreeNodeID
+typealias PbTreeRestoreSpan = Yorkie_V1_TreeRestoreSpan
 typealias PbVersionVector = Yorkie_V1_VersionVector
 
 typealias ErrorInfo = Google_Rpc_ErrorInfo

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -900,6 +900,22 @@ public struct Yorkie_V1_Operation: Sendable {
     /// Clears the value of `executedAt`. Subsequent reads from it will return its default value.
     public mutating func clearExecutedAt() {_uniqueStorage()._executedAt = nil}
 
+    /// identity-preserving undo/redo
+    public var restoreSpans: [Yorkie_V1_TreeRestoreSpan] {
+      get {_storage._restoreSpans}
+      set {_uniqueStorage()._restoreSpans = newValue}
+    }
+
+    public var restoreMode: Yorkie_V1_RestoreMode {
+      get {_storage._restoreMode}
+      set {_uniqueStorage()._restoreMode = newValue}
+    }
+
+    public var retombstoneSpans: [Yorkie_V1_TreeRestoreSpan] {
+      get {_storage._retombstoneSpans}
+      set {_uniqueStorage()._retombstoneSpans = newValue}
+    }
+
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     public init() {}
@@ -2431,6 +2447,88 @@ public struct Yorkie_V1_RestoreSpan: Sendable {
   fileprivate var _createdAt: Yorkie_V1_TimeTicket? = nil
 }
 
+/// TreeRestoreSpan carries a tree node run from a single deletion, addressed
+/// by TreeNodeID identity, for identity-preserving Tree undo/redo. Unlike the
+/// text RestoreSpan (flat offsets), a tree span records the node's structure
+/// (type/attrs) and its position anchors, because in a tree id-order is not
+/// sibling-order: left_sibling_id and right_sibling_id are redundant external
+/// boundary anchors of the deleted run, so restore can reconstruct the run's
+/// internal order from the op's own spans and needs only one surviving
+/// boundary to place it. value/attributes are a deep copy so a GC-purged node
+/// can be recreated.
+public struct Yorkie_V1_TreeRestoreSpan: @unchecked Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var id: Yorkie_V1_TreeNodeID {
+    get {_storage._id ?? Yorkie_V1_TreeNodeID()}
+    set {_uniqueStorage()._id = newValue}
+  }
+  /// Returns true if `id` has been explicitly set.
+  public var hasID: Bool {_storage._id != nil}
+  /// Clears the value of `id`. Subsequent reads from it will return its default value.
+  public mutating func clearID() {_uniqueStorage()._id = nil}
+
+  public var nodeType: String {
+    get {_storage._nodeType}
+    set {_uniqueStorage()._nodeType = newValue}
+  }
+
+  public var isText: Bool {
+    get {_storage._isText}
+    set {_uniqueStorage()._isText = newValue}
+  }
+
+  public var length: Int32 {
+    get {_storage._length}
+    set {_uniqueStorage()._length = newValue}
+  }
+
+  public var value: String {
+    get {_storage._value}
+    set {_uniqueStorage()._value = newValue}
+  }
+
+  public var attributes: Dictionary<String,Yorkie_V1_NodeAttr> {
+    get {_storage._attributes}
+    set {_uniqueStorage()._attributes = newValue}
+  }
+
+  public var parentID: Yorkie_V1_TreeNodeID {
+    get {_storage._parentID ?? Yorkie_V1_TreeNodeID()}
+    set {_uniqueStorage()._parentID = newValue}
+  }
+  /// Returns true if `parentID` has been explicitly set.
+  public var hasParentID: Bool {_storage._parentID != nil}
+  /// Clears the value of `parentID`. Subsequent reads from it will return its default value.
+  public mutating func clearParentID() {_uniqueStorage()._parentID = nil}
+
+  public var leftSiblingID: Yorkie_V1_TreeNodeID {
+    get {_storage._leftSiblingID ?? Yorkie_V1_TreeNodeID()}
+    set {_uniqueStorage()._leftSiblingID = newValue}
+  }
+  /// Returns true if `leftSiblingID` has been explicitly set.
+  public var hasLeftSiblingID: Bool {_storage._leftSiblingID != nil}
+  /// Clears the value of `leftSiblingID`. Subsequent reads from it will return its default value.
+  public mutating func clearLeftSiblingID() {_uniqueStorage()._leftSiblingID = nil}
+
+  public var rightSiblingID: Yorkie_V1_TreeNodeID {
+    get {_storage._rightSiblingID ?? Yorkie_V1_TreeNodeID()}
+    set {_uniqueStorage()._rightSiblingID = newValue}
+  }
+  /// Returns true if `rightSiblingID` has been explicitly set.
+  public var hasRightSiblingID: Bool {_storage._rightSiblingID != nil}
+  /// Clears the value of `rightSiblingID`. Subsequent reads from it will return its default value.
+  public mutating func clearRightSiblingID() {_uniqueStorage()._rightSiblingID = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
 public struct Yorkie_V1_TimeTicket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3753,7 +3851,7 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Yorkie_V1_Operation.protoMessageName + ".TreeEdit"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{3}created_at_map_by_actor\0\u{1}contents\0\u{3}executed_at\0\u{3}split_level\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{3}created_at_map_by_actor\0\u{1}contents\0\u{3}executed_at\0\u{3}split_level\0\u{3}restore_spans\0\u{3}restore_mode\0\u{3}retombstone_spans\0")
 
   fileprivate class _StorageClass {
     var _parentCreatedAt: Yorkie_V1_TimeTicket? = nil
@@ -3763,6 +3861,9 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
     var _contents: [Yorkie_V1_TreeNodes] = []
     var _splitLevel: Int32 = 0
     var _executedAt: Yorkie_V1_TimeTicket? = nil
+    var _restoreSpans: [Yorkie_V1_TreeRestoreSpan] = []
+    var _restoreMode: Yorkie_V1_RestoreMode = .unspecified
+    var _retombstoneSpans: [Yorkie_V1_TreeRestoreSpan] = []
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -3780,6 +3881,9 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
       _contents = source._contents
       _splitLevel = source._splitLevel
       _executedAt = source._executedAt
+      _restoreSpans = source._restoreSpans
+      _restoreMode = source._restoreMode
+      _retombstoneSpans = source._retombstoneSpans
     }
   }
 
@@ -3805,6 +3909,9 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
         case 5: try { try decoder.decodeRepeatedMessageField(value: &_storage._contents) }()
         case 6: try { try decoder.decodeSingularMessageField(value: &_storage._executedAt) }()
         case 7: try { try decoder.decodeSingularInt32Field(value: &_storage._splitLevel) }()
+        case 8: try { try decoder.decodeRepeatedMessageField(value: &_storage._restoreSpans) }()
+        case 9: try { try decoder.decodeSingularEnumField(value: &_storage._restoreMode) }()
+        case 10: try { try decoder.decodeRepeatedMessageField(value: &_storage._retombstoneSpans) }()
         default: break
         }
       }
@@ -3838,6 +3945,15 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
       if _storage._splitLevel != 0 {
         try visitor.visitSingularInt32Field(value: _storage._splitLevel, fieldNumber: 7)
       }
+      if !_storage._restoreSpans.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._restoreSpans, fieldNumber: 8)
+      }
+      if _storage._restoreMode != .unspecified {
+        try visitor.visitSingularEnumField(value: _storage._restoreMode, fieldNumber: 9)
+      }
+      if !_storage._retombstoneSpans.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._retombstoneSpans, fieldNumber: 10)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3854,6 +3970,9 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
         if _storage._contents != rhs_storage._contents {return false}
         if _storage._splitLevel != rhs_storage._splitLevel {return false}
         if _storage._executedAt != rhs_storage._executedAt {return false}
+        if _storage._restoreSpans != rhs_storage._restoreSpans {return false}
+        if _storage._restoreMode != rhs_storage._restoreMode {return false}
+        if _storage._retombstoneSpans != rhs_storage._retombstoneSpans {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -6096,6 +6215,132 @@ extension Yorkie_V1_RestoreSpan: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.end != rhs.end {return false}
     if lhs.content != rhs.content {return false}
     if lhs.attributes != rhs.attributes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Yorkie_V1_TreeRestoreSpan: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TreeRestoreSpan"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}node_type\0\u{3}is_text\0\u{1}length\0\u{1}value\0\u{1}attributes\0\u{3}parent_id\0\u{3}left_sibling_id\0\u{3}right_sibling_id\0")
+
+  fileprivate class _StorageClass {
+    var _id: Yorkie_V1_TreeNodeID? = nil
+    var _nodeType: String = String()
+    var _isText: Bool = false
+    var _length: Int32 = 0
+    var _value: String = String()
+    var _attributes: Dictionary<String,Yorkie_V1_NodeAttr> = [:]
+    var _parentID: Yorkie_V1_TreeNodeID? = nil
+    var _leftSiblingID: Yorkie_V1_TreeNodeID? = nil
+    var _rightSiblingID: Yorkie_V1_TreeNodeID? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _id = source._id
+      _nodeType = source._nodeType
+      _isText = source._isText
+      _length = source._length
+      _value = source._value
+      _attributes = source._attributes
+      _parentID = source._parentID
+      _leftSiblingID = source._leftSiblingID
+      _rightSiblingID = source._rightSiblingID
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._id) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._nodeType) }()
+        case 3: try { try decoder.decodeSingularBoolField(value: &_storage._isText) }()
+        case 4: try { try decoder.decodeSingularInt32Field(value: &_storage._length) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._value) }()
+        case 6: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_NodeAttr>.self, value: &_storage._attributes) }()
+        case 7: try { try decoder.decodeSingularMessageField(value: &_storage._parentID) }()
+        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._leftSiblingID) }()
+        case 9: try { try decoder.decodeSingularMessageField(value: &_storage._rightSiblingID) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._id {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      } }()
+      if !_storage._nodeType.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._nodeType, fieldNumber: 2)
+      }
+      if _storage._isText != false {
+        try visitor.visitSingularBoolField(value: _storage._isText, fieldNumber: 3)
+      }
+      if _storage._length != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._length, fieldNumber: 4)
+      }
+      if !_storage._value.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._value, fieldNumber: 5)
+      }
+      if !_storage._attributes.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Yorkie_V1_NodeAttr>.self, value: _storage._attributes, fieldNumber: 6)
+      }
+      try { if let v = _storage._parentID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      } }()
+      try { if let v = _storage._leftSiblingID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      } }()
+      try { if let v = _storage._rightSiblingID {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      } }()
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Yorkie_V1_TreeRestoreSpan, rhs: Yorkie_V1_TreeRestoreSpan) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._id != rhs_storage._id {return false}
+        if _storage._nodeType != rhs_storage._nodeType {return false}
+        if _storage._isText != rhs_storage._isText {return false}
+        if _storage._length != rhs_storage._length {return false}
+        if _storage._value != rhs_storage._value {return false}
+        if _storage._attributes != rhs_storage._attributes {return false}
+        if _storage._parentID != rhs_storage._parentID {return false}
+        if _storage._leftSiblingID != rhs_storage._leftSiblingID {return false}
+        if _storage._rightSiblingID != rhs_storage._rightSiblingID {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -132,6 +132,9 @@ message Operation {
     repeated TreeNodes contents = 5;
     int32 split_level = 7;
     TimeTicket executed_at = 6;
+    repeated TreeRestoreSpan restore_spans = 8; // identity-preserving undo/redo
+    RestoreMode restore_mode = 9;
+    repeated TreeRestoreSpan retombstone_spans = 10;
   }
   message TreeStyle {
     TimeTicket parent_created_at = 1;
@@ -447,6 +450,27 @@ enum RestoreMode {
   RESTORE_MODE_UNSPECIFIED = 0;
   RESTORE_MODE_RESTORE = 1;
   RESTORE_MODE_RETOMBSTONE = 2;
+}
+
+// TreeRestoreSpan carries a tree node run from a single deletion, addressed
+// by TreeNodeID identity, for identity-preserving Tree undo/redo. Unlike the
+// text RestoreSpan (flat offsets), a tree span records the node's structure
+// (type/attrs) and its position anchors, because in a tree id-order is not
+// sibling-order: left_sibling_id and right_sibling_id are redundant external
+// boundary anchors of the deleted run, so restore can reconstruct the run's
+// internal order from the op's own spans and needs only one surviving
+// boundary to place it. value/attributes are a deep copy so a GC-purged node
+// can be recreated.
+message TreeRestoreSpan {
+  TreeNodeID id = 1;
+  string node_type = 2;
+  bool is_text = 3;
+  int32 length = 4;
+  string value = 5;
+  map<string, NodeAttr> attributes = 6;
+  TreeNodeID parent_id = 7;
+  TreeNodeID left_sibling_id = 8;
+  TreeNodeID right_sibling_id = 9;
 }
 
 message TimeTicket {

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -38,6 +38,17 @@ enum TreeChangeType {
     case removeStyle
 }
 
+/// `PosBoundary` selects how a position inside a merged-away parent resolves in
+/// ``CRDTTree/findNodesAndSplitText(_:_:_:)``.
+enum PosBoundary {
+    /// The insertion boundary in the merge target, before the first moved child,
+    /// so RGA ordering breaks ties between concurrent inserts.
+    case insert
+    /// The position right after the merge-source tombstone, so a style range
+    /// neither grows over nor shrinks past nodes concurrently inserted there.
+    case range
+}
+
 enum TreeChangeValue {
     case nodes([CRDTTreeNode])
     case attributes([String: String])
@@ -936,10 +947,18 @@ class CRDTTree: CRDTElement {
      * The ids of the given `pos` are the ids of the node in the CRDT perspective.
      * This is different from `TreePos` which is a position of the tree in the
      * physical perspective.
+     *
+     * `boundary` selects how a position inside a merged-away parent resolves:
+     * ``PosBoundary/insert`` places it at the insertion boundary in the merge
+     * target (before the first moved child, so RGA ordering breaks ties), while
+     * ``PosBoundary/range`` places it right after the merge-source tombstone so a
+     * style range neither grows over nor shrinks past nodes concurrently inserted
+     * at that anchor.
      */
     func findNodesAndSplitText(
         _ pos: CRDTTreePos,
-        _ editedAt: TimeTicket? = nil
+        _ editedAt: TimeTicket? = nil,
+        _ boundary: PosBoundary = .insert
     ) throws -> (TreeNodePair, DataSize) {
         var diff = DataSize(data: 0, meta: 0)
         // 01. Find the parent and left sibling node of the given position.
@@ -957,6 +976,16 @@ class CRDTTree: CRDTElement {
         // tombstoned parent (i.e. the first child moved by the merge, in target
         // child order).
         if realParent.isRemoved, isLeftMost, let mergedInto = realParent.mergedInto {
+            // §9.3 Range Boundary at Merged-Away Anchors: a range boundary
+            // resolves to the position right after the merge-source tombstone,
+            // not the insertion boundary below. The insertion boundary sits
+            // before the first moved child, so it would extend a style range over
+            // nodes concurrently inserted between the tombstone and the moved
+            // children — nodes the styling client saw outside its range (after
+            // the then-live parent).
+            if boundary == .range, let tombstoneParent = realParent.parent {
+                return ((tombstoneParent, realParent), diff)
+            }
             if let mergeTarget = self.findFloorNode(mergedInto), !mergeTarget.isRemoved {
                 let allChildren = mergeTarget.innerChildren
                 for (index, targetChild) in allChildren.enumerated() {
@@ -1013,8 +1042,8 @@ class CRDTTree: CRDTElement {
         _ versionVector: VersionVector?
     ) throws -> ([GCPair], [TreeChange], DataSize, [String: String], [String]) {
         var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
-        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt, .range)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt, .range)
         diff.addDataSizes(others: fromDiff, toDiff)
 
         // Advance past split siblings unknown to the editing client so the range
@@ -1161,8 +1190,8 @@ class CRDTTree: CRDTElement {
         _ versionVector: VersionVector? = nil
     ) throws -> ([GCPair], [TreeChange], DataSize, [String: String]) {
         var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
-        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt, .range)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt, .range)
         diff.addDataSizes(others: fromDiff, toDiff)
 
         // Advance past split siblings unknown to the editing client so the range

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1384,7 +1384,11 @@ class CRDTTree: CRDTElement {
                 // intentional merge.
                 if ticketKnown(versionVector, node.createdAt) {
                     toBeMergedNodes.append(node)
-                    toBeMovedToFromParents.append(contentsOf: node.children)
+                    // Include removed children (innerChildren) so tombstones move
+                    // with the merge and survive as RGA anchors; a concurrent
+                    // insert referencing one then resolves in the merge target
+                    // and orders via the RGA tie-break.
+                    toBeMovedToFromParents.append(contentsOf: node.innerChildren)
                 }
             }
 
@@ -1527,23 +1531,30 @@ class CRDTTree: CRDTElement {
     }
 
     /**
-     * `applyMergeMoves` moves each alive node marked for merge into `fromParent`,
+     * `applyMergeMoves` moves each node marked for merge into `fromParent`,
      * recording `mergedFrom`/`mergedAt` (both persisted in the snapshot encoding;
      * `mergedAt` is captured here because the source's `removedAt` may be
-     * overwritten by a later LWW tombstone) and detaching it from its old parent.
-     * It then sets the `mergedInto` forwarding cache on the merge-source nodes.
+     * overwritten by a later LWW tombstone) and re-parenting it from its old
+     * parent. It then sets the `mergedInto` forwarding cache on the merge-source
+     * nodes.
      */
     private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) throws {
-        for node in toBeMovedToFromParents where node.removedAt == nil {
-            if let parent = node.parent {
-                node.mergedFrom = parent.id
-                node.mergedAt = editedAt
-                // Detach from old parent to prevent ghost references. The child
-                // may already have been detached by a concurrent operation
-                // (e.g., cascade delete of split sibling), so ignore the error.
-                try? parent.detachChild(child: node)
+        for node in toBeMovedToFromParents {
+            // A moved child must have a source parent to record; skip otherwise
+            // rather than append an untracked node (a node without `mergedFrom`
+            // is invisible to the merge-delete propagation and rebuild logic).
+            guard let parent = node.parent else {
+                continue
             }
-            try fromParent.append(contentsOf: [node])
+            // Tombstoned children are moved too (kept removed): they stay as RGA
+            // anchors so a concurrent insert referencing one resolves in the
+            // merge target and orders via the RGA tie-break, converging with the
+            // replica that inserted before the merge. `moveChild` keeps the size
+            // accounting correct for both live and tombstoned children
+            // (visible-neutral for the latter), so index positions stay correct.
+            node.mergedFrom = parent.id
+            node.mergedAt = editedAt
+            try fromParent.moveChild(child: node)
         }
 
         // Forwarding pointer rebuilt from `mergedFrom` on snapshot load.

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -871,12 +871,12 @@ class CRDTTree: CRDTElement {
      */
     private func resolveMergeTarget(_ node: CRDTTreeNode) -> CRDTTreeNode {
         var target = node
-        var seen = [CRDTTreeNode]([target])
+        var seen: Set<ObjectIdentifier> = [ObjectIdentifier(target)]
         while target.isRemoved, let mergedInto = target.mergedInto {
-            guard let next = self.findFloorNode(mergedInto), !seen.contains(where: { $0 === next }) else {
+            guard let next = self.findFloorNode(mergedInto), !seen.contains(ObjectIdentifier(next)) else {
                 break
             }
-            seen.append(next)
+            seen.insert(ObjectIdentifier(next))
             target = next
         }
         return target
@@ -1547,7 +1547,7 @@ class CRDTTree: CRDTElement {
         // 03. Merge: move the nodes that are marked as moved, then set the
         // forwarding pointer on merge-source nodes. Returns the resolved
         // destination, which differs from `fromParent` in a chained merge.
-        let mergeDest = try self.applyMergeMoves(toBeMovedToFromParents, fromParent, toBeMergedNodes, editedAt)
+        let mergeDest = try self.applyMergeMoves(toBeMovedToFromParents, fromParent, editedAt)
 
         // 03-1. Propagate deletes to children moved by prior merges. When a
         // merge-source node is fully deleted (not a merge boundary), its former
@@ -1653,7 +1653,7 @@ class CRDTTree: CRDTElement {
      * parent. It then sets the `mergedInto` forwarding cache on the merge-source
      * nodes.
      */
-    private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _: [CRDTTreeNode], _ editedAt: TimeTicket) throws -> CRDTTreeNode {
+    private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ editedAt: TimeTicket) throws -> CRDTTreeNode {
         // §6.3 Chained-Merge Flattening: a merge chain P->Q->R is kept flat so
         // runtime state matches what `rebuildMergeState` derives from a snapshot
         // (which can only ever represent the compressed chain, because it records
@@ -1748,7 +1748,7 @@ class CRDTTree: CRDTElement {
      */
     /// Skips when `mergedInto` points to the merge destination (concurrent
     /// merge). The comparison is against the resolved `dest`, not `fromParent`:
-    /// the forwarding pointers set by ``applyMergeMoves(_:_:_:_:)`` point at the
+    /// the forwarding pointers set by ``applyMergeMoves(_:_:_:)`` point at the
     /// flattened target, so a chained merge (`dest !== fromParent`) must
     /// recognise a concurrent-merge boundary by `dest`.
     private func propagateDeletesToMergedChildren(_ nodesToBeRemoved: [CRDTTreeNode], _ dest: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) -> [GCPair] {
@@ -2464,12 +2464,21 @@ extension CRDTTree {
 
         let node: CRDTTreeNode
         if span.isText {
+            // Slice in UTF-16 with an EXCLUSIVE end. Tree text offsets are UTF-16
+            // throughout (`CRDTTreeNode.value`'s setter sets `size` from
+            // `NSString.length`, and `splitText` slices with `NSString`), whereas
+            // `String.substring(from:to:)` indexes by grapheme AND treats `to` as
+            // inclusive — either would silently produce a node whose value and
+            // `size` disagree with JS, corrupting ancestor index accounting.
             let base = Int(offset - span.id.offset)
-            let source = (span.value as String?) ?? ""
-            let value = source.substring(from: base, to: base + Int(length))
+            let source: NSString = span.value ?? ""
+            guard base >= 0, length >= 0, base + Int(length) <= source.length else {
+                return nil
+            }
+            let value = source.substring(with: NSRange(location: base, length: Int(length))) as NSString
             node = CRDTTreeNode(id: CRDTTreeNodeID(createdAt: span.id.createdAt, offset: offset),
                                 type: span.nodeType,
-                                value: value as NSString)
+                                value: value)
         } else {
             node = CRDTTreeNode(id: span.id,
                                 type: span.nodeType,

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -255,6 +255,35 @@ typealias TreeNodePair = (CRDTTreeNode, CRDTTreeNode)
 public typealias TreePosStructRange = (CRDTTreePosStruct, CRDTTreePosStruct)
 
 /**
+ * `TreeRestoreSpan` identifies a node an edit transitioned visible → tombstoned,
+ * for identity-preserving Tree undo/redo. For text nodes the span is the
+ * absolute-offset interval `[id.offset, id.offset + length)` of the original
+ * insertion (split-invariant); for element nodes it is the whole node.
+ * `value`/`attrs` are deep-copied so a GC-purged node can be recreated.
+ * `leftSiblingID`/`rightSiblingID` are the deleted run's external boundary
+ * anchors captured at tombstone time — redundant on purpose: since a run's spans
+ * are carried together, restore can rebuild the run's internal order from the op
+ * itself and needs only ONE surviving boundary to place it (id-order is not
+ * sibling-order in a tree).
+ */
+struct TreeRestoreSpan {
+    let id: CRDTTreeNodeID
+    let nodeType: TreeNodeType
+    let isText: Bool
+    /// Text length; 0 for elements.
+    let length: Int32
+    /// Text content copy.
+    let value: NSString?
+    /// Element attribute snapshot.
+    let attrs: RHT?
+    let parentID: CRDTTreeNodeID?
+    /// `nil` → was first child.
+    let leftSiblingID: CRDTTreeNodeID?
+    /// `nil` → was last child.
+    let rightSiblingID: CRDTTreeNodeID?
+}
+
+/**
  * `CRDTTreeNode` is a node of CRDTTree. It includes the logical clock and
  * links to other nodes to resolve conflicts.
  */
@@ -396,6 +425,21 @@ final class CRDTTreeNode: IndexTreeNode {
         }
 
         return false
+    }
+
+    /**
+     * `unremove` clears the tombstone of this node (identity-preserving
+     * restore). Mirrors ``remove(_:)``'s ancestor-size bookkeeping so the node
+     * becomes visible again in place.
+     */
+    func unremove() {
+        guard self.removedAt != nil else {
+            return
+        }
+        self.removedAt = nil
+        // `updateAncestorsSize` signs the delta by the node's own `isRemoved`,
+        // which is now false, so this adds the size back.
+        self.updateAncestorsSize()
     }
 
     /**
@@ -1395,7 +1439,7 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan]) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
@@ -1488,13 +1532,17 @@ class CRDTTree: CRDTElement {
         let mergeLevel = toBeMergedNodes.count
 
         // 02. Delete: delete the nodes that are marked as removed.
-        var pairs = [GCPair]()
-        for node in nodesToBeRemoved {
-            let didRemove = node.remove(editedAt)
-            if didRemove {
-                pairs.append(GCPair(parent: self, child: node))
-            }
-        }
+        var (pairs, removedSpans) = self.applyDeletions(nodesToBeRemoved, editedAt)
+        // Captured in the insert phase: identity spans of the nodes this edit
+        // inserts, so an undo re-removes them by identity (not by index, which
+        // would clobber concurrently-restored content) and a redo revives them.
+        var insertedSpans = [TreeRestoreSpan]()
+        // Track how many GC pairs exist right after the plain-delete loop; if the
+        // merge phases (steps 03/03-1) add more, this edit involved merge-child
+        // propagation and its captured spans are NOT a complete description of
+        // the deletion — the op layer then falls back to the copy-reinsert
+        // reverse.
+        let deletePairCount = pairs.count
 
         // 03. Merge: move the nodes that are marked as moved, then set the
         // forwarding pointer on merge-source nodes. Returns the resolved
@@ -1548,6 +1596,10 @@ class CRDTTree: CRDTElement {
                     }
 
                     self.nodeMapByID.put(node.id, node)
+
+                    // Capture this inserted node's identity span for
+                    // identity-preserving insert undo/redo.
+                    insertedSpans.append(self.makeRestoreSpan(node))
                 }
 
                 if !content.isRemoved {
@@ -1579,7 +1631,18 @@ class CRDTTree: CRDTElement {
         }
         pairs.append(contentsOf: self.drainPendingGCPairs())
 
-        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel, preTombstoned)
+        // Identity-preserving restore only covers plain deletions. If this edit
+        // merged nodes, or its merge propagation removed extra nodes, the
+        // captured spans don't fully describe the deletion → signal the op layer
+        // (empty spans) to keep the copy-reinsert reverse.
+        let spansComplete = mergeLevel == 0 && pairs.count == deletePairCount
+
+        // `traverseAll` is post-order (children before parent), so reverse to get
+        // parent-before-child — the order `restore` needs to recreate a purged
+        // subtree top-down (a child's recreate resolves its parent by identity).
+        let outRemoved = spansComplete ? removedSpans : []
+        let outInserted = spansComplete ? Array(insertedSpans.reversed()) : []
+        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel, preTombstoned, outRemoved, outInserted)
     }
 
     /**
@@ -1728,7 +1791,7 @@ class CRDTTree: CRDTElement {
         _ splitLevel: Int32,
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan]) {
         let fromPos = try self.findPos(range.0)
         let toPos = try self.findPos(range.1)
         return try self.edit(
@@ -2181,5 +2244,302 @@ extension CRDTTree: CRDTGCPairContainable {
 extension CRDTTreeNode {
     var toXML: String {
         return CRDTTreeNode.toXML(node: self)
+    }
+}
+
+// MARK: - Identity-preserving Tree undo/redo (yorkie-js-sdk#1297)
+
+extension CRDTTree {
+    /**
+     * `applyDeletions` tombstones each node this edit removes and captures one
+     * ``TreeRestoreSpan`` per node it actually transitioned visible → tombstoned.
+     *
+     * `remove` returning true is exactly that transition, so pre-tombstoned nodes
+     * and LWW overwrites are excluded automatically. `nodesToBeRemoved` is in
+     * traversal order → parents precede children, which ``restore(_:)`` relies on
+     * when recreating purged subtrees.
+     */
+    private func applyDeletions(_ nodesToBeRemoved: [CRDTTreeNode], _ editedAt: TimeTicket) -> ([GCPair], [TreeRestoreSpan]) {
+        var pairs = [GCPair]()
+        var removedSpans = [TreeRestoreSpan]()
+        for node in nodesToBeRemoved where node.remove(editedAt) {
+            pairs.append(GCPair(parent: self, child: node))
+            removedSpans.append(self.makeRestoreSpan(node))
+        }
+        return (pairs, removedSpans)
+    }
+
+    /**
+     * `restore` re-establishes the nodes described by `spans` under their
+     * ORIGINAL identities (identity-preserving Tree undo): live → skip
+     * (idempotent), tombstoned → unremove in place, purged → recreate. Spans
+     * must be in parent-before-child order (``edit(_:_:_:_:_:_:)`` captures them
+     * that way).
+     *
+     * - Returns: the un-tombstoned and recreated nodes; the caller unregisters
+     *   GC pairs for the un-tombstoned ones.
+     */
+    func restore(_ spans: [TreeRestoreSpan]) throws -> ([CRDTTreeNode], [CRDTTreeNode]) {
+        var untombstoned = [CRDTTreeNode]()
+        var recreated = [CRDTTreeNode]()
+
+        for span in spans {
+            if !span.isText {
+                if let node = self.findFloorNode(span.id), node.id == span.id {
+                    if node.isRemoved {
+                        node.unremove()
+                        untombstoned.append(node)
+                    }
+                    continue
+                }
+                if let created = try self.recreateFromSpan(span, span.id.offset, span.length) {
+                    recreated.append(created)
+                }
+                continue
+            }
+
+            // Text: surviving pieces may be split finer than the span.
+            let start = span.id.offset
+            let end = start + span.length
+            let pieces = self.findPiecesOverlapping(span.id.createdAt, start, end)
+
+            var cursor = start
+            var pieceIdx = 0
+            while cursor < end {
+                let piece = pieceIdx < pieces.count ? pieces[pieceIdx] : nil
+                let pieceStart = piece?.id.offset ?? Int32.max
+                let pieceEnd = piece.map { $0.id.offset + Int32($0.size) } ?? Int32.max
+
+                if let piece, pieceStart <= cursor {
+                    if pieceStart < start || pieceEnd > end {
+                        // Piece straddles a span boundary. Under causal delivery
+                        // the forward delete split at span boundaries on every
+                        // replica before its undo could arrive, so this is not
+                        // expected; skip conservatively rather than un-tombstone
+                        // beyond the span. Mirrors the guard in `retombstone`.
+                        break
+                    }
+                    if piece.isRemoved {
+                        piece.unremove()
+                        untombstoned.append(piece)
+                    }
+                    cursor = Swift.min(pieceEnd, end)
+                    if cursor >= pieceEnd {
+                        pieceIdx += 1
+                    }
+                } else {
+                    let gapEnd = Swift.min(pieceStart, end)
+                    if let created = try self.recreateFromSpan(span, cursor, gapEnd - cursor) {
+                        recreated.append(created)
+                    }
+                    cursor = gapEnd
+                }
+            }
+        }
+
+        return (untombstoned, recreated)
+    }
+
+    /**
+     * `retombstone` re-deletes the nodes described by `spans` (redo of an
+     * identity-preserving undo). Live pieces only; idempotent.
+     *
+     * - Returns: GC pairs for the newly tombstoned nodes.
+     */
+    func retombstone(_ spans: [TreeRestoreSpan], _ executedAt: TimeTicket) -> [GCPair] {
+        var pairs = [GCPair]()
+        for span in spans {
+            let start = span.id.offset
+            let end = start + Swift.max(span.length, 1)
+            let pieces: [CRDTTreeNode]
+            if span.isText {
+                pieces = self.findPiecesOverlapping(span.id.createdAt, start, end)
+            } else if let node = self.findFloorNode(span.id), node.id == span.id {
+                pieces = [node]
+            } else {
+                pieces = []
+            }
+
+            for piece in pieces {
+                if piece.isRemoved {
+                    continue
+                }
+                if piece.isText, piece.id.offset < start || piece.id.offset + Int32(piece.size) > end {
+                    // Piece straddles a span boundary (same clamped `end` as
+                    // `findPiecesOverlapping`); skip so we never re-tombstone
+                    // content outside the span. Mirrors the guard in `restore`.
+                    continue
+                }
+                if piece.remove(executedAt) {
+                    pairs.append(GCPair(parent: self, child: piece))
+                }
+            }
+        }
+        return pairs
+    }
+
+    /**
+     * `findPiecesOverlapping` collects surviving pieces (live or tombstoned) of
+     * the text insertion `createdAt` overlapping `[start, end)`, in ascending
+     * offset order, via descending floorEntry probes.
+     */
+    private func findPiecesOverlapping(_ createdAt: TimeTicket, _ start: Int32, _ end: Int32) -> [CRDTTreeNode] {
+        var pieces = [CRDTTreeNode]()
+        var probe = end - 1
+        while probe >= 0 {
+            guard let node = self.findFloorNode(CRDTTreeNodeID(createdAt: createdAt, offset: probe)), node.isText else {
+                break
+            }
+            let nodeStart = node.id.offset
+            let nodeEnd = nodeStart + Int32(node.size)
+            if nodeEnd <= start {
+                break
+            }
+            if nodeStart < end, nodeEnd > start {
+                pieces.append(node)
+            }
+            if nodeStart <= start {
+                break
+            }
+            probe = nodeStart - 1
+        }
+        return pieces.reversed()
+    }
+
+    /**
+     * `makeRestoreSpan` captures the identity span of `node` — its id, type,
+     * content/attribute copy, and the external boundary anchors of its position
+     * — so an undo can re-establish it later even if it has been GC-purged.
+     */
+    private func makeRestoreSpan(_ node: CRDTTreeNode) -> TreeRestoreSpan {
+        var leftSiblingID: CRDTTreeNodeID?
+        var rightSiblingID: CRDTTreeNodeID?
+        let parent = node.parent
+        if let parent {
+            let siblings = parent.innerChildren
+            if let idx = siblings.firstIndex(where: { $0 === node }) {
+                if idx > 0 {
+                    leftSiblingID = self.leftAnchorID(siblings[idx - 1])
+                }
+                if idx < siblings.count - 1 {
+                    rightSiblingID = siblings[idx + 1].id
+                }
+            }
+        }
+
+        return TreeRestoreSpan(id: node.id,
+                               nodeType: node.type,
+                               isText: node.isText,
+                               length: node.isText ? Int32(node.size) : 0,
+                               value: node.isText ? node.value as NSString : nil,
+                               attrs: node.attrs?.deepcopy(),
+                               parentID: parent?.id,
+                               leftSiblingID: leftSiblingID,
+                               rightSiblingID: rightSiblingID)
+    }
+
+    /**
+     * `recreateFromSpan` rebuilds a purged node (or purged text sub-range) under
+     * its original identity and attaches it. Anchor ladder, each rung doing
+     * floor-lookup + parent-identity check:
+     *   (a) same-insertion successor/predecessor piece (text) → exact slot;
+     *   (b) captured left boundary sibling still under this parent → after it;
+     *   (c) captured right boundary sibling still under this parent → before it;
+     *   (d) deterministic id-order fallback: insert among the parent's current
+     *       children at the first position whose id compares greater than the
+     *       node's id (a pure function of ids → identical on every replica).
+     *
+     * A genuinely absent parent → skip: the node stays unplaced/invisible, which
+     * is convergent because every replica resolves parent-absent identically.
+     */
+    private func recreateFromSpan(_ span: TreeRestoreSpan, _ offset: Int32, _ length: Int32) throws -> CRDTTreeNode? {
+        guard let parentID = span.parentID,
+              let parent = self.findFloorNode(parentID),
+              parent.id == parentID
+        else {
+            // Parent gone (purged, and not part of this undo's spans). Leave the
+            // node unplaced; a later parent-restore will bring it back.
+            return nil
+        }
+
+        let node: CRDTTreeNode
+        if span.isText {
+            let base = Int(offset - span.id.offset)
+            let source = (span.value as String?) ?? ""
+            let value = source.substring(from: base, to: base + Int(length))
+            node = CRDTTreeNode(id: CRDTTreeNodeID(createdAt: span.id.createdAt, offset: offset),
+                                type: span.nodeType,
+                                value: value as NSString)
+        } else {
+            node = CRDTTreeNode(id: span.id,
+                                type: span.nodeType,
+                                attributes: span.attrs?.deepcopy())
+        }
+
+        let siblings = parent.innerChildren
+
+        // (a) same-insertion successor / predecessor piece (text): exact slot.
+        if span.isText {
+            if let succ = self.findFloorNode(CRDTTreeNodeID(createdAt: span.id.createdAt, offset: offset + length)),
+               succ.isText, succ.parent === parent, succ.id.offset == offset + length,
+               let succIdx = siblings.firstIndex(where: { $0 === succ })
+            {
+                try parent.insertAt(node, succIdx)
+                self.nodeMapByID.put(node.id, node)
+                return node
+            }
+            if offset > span.id.offset || offset > 0 {
+                if let pred = self.findFloorNode(CRDTTreeNodeID(createdAt: span.id.createdAt, offset: offset - 1)),
+                   pred.isText, pred.parent === parent
+                {
+                    try parent.insertAfter(node, pred)
+                    self.nodeMapByID.put(node.id, node)
+                    return node
+                }
+            }
+        }
+
+        // (b) captured left boundary sibling, if it still exists under this parent.
+        if let leftSiblingID = span.leftSiblingID,
+           let left = self.findFloorNode(leftSiblingID), left.parent === parent
+        {
+            try parent.insertAfter(node, left)
+            self.nodeMapByID.put(node.id, node)
+            return node
+        }
+
+        // (c) captured right boundary sibling (redundant anchor): insert before it.
+        if let rightSiblingID = span.rightSiblingID,
+           let right = self.findFloorNode(rightSiblingID), right.parent === parent,
+           let rightIdx = siblings.firstIndex(where: { $0 === right })
+        {
+            try parent.insertAt(node, rightIdx)
+            self.nodeMapByID.put(node.id, node)
+            return node
+        }
+
+        // (d) deterministic id-order fallback: first slot whose child id > node id.
+        // `CRDTTreeNodeID` is `Comparable` on (createdAt, offset), which is the
+        // total order this rung needs.
+        let insertIdx = siblings.firstIndex { $0.id > node.id } ?? siblings.count
+        try parent.insertAt(node, insertIdx)
+        self.nodeMapByID.put(node.id, node)
+        return node
+    }
+
+    /**
+     * `leftAnchorID` returns the id to store as a restore span's left-sibling
+     * anchor. For a text node the anchor is its LAST character's offset, not its
+     * start: a concurrent delete may later split the left neighbour, and only the
+     * last-char offset floor-resolves to the rightmost fragment (the true left
+     * neighbour of the restored node). For elements (never split by offset) the
+     * node's own id is exact. Right-sibling anchors always use the start offset,
+     * which floor-resolves to the leftmost fragment — the true right neighbour.
+     */
+    private func leftAnchorID(_ sibling: CRDTTreeNode) -> CRDTTreeNodeID {
+        guard sibling.isText else {
+            return sibling.id
+        }
+        return CRDTTreeNodeID(createdAt: sibling.id.createdAt, offset: sibling.id.offset + Int32(sibling.size) - 1)
     }
 }

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -806,6 +806,28 @@ class CRDTTree: CRDTElement {
     }
 
     /**
+     * `resolveMergeTarget` follows the `mergedInto` forwarding chain from the
+     * given node while the current node is a merge-away tombstone, returning the
+     * final live target. When a merge lands on a parent that a prior concurrent
+     * merge already merged away (a chained merge P->Q->R, applied Q->R before
+     * this P->Q), the children must flow to that parent's final destination so
+     * the merge chain stays flat (P->R, not P->Q) and both replicas converge.
+     * The seen set guards against cycles from a concurrent mutual merge.
+     */
+    private func resolveMergeTarget(_ node: CRDTTreeNode) -> CRDTTreeNode {
+        var target = node
+        var seen = [CRDTTreeNode]([target])
+        while target.isRemoved, let mergedInto = target.mergedInto {
+            guard let next = self.findFloorNode(mergedInto), !seen.contains(where: { $0 === next }) else {
+                break
+            }
+            seen.append(next)
+            target = next
+        }
+        return target
+    }
+
+    /**
      * `advancePastUnknownSplitSiblings` follows the `insNextID` chain of the
      * given node, advancing past element-type split siblings that the editing
      * client did not know about (not in `versionVector`).
@@ -1446,13 +1468,14 @@ class CRDTTree: CRDTElement {
         }
 
         // 03. Merge: move the nodes that are marked as moved, then set the
-        // forwarding pointer on merge-source nodes.
-        try self.applyMergeMoves(toBeMovedToFromParents, fromParent, toBeMergedNodes, editedAt)
+        // forwarding pointer on merge-source nodes. Returns the resolved
+        // destination, which differs from `fromParent` in a chained merge.
+        let mergeDest = try self.applyMergeMoves(toBeMovedToFromParents, fromParent, toBeMergedNodes, editedAt)
 
         // 03-1. Propagate deletes to children moved by prior merges. When a
         // merge-source node is fully deleted (not a merge boundary), its former
         // children in the merge target should also be deleted.
-        pairs.append(contentsOf: self.propagateDeletesToMergedChildren(nodesToBeRemoved, fromParent, toBeMergedNodes, editedAt))
+        pairs.append(contentsOf: self.propagateDeletesToMergedChildren(nodesToBeRemoved, mergeDest, toBeMergedNodes, editedAt))
 
         // 04. Split: split the element nodes for the given split level.
         if splitLevel > 0 {
@@ -1538,7 +1561,15 @@ class CRDTTree: CRDTElement {
      * parent. It then sets the `mergedInto` forwarding cache on the merge-source
      * nodes.
      */
-    private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) throws {
+    private func applyMergeMoves(_ toBeMovedToFromParents: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _: [CRDTTreeNode], _ editedAt: TimeTicket) throws -> CRDTTreeNode {
+        // §6.3 Chained-Merge Flattening: a merge chain P->Q->R is kept flat so
+        // runtime state matches what `rebuildMergeState` derives from a snapshot
+        // (which can only ever represent the compressed chain, because it records
+        // one `mergedFrom` pointer per child and reads the child's final physical
+        // parent). The destination is resolved through `resolveMergeTarget`, so
+        // children merged into an already-merged-away parent forward to the final
+        // live target instead of piling up under the removed intermediate.
+        let dest = self.resolveMergeTarget(fromParent)
         for node in toBeMovedToFromParents {
             // A moved child must have a source parent to record; skip otherwise
             // rather than append an untracked node (a node without `mergedFrom`
@@ -1552,15 +1583,40 @@ class CRDTTree: CRDTElement {
             // replica that inserted before the merge. `moveChild` keeps the size
             // accounting correct for both live and tombstoned children
             // (visible-neutral for the latter), so index positions stay correct.
-            node.mergedFrom = parent.id
-            node.mergedAt = editedAt
-            try fromParent.moveChild(child: node)
+            //
+            // `mergedFrom` and `mergedAt` are stamped together, only on the first
+            // move, so a child carried through a chained merge keeps its original
+            // source P and the original P->Q merge ticket. Stamping `mergedAt` on
+            // every move would diverge: a replica that applied P->Q then Q->R
+            // would record the Q->R ticket, while a replica where Q was already
+            // merged records the P->Q ticket on the single forwarded move.
+            if node.mergedFrom == nil {
+                node.mergedFrom = parent.id
+                node.mergedAt = editedAt
+            }
+            try dest.moveChild(child: node)
+            // Point this child's original source at the resolved destination,
+            // path-compressing a transitive source (a prior merge whose children
+            // were just relocated again) from the now-removed intermediate to the
+            // final target. This runtime cache is rebuilt from `mergedFrom` on
+            // snapshot load. Deriving `mergedInto` from a *moved* child — one that
+            // had a parent above — mirrors `rebuildMergeState`, which likewise
+            // skips parentless children, so runtime and snapshot agree. (A
+            // parentless child, detached by a concurrent split cascade, is
+            // skipped above and must not repoint its source here.)
+            //
+            // `mergedInto` is set solely from moved children (never from the
+            // merge-source list directly), so it is set only when
+            // `rebuildMergeState` can reconstruct it — a source with no moved
+            // child of its own (e.g. an intermediate that only relayed another
+            // source's children) is left unset on both paths, keeping runtime and
+            // snapshot consistent.
+            if let mergedFrom = node.mergedFrom, let src = self.findFloorNode(mergedFrom) {
+                src.mergedInto = dest.id
+            }
         }
 
-        // Forwarding pointer rebuilt from `mergedFrom` on snapshot load.
-        for src in toBeMergedNodes {
-            src.mergedInto = fromParent.id
-        }
+        return dest
     }
 
     /**
@@ -1598,12 +1654,17 @@ class CRDTTree: CRDTElement {
      * moved children are recomputed from the merge target's children filtered by
      * `mergedFrom`. Returns the GC pairs for the newly tombstoned nodes.
      */
-    private func propagateDeletesToMergedChildren(_ nodesToBeRemoved: [CRDTTreeNode], _ fromParent: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) -> [GCPair] {
+    /// Skips when `mergedInto` points to the merge destination (concurrent
+    /// merge). The comparison is against the resolved `dest`, not `fromParent`:
+    /// the forwarding pointers set by ``applyMergeMoves(_:_:_:_:)`` point at the
+    /// flattened target, so a chained merge (`dest !== fromParent`) must
+    /// recognise a concurrent-merge boundary by `dest`.
+    private func propagateDeletesToMergedChildren(_ nodesToBeRemoved: [CRDTTreeNode], _ dest: CRDTTreeNode, _ toBeMergedNodes: [CRDTTreeNode], _ editedAt: TimeTicket) -> [GCPair] {
         var pairs = [GCPair]()
         for node in nodesToBeRemoved {
             guard let mergedInto = node.mergedInto,
                   !toBeMergedNodes.contains(where: { $0 === node }),
-                  mergedInto != fromParent.id,
+                  mergedInto != dest.id,
                   let mergeTarget = self.findFloorNode(mergedInto)
             else {
                 continue

--- a/Sources/Document/CRDT/RGATreeSplit.swift
+++ b/Sources/Document/CRDT/RGATreeSplit.swift
@@ -915,6 +915,13 @@ class RGATreeSplit<T: RGATreeSplitValue> {
         var recreated = [RGATreeSplitNode<T>]()
         var liveDiff = DataSize(data: 0, meta: 0)
 
+        // The last node placed at the current cursor (un-tombstoned or recreated),
+        // in document order. When a recreated fragment has no surviving same-
+        // insertion anchor, chaining after this keeps a multi-fragment run in
+        // left-to-right order instead of each fragment prepending at the same fixed
+        // fallback anchor — which would rebuild the run reversed. Spans arrive in
+        // document order, so this is always the recreated fragment's left neighbour.
+        var chainAnchor: RGATreeSplitNode<T>?
         for span in spans {
             let pieces = self.findPiecesOverlapping(span.createdAt, span.start, span.end)
 
@@ -934,6 +941,9 @@ class RGATreeSplit<T: RGATreeSplitValue> {
                         // Repair splay weights on the path to root (length 0 → len).
                         self.treeByIndex.splayNode(target)
                         untombstoned.append(target)
+                        chainAnchor = target
+                    } else {
+                        chainAnchor = piece
                     }
                     cursor = overlapEnd
                     if overlapEnd >= pieceEnd {
@@ -950,10 +960,12 @@ class RGATreeSplit<T: RGATreeSplitValue> {
                         cursor,
                         gapEnd,
                         executedAt,
-                        fallbackAnchor
+                        fallbackAnchor,
+                        chainAnchor
                     )
                     _ = self.insertAfter(prev, newNode)
                     recreated.append(newNode)
+                    chainAnchor = newNode
                     cursor = gapEnd
                 }
             }
@@ -1105,15 +1117,19 @@ class RGATreeSplit<T: RGATreeSplitValue> {
      *      → directly after it
      *  (c) rightmost surviving piece of the same insertion (must be right
      *      of the gap) → directly before it
-     *  (d) the operation's fallback anchor (refined)
-     *  (e) head (deterministic last resort)
+     *  (d) chain anchor: the previously placed fragment of this same restore
+     *      (document order) → after it, so a purged multi-fragment run is
+     *      rebuilt left-to-right rather than reversed
+     *  (e) the operation's fallback anchor (refined)
+     *  (f) head (deterministic last resort)
      */
     private func findRestoreAnchor(
         _ createdAt: TimeTicket,
         _ gapStart: Int32,
         _ gapEnd: Int32,
         _ executedAt: TimeTicket,
-        _ fallbackAnchor: RGATreeSplitPos?
+        _ fallbackAnchor: RGATreeSplitPos?,
+        _ chainAnchor: RGATreeSplitNode<T>? = nil
     ) throws -> RGATreeSplitNode<T> {
         if let succ = self.findPieceCovering(createdAt, gapEnd), let prev = succ.prev {
             return prev
@@ -1133,6 +1149,13 @@ class RGATreeSplit<T: RGATreeSplitValue> {
            let prev = rightmost.value.prev
         {
             return prev
+        }
+
+        // (d) No surviving piece of this insertion anchors the fragment. When the
+        // whole run was purged, every fragment lands here; anchoring after the
+        // fragment placed just before it (document order) keeps the run forward.
+        if let chainAnchor {
+            return chainAnchor
         }
 
         if let fallbackAnchor {

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -787,7 +787,7 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, pairs, diff, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
+        let (_, pairs, diff, _, _, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
             context.issueTimeTicket
         }, nil)
         self.context?.acc(diff)

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -101,6 +101,16 @@ final class TreeEditOperation: Operation {
     /// for redo, rather than re-inserting the tombstoned boundary nodes as content.
     fileprivate var redoSplitLevel: Int32?
 
+    // Identity-preserving Tree undo/redo (mirrors ``EditOperation``): a reverse
+    // op carries the deleted nodes' spans and a mode. `.restore` revives
+    // `restoreSpans` and re-removes `retombstoneSpans`; `.retombstone` (the redo)
+    // does the opposite. Nodes are revived/removed by original identity, never
+    // copy-reinserted, so concurrent undos converge. Empty/nil for ordinary edits
+    // and for the copy-reinsert reverse of merge/split edits.
+    private(set) var restoreSpans: [TreeRestoreSpan]?
+    private(set) var restoreMode: RestoreMode?
+    private(set) var retombstoneSpans: [TreeRestoreSpan]?
+
     init(parentCreatedAt: TimeTicket,
          fromPos: CRDTTreePos,
          toPos: CRDTTreePos,
@@ -109,7 +119,10 @@ final class TreeEditOperation: Operation {
          executedAt: TimeTicket,
          isUndoOp: Bool = false,
          fromIdx: Int? = nil,
-         toIdx: Int? = nil)
+         toIdx: Int? = nil,
+         restoreSpans: [TreeRestoreSpan]? = nil,
+         restoreMode: RestoreMode? = nil,
+         retombstoneSpans: [TreeRestoreSpan]? = nil)
     {
         self.parentCreatedAt = parentCreatedAt
         self.fromPos = fromPos
@@ -120,6 +133,9 @@ final class TreeEditOperation: Operation {
         self.isUndoOp = isUndoOp
         self.fromIdx = fromIdx
         self.toIdx = toIdx
+        self.restoreSpans = restoreSpans
+        self.restoreMode = restoreMode
+        self.retombstoneSpans = retombstoneSpans
     }
 
     /**
@@ -142,6 +158,67 @@ final class TreeEditOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: "fail to execute, only Tree can execute edit")
         }
 
+        // Identity-preserving restore/retombstone path (mirrors ``EditOperation``).
+        // `restoreMode` selects direction; an undo (`.restore`) revives
+        // `restoreSpans` and re-removes `retombstoneSpans`, the redo
+        // (`.retombstone`) does the opposite. Nodes move by identity, never
+        // copy-reinsert.
+        if self.restoreSpans != nil || self.retombstoneSpans != nil {
+            var isRetombstone = false
+            if case .retombstone = self.restoreMode {
+                isRetombstone = true
+            }
+            let toRestore = (isRetombstone ? self.retombstoneSpans : self.restoreSpans) ?? []
+            let toRetombstone = (isRetombstone ? self.restoreSpans : self.retombstoneSpans) ?? []
+
+            var diff = DataSize(data: 0, meta: 0)
+            // 1. Re-remove (retombstone) by identity.
+            for pair in tree.retombstone(toRetombstone, editedAt) {
+                root.registerGCPair(pair)
+            }
+            // 2. Revive (restore) by identity: un-tombstoned nodes move gc->live
+            // via `unregisterGCPair` (must be after `removedAt` is cleared, which
+            // `restore` does); recreated nodes are brand new, so add their size to
+            // live.
+            let (untombstoned, recreated) = try tree.restore(toRestore)
+            for node in untombstoned {
+                root.unregisterGCPair(GCPair(parent: tree, child: node))
+            }
+            for node in recreated {
+                diff.addDataSizes(others: node.getDataSize())
+            }
+            root.acc(diff)
+
+            // `opInfos` must be non-empty or `Document.executeUndoRedo` drops the
+            // undo change from localChanges (it never propagates to peers). Exact
+            // from/to for editor integration is best-effort here.
+            let opInfos: [any OperationInfo] = try [
+                TreeEditOpInfo(path: root.createPath(createdAt: self.parentCreatedAt),
+                               from: self.fromIdx ?? 0,
+                               to: self.toIdx ?? self.fromIdx ?? 0,
+                               value: [],
+                               splitLevel: 0,
+                               fromPath: [],
+                               toPath: [])
+            ]
+
+            // Reverse keeps the same span sets and flips the direction.
+            let reverseOp = TreeEditOperation(parentCreatedAt: self.parentCreatedAt,
+                                              fromPos: self.fromPos,
+                                              toPos: self.toPos,
+                                              contents: nil,
+                                              splitLevel: 0,
+                                              executedAt: self.executedAt,
+                                              isUndoOp: true,
+                                              fromIdx: self.fromIdx,
+                                              toIdx: self.toIdx,
+                                              restoreSpans: self.restoreSpans,
+                                              restoreMode: isRetombstone ? .restore : .retombstone,
+                                              retombstoneSpans: self.retombstoneSpans)
+
+            return ExecutionResult(opInfos: opInfos, reverseOp: reverseOp)
+        }
+
         // For undo ops the stored integer indices may have been reconciled against remote edits;
         // convert them back to positions on the current tree before editing.
         if self.isUndoOp, let fromIdx = self.fromIdx, let toIdx = self.toIdx {
@@ -156,7 +233,7 @@ final class TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
+        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -183,7 +260,7 @@ final class TreeEditOperation: Operation {
             && removedNodes.isEmpty
         let reverseOp: Operation?
         if self.splitLevel == 0 {
-            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx, preTombstoned: preTombstoned, mergeLevel: mergeLevel)
+            reverseOp = try self.toReverseOperation(tree, removedNodes, preEditFromIdx, preTombstoned: preTombstoned, mergeLevel: mergeLevel, removedSpans: removedSpans, insertedSpans: insertedSpans)
         } else if isPureSplit {
             reverseOp = try self.toSplitReverseOperation(tree, preEditFromIdx)
         } else {
@@ -244,7 +321,30 @@ final class TreeEditOperation: Operation {
     ///   - mergeLevel: The number of element boundaries merged by this edit. When greater than
     ///     zero the reverse op is a split rather than a content reinsertion.
     /// - Returns: The reverse ``TreeEditOperation``, or `nil` when the edit was a no-op.
-    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int, preTombstoned: Set<String> = [], mergeLevel: Int = 0) throws -> Operation? {
+    private func toReverseOperation(_ tree: CRDTTree, _ removedNodes: [CRDTTreeNode], _ preEditFromIdx: Int, preTombstoned: Set<String> = [], mergeLevel: Int = 0, removedSpans: [TreeRestoreSpan] = [], insertedSpans: [TreeRestoreSpan] = []) throws -> Operation? {
+        // Identity-preserving reverse: reverse an edit by reviving the nodes it
+        // removed (`restoreSpans`) AND re-removing the nodes it inserted
+        // (`retombstoneSpans`), both by ORIGINAL identity instead of
+        // copy-reinsert. `edit` only fills these spans when the edit was
+        // merge/split-free (spansComplete), so this never fires for the
+        // merge/split cases below; the `redoSplitLevel` guard keeps a split's own
+        // boundary-deletion undo on the re-split path (its deletion would
+        // otherwise fill `removedSpans` here).
+        if self.redoSplitLevel == nil, !removedSpans.isEmpty || !insertedSpans.isEmpty {
+            return TreeEditOperation(parentCreatedAt: self.parentCreatedAt,
+                                     fromPos: self.fromPos,
+                                     toPos: self.toPos,
+                                     contents: nil,
+                                     splitLevel: 0,
+                                     executedAt: TimeTicket.initial, // assigned at undo time
+                                     isUndoOp: true,
+                                     fromIdx: preEditFromIdx,
+                                     toIdx: preEditFromIdx,
+                                     restoreSpans: removedSpans,
+                                     restoreMode: .restore,
+                                     retombstoneSpans: insertedSpans)
+        }
+
         // Special case: this op is a boundary-deletion that was generated to reverse a split.
         // Its redo (i.e. the reverse of this reverse) should re-split at the merged position,
         // not re-insert the tombstoned boundary nodes as raw content.
@@ -400,6 +500,12 @@ final class TreeEditOperation: Operation {
     /// tree while the operation is parked on the undo/redo stack, so a later undo lands in the right
     /// spot. Uses the same 6-case overlap logic as ``EditOperation/reconcileOperation(_:_:_:)``.
     func reconcileOperation(_ remoteFrom: Int, _ remoteTo: Int, _ contentLen: Int) {
+        // Identity-addressed restore/retombstone ops locate their nodes by
+        // `CRDTTreeNodeID`, not by index, so index reconciliation must not touch
+        // them (mirrors ``EditOperation`` for Text).
+        if self.restoreSpans != nil || self.retombstoneSpans != nil {
+            return
+        }
         guard self.isUndoOp, let localFrom = self.fromIdx, let localTo = self.toIdx, remoteFrom <= remoteTo else {
             return
         }

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -208,7 +208,7 @@ final class TreeEditOperation: Operation {
                                               toPos: self.toPos,
                                               contents: nil,
                                               splitLevel: 0,
-                                              executedAt: self.executedAt,
+                                              executedAt: TimeTicket.initial, // reassigned at (re)undo time
                                               isUndoOp: true,
                                               fromIdx: self.fromIdx,
                                               toIdx: self.toIdx,

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -449,6 +449,56 @@ extension IndexTreeNode {
     }
 
     /**
+     * `moveChild` detaches the given child from its current parent (if any) and
+     * appends it to this node, preserving the size accounting on both parents.
+     *
+     * Unlike ``detachChild(child:)`` followed by ``append(contentsOf:)``, it is
+     * correct for tombstoned children: a removed node contributes nothing to
+     * either parent's size (removal already excluded it from its ancestors), so
+     * moving it must not touch the size at all. It is used by merge to move
+     * tombstones as RGA anchors without corrupting index positions.
+     *
+     * iOS caches only the visible size and derives the include-removed total on
+     * demand via ``nodeLength(includeRemoved:)``, so — unlike yorkie-js-sdk,
+     * which caches both dimensions — only the visible dimension is relocated
+     * here.
+     */
+    func moveChild(child: Self) throws {
+        guard self.isText == false else {
+            throw YorkieError(code: .errRefused, message: "Text node cannot have children")
+        }
+
+        let removed = child.isRemoved
+
+        if let oldParent = child.parent {
+            // The child may already have been spliced out of its parent's list by
+            // a concurrent operation (e.g. cascade delete of a split sibling),
+            // which already reconciled the old ancestors' size. In that case only
+            // re-parent; otherwise detach with size accounting.
+            if let offset = oldParent.innerChildren.firstIndex(where: { $0 === child }) {
+                oldParent.innerChildren.splice(offset, 1, with: [])
+                if !removed {
+                    var ancestor = child.parent
+                    while ancestor != nil {
+                        ancestor?.size -= child.paddedSize
+                        if ancestor!.isRemoved {
+                            break
+                        }
+                        ancestor = ancestor?.parent
+                    }
+                }
+            }
+            child.parent = nil
+        }
+
+        self.innerChildren.append(child)
+        child.parent = self
+        if !removed {
+            child.updateAncestorsSize()
+        }
+    }
+
+    /**
      * `shouldStayLeftOnSplit` returns true when `child` was moved here by a
      * concurrent merge whose source is one of `siblings`, and that merge is
      * unknown to `versionVector`. Such a child must remain in the original

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.13"
+let yorkieVersion = "0.7.14"

--- a/Tests/Unit/API/V1/TreeRestoreSpanConverterTests.swift
+++ b/Tests/Unit/API/V1/TreeRestoreSpanConverterTests.swift
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftProtobuf
+import XCTest
+@testable import Yorkie
+
+/// Ports `packages/sdk/test/unit/api/tree_restore_converter_test.ts` from
+/// yorkie-js-sdk v0.7.14 (yorkie-js-sdk#1297 "Add identity-preserving restore
+/// for Tree undo/redo"), covering the new `TreeRestoreSpan` message and the
+/// `Operation.TreeEdit` fields `restore_spans = 8`, `restore_mode = 9` and
+/// `retombstone_spans = 10`.
+final class TreeRestoreSpanConverterTests: XCTestCase {
+    private let seed = TimeTicket(lamport: 1, delimiter: 0, actorID: ActorIDs.initial)
+    private let executedAt = TimeTicket(lamport: 4, delimiter: 0, actorID: ActorIDs.initial)
+
+    private func textSpan() -> TreeRestoreSpan {
+        TreeRestoreSpan(id: CRDTTreeNodeID(createdAt: self.seed, offset: 2),
+                        nodeType: DefaultTreeNodeType.text.rawValue,
+                        isText: true,
+                        length: 3,
+                        value: "bcd",
+                        attrs: nil,
+                        parentID: CRDTTreeNodeID(createdAt: self.seed, offset: 0),
+                        leftSiblingID: CRDTTreeNodeID(createdAt: self.seed, offset: 1),
+                        rightSiblingID: CRDTTreeNodeID(createdAt: self.seed, offset: 5))
+    }
+
+    func test_round_trips_a_text_span_over_the_wire() throws {
+        // given / when
+        let restored = try Converter.fromTreeRestoreSpan(Converter.toTreeRestoreSpan(self.textSpan()))
+
+        // then
+        XCTAssertEqual(restored.id, CRDTTreeNodeID(createdAt: self.seed, offset: 2))
+        XCTAssertTrue(restored.isText)
+        XCTAssertEqual(restored.length, 3)
+        XCTAssertEqual(restored.value, "bcd")
+        XCTAssertEqual(restored.parentID, CRDTTreeNodeID(createdAt: self.seed, offset: 0))
+        XCTAssertEqual(restored.leftSiblingID, CRDTTreeNodeID(createdAt: self.seed, offset: 1))
+        XCTAssertEqual(restored.rightSiblingID, CRDTTreeNodeID(createdAt: self.seed, offset: 5))
+    }
+
+    /// `RHT` iterates removed nodes too, so a tombstoned attribute must survive
+    /// the wire with its `isRemoved` flag intact — otherwise a restored element
+    /// resurrects an attribute the user had deleted.
+    func test_round_trips_an_element_span_including_a_tombstoned_attribute() throws {
+        // given
+        let attrs = RHT()
+        attrs.setInternal(key: "bold", value: "true", executedAt: self.seed, removed: false)
+        attrs.setInternal(key: "italic", value: "true", executedAt: self.seed, removed: true)
+        let span = TreeRestoreSpan(id: CRDTTreeNodeID(createdAt: self.seed, offset: 0),
+                                   nodeType: "p",
+                                   isText: false,
+                                   length: 0,
+                                   value: nil,
+                                   attrs: attrs,
+                                   parentID: CRDTTreeNodeID(createdAt: self.seed, offset: 0),
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+
+        // when
+        let restored = try Converter.fromTreeRestoreSpan(Converter.toTreeRestoreSpan(span))
+
+        // then
+        XCTAssertFalse(restored.isText)
+        XCTAssertEqual(restored.nodeType, "p")
+        XCTAssertNil(restored.value, "an element span carries no text value")
+        let got = try XCTUnwrap(restored.attrs)
+        var seen = [String: Bool]()
+        for node in got {
+            seen[node.key] = node.isRemoved
+        }
+        XCTAssertEqual(seen["bold"], false)
+        XCTAssertEqual(seen["italic"], true, "the attribute tombstone must survive the wire")
+        XCTAssertNil(restored.leftSiblingID, "nil means the node was the first child")
+        XCTAssertNil(restored.rightSiblingID, "nil means the node was the last child")
+    }
+
+    func test_round_trips_a_tree_edit_operation_carrying_both_span_sets() throws {
+        // given
+        let pos = CRDTTreePos(parentID: CRDTTreeNodeID(createdAt: self.seed, offset: 0),
+                              leftSiblingID: CRDTTreeNodeID(createdAt: self.seed, offset: 0))
+        let op = TreeEditOperation(parentCreatedAt: TimeTicket.initial,
+                                   fromPos: pos,
+                                   toPos: pos,
+                                   contents: nil,
+                                   splitLevel: 0,
+                                   executedAt: self.executedAt,
+                                   isUndoOp: true,
+                                   fromIdx: 0,
+                                   toIdx: 0,
+                                   restoreSpans: [self.textSpan()],
+                                   restoreMode: .retombstone,
+                                   retombstoneSpans: [self.textSpan()])
+
+        // when — serialize to bytes and back, mirroring a real change pack
+        let bytes = try Converter.toOperation(op).serializedData()
+        let decoded = try Converter.fromOperations([PbOperation(serializedBytes: bytes)])
+
+        // then
+        let restored = try XCTUnwrap(decoded.first as? TreeEditOperation)
+        XCTAssertEqual(restored.restoreSpans?.count, 1)
+        XCTAssertEqual(restored.retombstoneSpans?.count, 1)
+        guard case .retombstone = restored.restoreMode else {
+            return XCTFail("expected .retombstone, got \(String(describing: restored.restoreMode))")
+        }
+    }
+
+    func test_leaves_ordinary_tree_edits_without_a_restore_payload() throws {
+        // given — a plain edit, no spans at all
+        let pos = CRDTTreePos(parentID: CRDTTreeNodeID(createdAt: self.seed, offset: 0),
+                              leftSiblingID: CRDTTreeNodeID(createdAt: self.seed, offset: 0))
+        let op = TreeEditOperation(parentCreatedAt: TimeTicket.initial,
+                                   fromPos: pos,
+                                   toPos: pos,
+                                   contents: nil,
+                                   splitLevel: 0,
+                                   executedAt: self.executedAt)
+
+        // when
+        let bytes = try Converter.toOperation(op).serializedData()
+        let decoded = try Converter.fromOperations([PbOperation(serializedBytes: bytes)])
+
+        // then
+        let restored = try XCTUnwrap(decoded.first as? TreeEditOperation)
+        XCTAssertNil(restored.restoreSpans)
+        XCTAssertNil(restored.restoreMode)
+    }
+
+    /// A span addresses content by insertion identity, so a node ID without a
+    /// `createdAt` — or an attribute without an `updatedAt` — is malformed. It is
+    /// rejected at the boundary rather than decoded into a default ticket that
+    /// only fails deep inside the restore path.
+    func test_rejects_a_span_missing_a_timestamp() throws {
+        // given — a well-formed span, then each timestamp stripped in turn
+        let base = Converter.toTreeRestoreSpan(self.textSpan())
+
+        var noID = base
+        noID.clearID()
+        XCTAssertThrowsError(try Converter.fromTreeRestoreSpan(noID), "a span with no id must be rejected")
+
+        var noParentTicket = base
+        noParentTicket.parentID.clearCreatedAt()
+        XCTAssertThrowsError(try Converter.fromTreeRestoreSpan(noParentTicket), "a parent anchor with no createdAt must be rejected")
+
+        var noLeftTicket = base
+        noLeftTicket.leftSiblingID.clearCreatedAt()
+        XCTAssertThrowsError(try Converter.fromTreeRestoreSpan(noLeftTicket), "a left anchor with no createdAt must be rejected")
+
+        var noAttrTicket = base
+        var attr = PbNodeAttr()
+        attr.value = "true"
+        noAttrTicket.attributes["bold"] = attr
+        XCTAssertThrowsError(try Converter.fromTreeRestoreSpan(noAttrTicket), "an attribute with no updatedAt must be rejected")
+    }
+}

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -253,7 +253,7 @@ final class CRDTTreeEditTests: XCTestCase {
         let sizeBefore = tree.size
         let fromPos = try tree.findPos(0)
         let toPos = try tree.findPos(4)
-        let (_, _, _, removedNodes, _, _, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
+        let (_, _, _, removedNodes, _, _, _, _, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
 
         XCTAssertEqual(removedNodes.count, 2, "both the <p> and its text child are removed")
         let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }

--- a/Tests/Unit/Document/CRDT/PrimitiveTests.swift
+++ b/Tests/Unit/Document/CRDT/PrimitiveTests.swift
@@ -136,4 +136,36 @@ class PrimitiveTests: XCTestCase {
         // then — date encodes as an ISO-8601 UTC string with fractional seconds
         XCTAssertEqual(dateValue.toJSON(), "\"1995-12-17T03:24:00.000Z\"")
     }
+
+    /// Parity guard for yorkie-js-sdk#1291 ("Promote out-of-int32 integers to
+    /// Long in Primitive"). JS has a single `number` type, so it classified any
+    /// integer as `Integer` and silently overflowed int32 on the wire; the fix
+    /// promotes out-of-range values to Long. Swift cannot express that bug —
+    /// `.integer` only ever takes a statically-typed `Int32` — so there is no
+    /// logic to port. This pins the property that makes it unrepresentable, so a
+    /// future widening of the integer path cannot reintroduce it.
+    func test_out_of_int32_integers_are_typed_as_long() throws {
+        // given — values beyond both ends of the int32 range
+        let aboveMax = Int64(Int32.max) + 1
+        let belowMin = Int64(Int32.min) - 1
+
+        // when / then — they classify as long, never as integer
+        for raw in [aboveMax, belowMin] {
+            guard case .long(let value) = Primitive.type(of: raw) else {
+                return XCTFail("expected .long for \(raw), got \(String(describing: Primitive.type(of: raw)))")
+            }
+            XCTAssertEqual(value, raw, "the value survives the promotion intact")
+        }
+
+        // and — a platform `Int` is always long, so it cannot overflow int32 either
+        guard case .long = Primitive.type(of: Int(aboveMax)) else {
+            return XCTFail("expected Int to classify as .long")
+        }
+
+        // and — an in-range Int32 still classifies as integer
+        guard case .integer(let small) = Primitive.type(of: Int32(42)) else {
+            return XCTFail("expected .integer for an Int32")
+        }
+        XCTAssertEqual(small, 42)
+    }
 }

--- a/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
+++ b/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Unit coverage for the v0.7.14 identity-preserving Tree restore
+/// (yorkie-js-sdk#1297) and the merge-tombstone move it depends on
+/// (yorkie-js-sdk#1303).
+final class TreeRestoreTests: XCTestCase {
+    /// Regression: `recreateFromSpan` must slice the span's text in UTF-16 with an
+    /// EXCLUSIVE end. `String.substring(from:to:)` treats `to` as inclusive and
+    /// indexes by grapheme, so using it produced a recreated node one character
+    /// too long whose `size` disagreed with JS — corrupting every ancestor's index
+    /// accounting and overlapping the id range of a surviving piece.
+    ///
+    /// The bug only shows on a PARTIAL gap: when the gap runs to the end of the
+    /// span, the inclusive end clamps to `count - 1` and the result looks right.
+    func test_recreates_a_prefix_gap_with_exactly_the_requested_length() throws {
+        // given — "hello" inserted as one 5-char run, then the whole run purged
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        let textID = posT()
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "hello")],
+                       0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<root><p>hello</p></root>")
+
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        let textNode = try XCTUnwrap(paragraph.innerChildren.first)
+        textNode.remove(timeT())
+        // Purge it through the real GC path so restore must take the recreate
+        // branch rather than simply un-tombstoning in place.
+        tree.purge(node: textNode)
+        XCTAssertEqual(tree.toXML(), "<root><p></p></root>")
+
+        // when — restore only the PREFIX [0, 3) of the original 5-char span. The
+        // span still carries the WHOLE original value ("hello"), exactly as
+        // `makeRestoreSpan` captured it; the recreate slices the prefix out of
+        // it. That is what exposes an inclusive end — the slice must not run on
+        // into the 4th character.
+        let span = TreeRestoreSpan(id: textID,
+                                   nodeType: DefaultTreeNodeType.text.rawValue,
+                                   isText: true,
+                                   length: 3,
+                                   value: "hello",
+                                   attrs: nil,
+                                   parentID: paragraph.id,
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+        let (untombstoned, recreated) = try tree.restore([span])
+
+        // then — exactly 3 characters, and `size` agrees with the value length
+        XCTAssertTrue(untombstoned.isEmpty, "the node was purged, so nothing can be un-tombstoned")
+        let node = try XCTUnwrap(recreated.first)
+        XCTAssertEqual(node.value as String, "hel", "an inclusive-end slice would yield 'hell'")
+        XCTAssertEqual(node.size, 3, "size must match the UTF-16 length of the recreated value")
+        XCTAssertEqual(tree.toXML(), "<root><p>hel</p></root>")
+    }
+
+    /// `restore` is idempotent on a live node and revives a tombstoned one in
+    /// place, without recreating a duplicate.
+    func test_restore_untombstones_in_place_and_is_idempotent() throws {
+        // given
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        let textID = posT()
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "ab")],
+                       0, timeT(), timeT)
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        let textNode = try XCTUnwrap(paragraph.innerChildren.first)
+        textNode.remove(timeT())
+        XCTAssertEqual(tree.toXML(), "<root><p></p></root>")
+
+        let span = TreeRestoreSpan(id: textID,
+                                   nodeType: DefaultTreeNodeType.text.rawValue,
+                                   isText: true,
+                                   length: 2,
+                                   value: "ab",
+                                   attrs: nil,
+                                   parentID: paragraph.id,
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+
+        // when — restore twice
+        let (first, recreatedFirst) = try tree.restore([span])
+        let sizeAfterFirst = tree.size
+        let (second, recreatedSecond) = try tree.restore([span])
+
+        // then
+        XCTAssertEqual(first.count, 1, "the tombstoned node is revived in place")
+        XCTAssertTrue(recreatedFirst.isEmpty, "a surviving node is never recreated")
+        XCTAssertEqual(tree.toXML(), "<root><p>ab</p></root>")
+        XCTAssertTrue(second.isEmpty, "restoring a live node is a no-op")
+        XCTAssertTrue(recreatedSecond.isEmpty)
+        XCTAssertEqual(tree.size, sizeAfterFirst, "an idempotent restore must not change size")
+    }
+
+    /// `retombstone` re-removes by identity and is likewise idempotent, so a redo
+    /// applied twice cannot double-count.
+    func test_retombstone_removes_by_identity_and_is_idempotent() throws {
+        // given
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        let textID = posT()
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "ab")],
+                       0, timeT(), timeT)
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        let span = TreeRestoreSpan(id: textID,
+                                   nodeType: DefaultTreeNodeType.text.rawValue,
+                                   isText: true,
+                                   length: 2,
+                                   value: "ab",
+                                   attrs: nil,
+                                   parentID: paragraph.id,
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+
+        // when
+        let firstPairs = tree.retombstone([span], timeT())
+        let xmlAfterFirst = tree.toXML()
+        let secondPairs = tree.retombstone([span], timeT())
+
+        // then
+        XCTAssertEqual(firstPairs.count, 1, "the live node is tombstoned and registered for GC")
+        XCTAssertEqual(xmlAfterFirst, "<root><p></p></root>")
+        XCTAssertTrue(secondPairs.isEmpty, "re-tombstoning an already-removed node is a no-op")
+        XCTAssertEqual(tree.toXML(), xmlAfterFirst)
+    }
+
+    /// yorkie-js-sdk#1303: a merge moves tombstoned children too, so they survive
+    /// as RGA anchors. Moving a tombstone must be size-neutral in BOTH dimensions
+    /// — iOS caches only the visible `size` and derives the include-removed total
+    /// from `innerChildren`, so this asserts both rather than trusting one.
+    func test_moveChild_relocates_a_tombstone_without_disturbing_either_size() throws {
+        // given — <p>ab</p><p>cd</p>, with "ab" tombstoned
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "ab")],
+                       0, timeT(), timeT)
+        try tree.editT((4, 4), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((5, 5),
+                       [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "cd")],
+                       0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<root><p>ab</p><p>cd</p></root>")
+
+        let root = tree.root
+        let first = try XCTUnwrap(root.innerChildren.first)
+        let second = try XCTUnwrap(root.innerChildren.last)
+        let tombstone = try XCTUnwrap(first.innerChildren.first)
+        tombstone.remove(timeT())
+
+        let visibleBefore = tree.size
+        let totalBefore = root.nodeLength(includeRemoved: true)
+
+        // when — move the tombstone to the other paragraph, as merge does
+        try second.moveChild(child: tombstone)
+
+        // then — neither dimension moves: a removed node contributes to neither
+        XCTAssertEqual(tree.size, visibleBefore, "a tombstone contributes no visible size to either parent")
+        XCTAssertEqual(root.nodeLength(includeRemoved: true), totalBefore,
+                       "the include-removed total is conserved by the move")
+        XCTAssertTrue(second.innerChildren.contains { $0 === tombstone }, "the tombstone re-parented")
+        XCTAssertFalse(first.innerChildren.contains { $0 === tombstone }, "and left its old parent")
+        XCTAssertEqual(tree.toXML(), "<root><p></p><p>cd</p></root>")
+    }
+
+    /// Moving a LIVE child must relocate its visible size rather than conserve it
+    /// in place — the complementary case to the tombstone move above.
+    func test_moveChild_relocates_a_live_child_size_to_the_new_parent() throws {
+        // given
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "ab")],
+                       0, timeT(), timeT)
+        try tree.editT((4, 4), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+
+        let root = tree.root
+        let first = try XCTUnwrap(root.innerChildren.first)
+        let second = try XCTUnwrap(root.innerChildren.last)
+        let live = try XCTUnwrap(first.innerChildren.first)
+        let totalBefore = tree.size
+
+        // when
+        try second.moveChild(child: live)
+
+        // then — the document total is unchanged, but the size moved parents
+        XCTAssertEqual(tree.size, totalBefore, "moving within the tree conserves the document size")
+        XCTAssertEqual(first.size, 0, "the old parent gave up the child's size")
+        XCTAssertEqual(second.size, live.paddedSize, "the new parent took it on")
+        XCTAssertEqual(tree.toXML(), "<root><p></p><p>ab</p></root>")
+    }
+}

--- a/Tests/Unit/Document/TextRestoreAfterGCTests.swift
+++ b/Tests/Unit/Document/TextRestoreAfterGCTests.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+/// Ports `packages/sdk/test/unit/document/text_restore_after_gc_test.ts` from
+/// yorkie-js-sdk v0.7.14 (yorkie-js-sdk#1310 "Recreate purged text runs in order
+/// on restore, not reversed").
+///
+/// Regression for the reversed-text undo. Typing character by character makes
+/// each character its own single-char insertion. Deleting a contiguous run and
+/// then undoing AFTER the tombstones were GC-purged forces every character down
+/// restore's recreate path. Because no character shares an insertion with any
+/// other, none of the same-insertion anchor rungs fire; each recreated fragment
+/// must chain after the one placed just before it, or the run comes back
+/// reversed ("my name" -> "eman ym"). Un-tombstoning (no GC) already preserved
+/// order, which is why this only reproduced once the run was purged.
+final class TextRestoreAfterGCTests: XCTestCase {
+    private let actor = "000000000000000000000001"
+
+    @MainActor
+    func test_recreates_a_purged_multi_insertion_run_in_document_order_on_undo() throws {
+        // given — each character typed separately, so each is its own insertion
+        let doc = Document(key: "text-restore-after-gc")
+        doc.setActor(self.actor)
+        try doc.update { root, _ in
+            root.t = JSONText()
+        }
+
+        let text = "hello my name is"
+        for (index, character) in text.enumerated() {
+            try doc.update { root, _ in
+                (root.t as? JSONText)?.edit(index, index, String(character))
+            }
+        }
+        XCTAssertEqual((doc.getRoot().t as? JSONText)?.toString, text)
+
+        // when — delete "my name", then purge the tombstones so undo cannot
+        // un-tombstone in place and must recreate from the spans
+        try doc.update { root, _ in
+            (root.t as? JSONText)?.edit(6, 13, "")
+        }
+        XCTAssertEqual((doc.getRoot().t as? JSONText)?.toString, "hello  is")
+
+        let purged = doc.garbageCollect(minSyncedVersionVector: maxVectorOf(actors: [self.actor]))
+        XCTAssertGreaterThan(purged, 0, "the deleted run should be purged")
+
+        try doc.undo()
+
+        // then — the run comes back forward, not reversed
+        XCTAssertEqual((doc.getRoot().t as? JSONText)?.toString, text)
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.13'
+    image: 'yorkieteam/yorkie:0.7.14'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.13'
+    image: 'yorkieteam/yorkie:0.7.14'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports the changes in yorkie-js-sdk v0.7.14, one commit per upstream change:

- **Add identity-preserving restore for Tree undo/redo** (js-sdk#1297) — reverses a Tree edit by
  reviving the nodes it removed and re-removing the nodes it inserted, both by *original identity*
  rather than copy-reinserting content, so concurrent undos converge. Adds the `TreeRestoreSpan`
  message and `Operation.TreeEdit` fields `restore_spans = 8`, `restore_mode = 9`,
  `retombstone_spans = 10`, plus `CRDTTree.restore`/`retombstone` and a recreate path that rebuilds a
  GC-purged node under its original id.
- **Recreate purged text runs in order on restore, not reversed** (js-sdk#1310) — threads a chain
  anchor through `RGATreeSplit.restore` so a purged multi-fragment run is rebuilt left-to-right.
- **Keep style ranges from crossing a concurrent merge anchor** (js-sdk#1309) — adds a boundary mode
  to `findNodesAndSplitText`; `style`/`removeStyle` resolve a range boundary just after the
  merge-source tombstone instead of at the insertion boundary.
- **Flatten chained merge to converge an anchored concurrent insert** (js-sdk#1305) — resolves the
  merge destination through the `mergedInto` chain so P→Q→R stays flat and matches what
  `rebuildMergeState` derives from a snapshot.
- **Move tombstones with merge to preserve tree RGA anchors** (js-sdk#1303) — adds
  `IndexTreeNode.moveChild` so tombstones move with the merge and survive as RGA anchors.

Also bumps `Sources/Version.swift` to `0.7.14` and the CI yorkie-server pin to v0.7.14.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Gate results, against the CI-pinned toolchain (SwiftLint 0.58.2, SwiftFormat 0.55.6): lint clean,
build clean, **636 unit tests** and **477 integration tests** passing, 0 failures.

Three things worth a reviewer's attention:

1. **The server pin bump is load-bearing, not housekeeping.** `TreeEdit` fields 8–10 only exist from
   server v0.7.14. The server re-encodes operations from its own domain model rather than relaying
   bytes, so a v0.7.13 server silently drops them — an identity-preserving Tree undo then applies on
   the originating replica and reaches peers stripped, leaving them diverged. Verified both ways: the
   tree undo/redo suites fail against a 0.7.13 server and pass against 0.7.14.

   Backward compatibility for anyone still on an older server is **graceful degradation, not
   breakage**: the failures are pure convergence divergence, no crash and no corruption, and each
   replica stays internally consistent. Text undo/redo (v0.7.13's feature) is unaffected, since
   `Operation.Edit` fields 8–10 exist on 0.7.13.

2. **`IndexTreeNode.moveChild` is the one place this port deliberately diverges from JS.** yorkie-js-sdk
   caches both a visible and an include-removed size and relocates both; iOS caches only the visible
   size and derives the include-removed total on demand via `nodeLength(includeRemoved:)`, so the
   Swift version relocates one dimension. Getting this wrong in either direction corrupts index
   positions silently, so it has a dedicated test asserting both dimensions across a tombstone move
   and a live move.

3. **js-sdk#1291 ("Promote out-of-int32 integers to Long in Primitive") is intentionally not ported.**
   JS has a single `number` type and classified any integer as `Integer`, overflowing int32 on the
   wire. Swift cannot express that: every `.integer(...)` construction is fed by a statically-typed
   `Int32`, and `Int` maps to `.long`. A parity-guard test pins the property instead of adding dead
   code.

Not ported yet, flagged rather than left silent: upstream's new *integration* suites for the tree
merge/style anchors (`tree_merge_anchor_test.ts`, `tree_style_anchor_test.ts`) and the two new
`history_tree_test.ts` cases. The unit-level converter round-trip, restore/retombstone identity and
idempotence, and `moveChild` accounting are covered here; the cross-document integration ports are a
follow-up.

**Does this PR introduce a user-facing change?**:

```release-note
Tree undo/redo now restores removed nodes by their original identity, so concurrent undos converge
instead of duplicating content. Requires yorkie server v0.7.14 or later; against an older server a
Tree undo applies locally but does not propagate to peers. No API change.
```

**Additional documentation**:

```docs
CHANGELOG.md
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
