### PR TITLE
Apply updates from yorkie-js-sdk 0.7.15

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.14
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/d34c1e8459b1bf78612849852673fbf5148a2982/Formula/y/yorkie.rb"
+      # yorkie server v0.7.15
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/c9c5c207238bd689309f0715f4adf9b6aa190cae/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.14
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/d34c1e8459b1bf78612849852673fbf5148a2982/Formula/y/yorkie.rb"
+      # yorkie server v0.7.15
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/c9c5c207238bd689309f0715f4adf9b6aa190cae/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.15] - 2026-08-20
+
+- Make Tree restore split-aware for concurrent overlapping undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/269
+- Wrap Int counter result in both increase branches in https://github.com/yorkie-team/yorkie-ios-sdk/pull/269
+
 ## [v0.7.14] - 2026-08-19
 
 - Add identity-preserving restore for Tree undo/redo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/268

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
-## [v0.7.15] - 2026-08-20
+## [v0.7.15] - 2026-08-21
 
 - Make Tree restore split-aware for concurrent overlapping undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/269
 - Wrap Int counter result in both increase branches in https://github.com/yorkie-team/yorkie-ios-sdk/pull/269

--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -121,6 +121,10 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
 
     /// Increases the counter by the given primitive value.
     ///
+    /// The sum is computed in 64-bit and then wrapped to the counter's own width, so
+    /// an `Int32` counter increased by an out-of-int32 `Long` wraps around instead of
+    /// trapping, converging with the other SDKs.
+    ///
     /// - Throws: ``YorkieError`` when called on a dedup counter; use
     ///   ``increaseDedup(_:actor:)`` instead.
     @discardableResult
@@ -132,11 +136,15 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
             )
         }
 
+        // Add in 64-bit, then wrap the *result* down to `T`'s width. This mirrors
+        // JS `bigintToInt32(BigInt(value) + delta)` / `BigInt.asIntN(64, …)` and the
+        // Go SDK: an `Int32` counter keeps the low 32 bits of the sum instead of
+        // trapping on an out-of-int32 `Long` delta, an `Int64` counter wraps at 64.
         switch primitive.value {
         case .integer(let int32Value):
-            self.value &+= T(int32Value)
+            self.value = T(truncatingIfNeeded: Int64(self.value) &+ Int64(int32Value))
         case .long(let int64Value):
-            self.value &+= T(int64Value)
+            self.value = T(truncatingIfNeeded: Int64(self.value) &+ int64Value)
         default:
             throw YorkieError(code: .errUnimplemented, message: "Unsupported type of value: \(type(of: primitive.value))")
         }

--- a/Sources/Document/CRDT/CRDTCounter.swift
+++ b/Sources/Document/CRDT/CRDTCounter.swift
@@ -142,9 +142,9 @@ class CRDTCounter<T: YorkieCountable>: CRDTElement {
         // trapping on an out-of-int32 `Long` delta, an `Int64` counter wraps at 64.
         switch primitive.value {
         case .integer(let int32Value):
-            self.value = T(truncatingIfNeeded: Int64(self.value) &+ Int64(int32Value))
+            self.value = T(truncatingIfNeeded: Int64(truncatingIfNeeded: self.value) &+ Int64(int32Value))
         case .long(let int64Value):
-            self.value = T(truncatingIfNeeded: Int64(self.value) &+ int64Value)
+            self.value = T(truncatingIfNeeded: Int64(truncatingIfNeeded: self.value) &+ int64Value)
         default:
             throw YorkieError(code: .errUnimplemented, message: "Unsupported type of value: \(type(of: primitive.value))")
         }

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -2377,8 +2377,16 @@ extension CRDTTree {
         if from > node.id.offset {
             let (right, splitDiff) = try node.split(self, from - node.id.offset)
             diff.addDataSizes(others: splitDiff)
+            // The caller's invariants (``restore(_:)``'s cursor, ``retombstone(_:_:)``'s
+            // clamp) guarantee a real split here. Returning the unsplit — wider —
+            // node instead would un-tombstone or re-tombstone content OUTSIDE the
+            // span, silently diverging the replicas: precisely what isolating is
+            // meant to prevent. Fail loudly rather than corrupt the document.
             guard let right else {
-                return node
+                throw YorkieError(
+                    code: .errInvalidArgument,
+                    message: "isolateTextRange: split failed at \(from) for piece \(node.id)"
+                )
             }
             node = right
         }

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -2276,12 +2276,21 @@ extension CRDTTree {
      * must be in parent-before-child order (``edit(_:_:_:_:_:_:)`` captures them
      * that way).
      *
-     * - Returns: the un-tombstoned and recreated nodes; the caller unregisters
-     *   GC pairs for the un-tombstoned ones.
+     * - Returns: a tuple of
+     *   - `untombstoned`: nodes revived in place (the caller unregisters their GC
+     *     pairs);
+     *   - `recreated`: brand-new nodes rebuilt for purged ranges (the caller adds
+     *     their size to Live);
+     *   - `pairs`: pending GC pairs for born-removed remainders split off a removed
+     *     straddler (the caller registers them BEFORE unregistering the
+     *     un-tombstoned ones);
+     *   - `diff`: the metadata overhead of splitting live straddlers (the caller
+     *     `acc`s it to Live).
      */
-    func restore(_ spans: [TreeRestoreSpan]) throws -> ([CRDTTreeNode], [CRDTTreeNode]) {
+    func restore(_ spans: [TreeRestoreSpan]) throws -> ([CRDTTreeNode], [CRDTTreeNode], [GCPair], DataSize) {
         var untombstoned = [CRDTTreeNode]()
         var recreated = [CRDTTreeNode]()
+        var diff = DataSize(data: 0, meta: 0)
 
         for span in spans {
             if !span.isText {
@@ -2298,7 +2307,13 @@ extension CRDTTree {
                 continue
             }
 
-            // Text: surviving pieces may be split finer than the span.
+            // Text: pieces may be split finer than the span, and a concurrent op
+            // or a post-GC recreate can leave pieces whose boundaries straddle it.
+            // Isolate the exact `[start, end)` sub-range out of every overlapping
+            // piece — splitting at the span boundaries, live or removed — so all
+            // replicas converge on identical text-node segmentation (the tree
+            // analogue of ``RGATreeSplit.isolateRange``). Then revive the removed
+            // parts and recreate the purged gaps.
             let start = span.id.offset
             let end = start + span.length
             let pieces = self.findPiecesOverlapping(span.id.createdAt, start, end)
@@ -2311,20 +2326,14 @@ extension CRDTTree {
                 let pieceEnd = piece.map { $0.id.offset + Int32($0.size) } ?? Int32.max
 
                 if let piece, pieceStart <= cursor {
-                    if pieceStart < start || pieceEnd > end {
-                        // Piece straddles a span boundary. Under causal delivery
-                        // the forward delete split at span boundaries on every
-                        // replica before its undo could arrive, so this is not
-                        // expected; skip conservatively rather than un-tombstone
-                        // beyond the span. Mirrors the guard in `retombstone`.
-                        break
+                    let overlapEnd = Swift.min(pieceEnd, end)
+                    let target = try self.isolateTextRange(piece, cursor, overlapEnd, &diff)
+                    if target.isRemoved {
+                        target.unremove()
+                        untombstoned.append(target)
                     }
-                    if piece.isRemoved {
-                        piece.unremove()
-                        untombstoned.append(piece)
-                    }
-                    cursor = Swift.min(pieceEnd, end)
-                    if cursor >= pieceEnd {
+                    cursor = overlapEnd
+                    if overlapEnd >= pieceEnd {
                         pieceIdx += 1
                     }
                 } else {
@@ -2337,17 +2346,62 @@ extension CRDTTree {
             }
         }
 
-        return (untombstoned, recreated)
+        // Splitting a removed straddler buffers born-removed remainders as pending
+        // GC pairs (see ``CRDTTreeNode.split(_:_:_:_:)``). The caller registers
+        // these BEFORE unregistering the un-tombstoned targets, so a target that
+        // was itself a split-born piece is walked gc -> live correctly (mirrors the
+        // Text path).
+        let pairs = self.drainPendingGCPairs()
+        return (untombstoned, recreated, pairs, diff)
+    }
+
+    /**
+     * `isolateTextRange` splits `piece` so that a node exactly covering the
+     * absolute-offset interval `[from, to)` of its insertion exists, and returns
+     * it. Splitting at the caller's boundaries — rather than skipping a piece that
+     * straddles them — is what lets concurrent restores converge on the same
+     * text-node segmentation across replicas (the tree analogue of
+     * ``RGATreeSplit.isolateRange``). A live split's metadata overhead is added to
+     * `diff`; a removed split buffers a pending GC pair internally (contributing
+     * zero here).
+     *
+     * Requires `pieceStart <= from < to <= pieceEnd`.
+     */
+    private func isolateTextRange(
+        _ piece: CRDTTreeNode,
+        _ from: Int32,
+        _ to: Int32,
+        _ diff: inout DataSize
+    ) throws -> CRDTTreeNode {
+        var node = piece
+        if from > node.id.offset {
+            let (right, splitDiff) = try node.split(self, from - node.id.offset)
+            diff.addDataSizes(others: splitDiff)
+            guard let right else {
+                return node
+            }
+            node = right
+        }
+        if to < node.id.offset + Int32(node.size) {
+            let (_, splitDiff) = try node.split(self, to - node.id.offset)
+            diff.addDataSizes(others: splitDiff)
+        }
+        return node
     }
 
     /**
      * `retombstone` re-deletes the nodes described by `spans` (redo of an
-     * identity-preserving undo). Live pieces only; idempotent.
+     * identity-preserving undo). Live pieces only; idempotent. A piece that
+     * straddles a span boundary is split at that boundary so only the in-span range
+     * is re-removed (symmetric with ``restore(_:)``'s isolate, so undo/redo stay
+     * mirror images and segmentation stays convergent).
      *
-     * - Returns: GC pairs for the newly tombstoned nodes.
+     * - Returns: the GC pairs for the newly tombstoned nodes, and the live-split
+     *   metadata overhead.
      */
-    func retombstone(_ spans: [TreeRestoreSpan], _ executedAt: TimeTicket) -> [GCPair] {
+    func retombstone(_ spans: [TreeRestoreSpan], _ executedAt: TimeTicket) throws -> ([GCPair], DataSize) {
         var pairs = [GCPair]()
+        var diff = DataSize(data: 0, meta: 0)
         for span in spans {
             let start = span.id.offset
             let end = start + Swift.max(span.length, 1)
@@ -2364,18 +2418,18 @@ extension CRDTTree {
                 if piece.isRemoved {
                     continue
                 }
-                if piece.isText, piece.id.offset < start || piece.id.offset + Int32(piece.size) > end {
-                    // Piece straddles a span boundary (same clamped `end` as
-                    // `findPiecesOverlapping`); skip so we never re-tombstone
-                    // content outside the span. Mirrors the guard in `restore`.
-                    continue
+                var target = piece
+                if piece.isText {
+                    let from = Swift.max(piece.id.offset, start)
+                    let to = Swift.min(piece.id.offset + Int32(piece.size), end)
+                    target = try self.isolateTextRange(piece, from, to, &diff)
                 }
-                if piece.remove(executedAt) {
-                    pairs.append(GCPair(parent: self, child: piece))
+                if target.remove(executedAt) {
+                    pairs.append(GCPair(parent: self, child: target))
                 }
             }
         }
-        return pairs
+        return (pairs, diff)
     }
 
     /**

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -172,18 +172,29 @@ final class TreeEditOperation: Operation {
             let toRetombstone = (isRetombstone ? self.restoreSpans : self.retombstoneSpans) ?? []
 
             var diff = DataSize(data: 0, meta: 0)
-            // 1. Re-remove (retombstone) by identity.
-            for pair in tree.retombstone(toRetombstone, editedAt) {
+            // 1. Re-remove (retombstone) by identity. Isolating a straddling piece
+            // splits it (live-split overhead accounted to `diff`).
+            let (retombstonePairs, retombstoneDiff) = try tree.retombstone(toRetombstone, editedAt)
+            diff.addDataSizes(others: retombstoneDiff)
+            for pair in retombstonePairs {
                 root.registerGCPair(pair)
             }
-            // 2. Revive (restore) by identity: un-tombstoned nodes move gc->live
-            // via `unregisterGCPair` (must be after `removedAt` is cleared, which
-            // `restore` does); recreated nodes are brand new, so add their size to
-            // live.
-            let (untombstoned, recreated) = try tree.restore(toRestore)
+            // 2. Revive (restore) by identity. Isolating a range out of a straddling
+            // piece can split off born-removed remainders as pending GC pairs;
+            // register them FIRST so a split-born un-tombstoned target is walked
+            // gc->live correctly by the unregister below (mirrors the Text path).
+            // Un-tombstoned nodes move gc->live via `unregisterGCPair` (must be
+            // after `removedAt` is cleared, which `restore` does); recreated nodes
+            // are brand new, so add their size to live, plus any live-split
+            // overhead.
+            let (untombstoned, recreated, restorePairs, restoreDiff) = try tree.restore(toRestore)
+            for pair in restorePairs {
+                root.registerGCPair(pair)
+            }
             for node in untombstoned {
                 root.unregisterGCPair(GCPair(parent: tree, child: node))
             }
+            diff.addDataSizes(others: restoreDiff)
             for node in recreated {
                 diff.addDataSizes(others: node.getDataSize())
             }

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.14"
+let yorkieVersion = "0.7.15"

--- a/Tests/Integration/CounterIntegrationTests.swift
+++ b/Tests/Integration/CounterIntegrationTests.swift
@@ -16,6 +16,9 @@
 
 import XCTest
 @testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
 
 // swiftlint: disable force_cast
 final class CounterIntegrationTests: XCTestCase {
@@ -164,6 +167,34 @@ final class CounterIntegrationTests: XCTestCase {
 
         try await self.c1.deactivate()
         try await self.c2.deactivate()
+    }
+
+    /// Ports: "Can handle increase operation with out-of-int32 Long".
+    ///
+    /// An `Int32` counter increased by an out-of-int32 `Long` wraps under int32
+    /// arithmetic on every SDK, so the two replicas must agree on 705032705.
+    @MainActor
+    func test_can_handle_increase_operation_with_out_of_int32_long() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given — an Int32 counter at 1, shared by both replicas
+            try d1.update { root, _ in
+                root.age = JSONCounter(value: Int32(1))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — increased by a Long well beyond the int32 range
+            try d1.update { root, _ in
+                (root.age as! JSONCounter<Int32>).increase(value: Int64(5_000_000_000))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // then — 1 + 5_000_000_000 wraps to 705032705 under int32 arithmetic,
+            // which is what the JS and Go SDKs compute.
+            XCTAssertEqual(d1.toSortedJSON(), "{\"age\":705032705}")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
     }
 }
 

--- a/Tests/Integration/TreeHistoryConcurrentUndoAfterGCTests.swift
+++ b/Tests/Integration/TreeHistoryConcurrentUndoAfterGCTests.swift
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+//
+// Ports: packages/sdk/test/integration/history_tree_concurrent_test.ts
+// ("Tree History - concurrent overlapping undo after GC", added in
+// yorkie-js-sdk#1315).
+//
+// Convergence of concurrent OVERLAPPING undo/redo once the deleted nodes have
+// been GC-purged (so `restore` takes the recreate path). The existing
+// `TreeHistoryIntegrationTests` reconcile cases undo before GC runs and so never
+// exercise this; these settle enough rounds to let GC purge the tombstones
+// first. Regression for the multi-user tree undo corruption seen in wafflebase
+// docs: split-aware restore/retombstone that isolates each piece at the span
+// boundaries so all replicas converge on the same text-node segmentation.
+//
+
+// MARK: - Helpers
+
+/// `settle` runs several push/pull rounds on both clients so their changes are
+/// fully exchanged and each replica's min-synced version vector advances far
+/// enough for GC to purge the tombstones. Two `settle` calls back to back are
+/// used before an undo to guarantee the deleted nodes are actually purged, so
+/// `restore` exercises the recreate path.
+@MainActor
+private func settle(_ c1: Client, _ c2: Client) async throws {
+    for _ in 0 ..< 3 {
+        try await c1.sync()
+        try await c2.sync()
+    }
+}
+
+/// `initFlat` seeds `doc` with `<doc><p>0123456789</p></doc>`.
+@MainActor
+private func initFlat(_ doc: Document) throws {
+    try doc.update { root, _ in
+        root.t = JSONTree(initialRoot:
+            JSONTreeElementNode(type: "doc", children: [
+                JSONTreeElementNode(type: "p", children: [
+                    JSONTreeTextNode(value: "0123456789")
+                ])
+            ])
+        )
+    }
+}
+
+/// Returns the XML of the `t` field in the document root.
+@MainActor
+private func flatXML(_ doc: Document) -> String {
+    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+}
+
+/// Asserts the two replicas converged, reporting both trees when they have not.
+@MainActor
+private func assertConverged(_ d1: Document, _ d2: Document, _ label: String) {
+    XCTAssertEqual(d1.toSortedJSON(),
+                   d2.toSortedJSON(),
+                   "\(label) DIVERGED\n  d1=\(flatXML(d1))\n  d2=\(flatXML(d2))")
+}
+
+/// One undo range on `d1` versus one on `d2`, covering every overlap
+/// relationship between the two deletes.
+private struct OverlapCase {
+    let name: String
+    let r1: (Int, Int)
+    let r2: (Int, Int)
+}
+
+private let overlapCases: [OverlapCase] = [
+    OverlapCase(name: "contained_by", r1: (5, 7), r2: (3, 9)),
+    OverlapCase(name: "contains", r1: (3, 9), r2: (5, 7)),
+    OverlapCase(name: "overlap_start", r1: (5, 9), r2: (3, 7)),
+    OverlapCase(name: "overlap_end", r1: (3, 7), r2: (5, 9)),
+    OverlapCase(name: "identical", r1: (3, 7), r2: (3, 7)),
+    OverlapCase(name: "adjacent", r1: (3, 5), r2: (5, 7))
+]
+
+// MARK: - Tests
+
+final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
+    // MARK: - converges on undo of overlapping deletes
+
+    // Ports: "converges on undo of overlapping deletes: contained_by"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_contained_by() async throws {
+        try await self.runUndoCase("contained_by")
+    }
+
+    // Ports: "converges on undo of overlapping deletes: contains"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_contains() async throws {
+        try await self.runUndoCase("contains")
+    }
+
+    // Ports: "converges on undo of overlapping deletes: overlap_start"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_overlap_start() async throws {
+        try await self.runUndoCase("overlap_start")
+    }
+
+    // Ports: "converges on undo of overlapping deletes: overlap_end"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_overlap_end() async throws {
+        try await self.runUndoCase("overlap_end")
+    }
+
+    // Ports: "converges on undo of overlapping deletes: identical"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_identical() async throws {
+        try await self.runUndoCase("identical")
+    }
+
+    // Ports: "converges on undo of overlapping deletes: adjacent"
+    @MainActor
+    func test_converges_on_undo_of_overlapping_deletes_adjacent() async throws {
+        try await self.runUndoCase("adjacent")
+    }
+
+    // MARK: - converges on undo+redo of overlapping deletes
+
+    // Ports: "converges on undo+redo of overlapping deletes: contained_by"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_contained_by() async throws {
+        try await self.runUndoRedoCase("contained_by")
+    }
+
+    // Ports: "converges on undo+redo of overlapping deletes: contains"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_contains() async throws {
+        try await self.runUndoRedoCase("contains")
+    }
+
+    // Ports: "converges on undo+redo of overlapping deletes: overlap_start"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_overlap_start() async throws {
+        try await self.runUndoRedoCase("overlap_start")
+    }
+
+    // Ports: "converges on undo+redo of overlapping deletes: overlap_end"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_overlap_end() async throws {
+        try await self.runUndoRedoCase("overlap_end")
+    }
+
+    // Ports: "converges on undo+redo of overlapping deletes: identical"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_identical() async throws {
+        try await self.runUndoRedoCase("identical")
+    }
+
+    // Ports: "converges on undo+redo of overlapping deletes: adjacent"
+    @MainActor
+    func test_converges_on_undo_redo_of_overlapping_deletes_adjacent() async throws {
+        try await self.runUndoRedoCase("adjacent")
+    }
+
+    // MARK: - Known limitations (skipped, mirroring JS `it.skip`)
+
+    // Ports: "KNOWN: delete a whole <p> vs edit text inside it, both undo"
+    //
+    // When a whole element is deleted concurrently with a text edit INSIDE it and
+    // both undo AFTER GC, the visible content converges but internal text-node
+    // segmentation can differ (one replica un-tombstones the concurrent edit's
+    // finer split, the other recreates the run monolithically from the element's
+    // span) so `toSortedJSON` mismatches. Removing restore's straddle-break
+    // (needed to fix the overlapping text-delete cases above) removed the
+    // coincidental coarsening that made these converge. A sound fix needs the
+    // child sub-restore's split points to survive a transiently-purged parent
+    // (e.g. undo-stack-aware GC so restore un-tombstones in place).
+    // Merge-normalizing segmentation was tried and rejected upstream
+    // (non-commutative — broke GC/tombstone symmetry after redo).
+    @MainActor
+    func test_known_delete_whole_element_vs_edit_inside_both_undo() async throws {
+        throw XCTSkip("KNOWN: element-delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+    }
+
+    // Ports: "KNOWN: delete two <p> vs edit inside first, both undo (segmentation)"
+    //
+    // Deleting MULTIPLE elements concurrently with an edit inside one of them,
+    // then both undo after GC, converges on visible content but NOT on internal
+    // text-node segmentation (d1: "a","aa","a"; d2: "aaaa") — so `toSortedJSON`
+    // differs. Root cause: a child sub-restore is B1-skipped while its parent is
+    // transiently purged, so the two replicas end with different split points;
+    // the element-restore's span is monolithic and cannot re-introduce them.
+    // Left skipped until undo-stack-aware GC lands.
+    @MainActor
+    func test_known_delete_two_elements_vs_edit_inside_first_both_undo() async throws {
+        throw XCTSkip("KNOWN: multi-element delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+    }
+
+    // MARK: - Shared runners
+
+    /// Both undos revive both deleted runs by identity, restoring the pre-delete
+    /// visible content on both replicas. (The internal text-node segmentation may
+    /// be finer than the original — isolate splits at the span boundaries — but
+    /// both replicas agree, which `assertConverged` checks.)
+    @MainActor
+    private func runUndoCase(_ name: String) async throws {
+        let tc = try XCTUnwrap(overlapCases.first { $0.name == name })
+
+        try await withTwoClientsAndDocuments("\(self.description)-\(name)") { c1, d1, c2, d2 in
+            // given — a flat tree shared by both replicas
+            try initFlat(d1)
+            try await c1.sync()
+            try await c2.sync()
+            let initial = flatXML(d1)
+
+            // when — concurrent overlapping deletes, settled twice so GC purges
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(tc.r1.0, tc.r1.1)
+            }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(tc.r2.0, tc.r2.1)
+            }
+            try await settle(c1, c2)
+            try await settle(c1, c2)
+            assertConverged(d1, d2, "after deletes")
+
+            // when — both replicas undo their own delete
+            try d1.undo()
+            try d2.undo()
+            try await settle(c1, c2)
+
+            // then
+            assertConverged(d1, d2, "after undo")
+            XCTAssertEqual(flatXML(d1), initial, "undo restores the initial visible content")
+        }
+    }
+
+    /// Both redos re-remove both runs by identity, back to the converged
+    /// post-delete state.
+    @MainActor
+    private func runUndoRedoCase(_ name: String) async throws {
+        let tc = try XCTUnwrap(overlapCases.first { $0.name == name })
+
+        try await withTwoClientsAndDocuments("\(self.description)-\(name)") { c1, d1, c2, d2 in
+            // given — a flat tree shared by both replicas
+            try initFlat(d1)
+            try await c1.sync()
+            try await c2.sync()
+            let initial = flatXML(d1)
+
+            // when — concurrent overlapping deletes, settled twice so GC purges
+            try d1.update { root, _ in
+                try (root.t as? JSONTree)?.edit(tc.r1.0, tc.r1.1)
+            }
+            try d2.update { root, _ in
+                try (root.t as? JSONTree)?.edit(tc.r2.0, tc.r2.1)
+            }
+            try await settle(c1, c2)
+            try await settle(c1, c2)
+            let afterDeletes = flatXML(d1)
+
+            // when — both undo
+            try d1.undo()
+            try d2.undo()
+            try await settle(c1, c2)
+
+            // then
+            assertConverged(d1, d2, "after undo")
+            XCTAssertEqual(flatXML(d1), initial, "undo restores the initial visible content")
+
+            // when — both redo
+            try d1.redo()
+            try d2.redo()
+            try await settle(c1, c2)
+
+            // then
+            assertConverged(d1, d2, "after redo")
+            XCTAssertEqual(flatXML(d1), afterDeletes, "redo restores the post-delete visible content")
+        }
+    }
+}

--- a/Tests/Integration/TreeHistoryConcurrentUndoAfterGCTests.swift
+++ b/Tests/Integration/TreeHistoryConcurrentUndoAfterGCTests.swift
@@ -64,17 +64,22 @@ private func initFlat(_ doc: Document) throws {
 }
 
 /// Returns the XML of the `t` field in the document root.
+///
+/// Unwraps rather than defaulting to `""`: a broken document model would
+/// otherwise let every comparison pass vacuously as `"" == ""`.
 @MainActor
-private func flatXML(_ doc: Document) -> String {
-    (doc.getRoot().t as? JSONTree)?.toXML() ?? ""
+private func flatXML(_ doc: Document) throws -> String {
+    try XCTUnwrap(doc.getRoot().t as? JSONTree, "root.t is not a JSONTree").toXML()
 }
 
 /// Asserts the two replicas converged, reporting both trees when they have not.
 @MainActor
-private func assertConverged(_ d1: Document, _ d2: Document, _ label: String) {
+private func assertConverged(_ d1: Document, _ d2: Document, _ label: String) throws {
+    let x1 = try flatXML(d1)
+    let x2 = try flatXML(d2)
     XCTAssertEqual(d1.toSortedJSON(),
                    d2.toSortedJSON(),
-                   "\(label) DIVERGED\n  d1=\(flatXML(d1))\n  d2=\(flatXML(d2))")
+                   "\(label) DIVERGED\n  d1=\(x1)\n  d2=\(x2)")
 }
 
 /// One undo range on `d1` versus one on `d2`, covering every overlap
@@ -190,7 +195,38 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
     // (non-commutative — broke GC/tombstone symmetry after redo).
     @MainActor
     func test_known_delete_whole_element_vs_edit_inside_both_undo() async throws {
-        throw XCTSkip("KNOWN: element-delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+        // `XCTSkipIf(true, …)` rather than a bare `throw`: the body below stays
+        // compiled (so it cannot rot) and re-enabling is a one-line deletion,
+        // matching how upstream keeps the scenario under `it.skip`.
+        try XCTSkipIf(true, "KNOWN: element-delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "hello")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "world")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // d1 removes the whole first <p>; d2 replaces text inside it.
+            try d1.update { root, _ in
+                try XCTUnwrap(root.t as? JSONTree).edit(0, 7)
+            }
+            try d2.update { root, _ in
+                try XCTUnwrap(root.t as? JSONTree).edit(3, 5, JSONTreeTextNode(value: "XY"))
+            }
+            try await settle(c1, c2)
+            try assertConverged(d1, d2, "after ops")
+
+            try d1.undo()
+            try d2.undo()
+            try await settle(c1, c2)
+            try assertConverged(d1, d2, "after undo")
+        }
     }
 
     // Ports: "KNOWN: delete two <p> vs edit inside first, both undo (segmentation)"
@@ -204,7 +240,35 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
     // Left skipped until undo-stack-aware GC lands.
     @MainActor
     func test_known_delete_two_elements_vs_edit_inside_first_both_undo() async throws {
-        throw XCTSkip("KNOWN: multi-element delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+        try XCTSkipIf(true, "KNOWN: multi-element delete vs inner text edit diverges on segmentation after GC — mirrors JS it.skip")
+
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            try d1.update { root, _ in
+                root.t = JSONTree(initialRoot:
+                    JSONTreeElementNode(type: "doc", children: [
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "aaaa")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "bbbb")]),
+                        JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cccc")])
+                    ])
+                )
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            try d1.update { root, _ in
+                try XCTUnwrap(root.t as? JSONTree).edit(0, 12)
+            }
+            try d2.update { root, _ in
+                try XCTUnwrap(root.t as? JSONTree).edit(2, 4, JSONTreeTextNode(value: "XY"))
+            }
+            try await settle(c1, c2)
+            try await settle(c1, c2)
+
+            try d1.undo()
+            try d2.undo()
+            try await settle(c1, c2)
+            try assertConverged(d1, d2, "after undo")
+        }
     }
 
     // MARK: - Shared runners
@@ -222,18 +286,18 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
             try initFlat(d1)
             try await c1.sync()
             try await c2.sync()
-            let initial = flatXML(d1)
+            let initial = try flatXML(d1)
 
             // when — concurrent overlapping deletes, settled twice so GC purges
             try d1.update { root, _ in
-                try (root.t as? JSONTree)?.edit(tc.r1.0, tc.r1.1)
+                try XCTUnwrap(root.t as? JSONTree).edit(tc.r1.0, tc.r1.1)
             }
             try d2.update { root, _ in
-                try (root.t as? JSONTree)?.edit(tc.r2.0, tc.r2.1)
+                try XCTUnwrap(root.t as? JSONTree).edit(tc.r2.0, tc.r2.1)
             }
             try await settle(c1, c2)
             try await settle(c1, c2)
-            assertConverged(d1, d2, "after deletes")
+            try assertConverged(d1, d2, "after deletes")
 
             // when — both replicas undo their own delete
             try d1.undo()
@@ -241,8 +305,8 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
             try await settle(c1, c2)
 
             // then
-            assertConverged(d1, d2, "after undo")
-            XCTAssertEqual(flatXML(d1), initial, "undo restores the initial visible content")
+            try assertConverged(d1, d2, "after undo")
+            XCTAssertEqual(try flatXML(d1), initial, "undo restores the initial visible content")
         }
     }
 
@@ -257,18 +321,18 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
             try initFlat(d1)
             try await c1.sync()
             try await c2.sync()
-            let initial = flatXML(d1)
+            let initial = try flatXML(d1)
 
             // when — concurrent overlapping deletes, settled twice so GC purges
             try d1.update { root, _ in
-                try (root.t as? JSONTree)?.edit(tc.r1.0, tc.r1.1)
+                try XCTUnwrap(root.t as? JSONTree).edit(tc.r1.0, tc.r1.1)
             }
             try d2.update { root, _ in
-                try (root.t as? JSONTree)?.edit(tc.r2.0, tc.r2.1)
+                try XCTUnwrap(root.t as? JSONTree).edit(tc.r2.0, tc.r2.1)
             }
             try await settle(c1, c2)
             try await settle(c1, c2)
-            let afterDeletes = flatXML(d1)
+            let afterDeletes = try flatXML(d1)
 
             // when — both undo
             try d1.undo()
@@ -276,8 +340,8 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
             try await settle(c1, c2)
 
             // then
-            assertConverged(d1, d2, "after undo")
-            XCTAssertEqual(flatXML(d1), initial, "undo restores the initial visible content")
+            try assertConverged(d1, d2, "after undo")
+            XCTAssertEqual(try flatXML(d1), initial, "undo restores the initial visible content")
 
             // when — both redo
             try d1.redo()
@@ -285,8 +349,8 @@ final class TreeHistoryConcurrentUndoAfterGCTests: XCTestCase {
             try await settle(c1, c2)
 
             // then
-            assertConverged(d1, d2, "after redo")
-            XCTAssertEqual(flatXML(d1), afterDeletes, "redo restores the post-delete visible content")
+            try assertConverged(d1, d2, "after redo")
+            XCTAssertEqual(try flatXML(d1), afterDeletes, "redo restores the post-delete visible content")
         }
     }
 }

--- a/Tests/Unit/Document/CRDT/CRDTCountTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTCountTests.swift
@@ -60,4 +60,40 @@ final class CRDTCountTests: XCTestCase {
         XCTAssert(int.value == -30)
         XCTAssert(long.value == 100)
     }
+
+    /// An `Int32` counter increased by an out-of-int32 `Long` must wrap around
+    /// rather than trap, so it converges with the JS and Go SDKs.
+    func test_can_wrap_around_int_counter_when_increased_by_out_of_int32_long() throws {
+        // given
+        let counter = CRDTCounter(value: Int32(0), createdAt: TimeTicket.initial)
+        let outOfInt32 = Primitive(value: .long(2_147_483_648), createdAt: TimeTicket.initial) // 2^31
+
+        // when
+        try counter.increase(outOfInt32)
+
+        // then
+        XCTAssertEqual(counter.value, -2_147_483_648)
+
+        // given — a nonzero base: truncating the delta before adding would yield
+        // -2147483649, which is not representable in int32.
+        let nonZeroBase = CRDTCounter(value: Int32(-1), createdAt: TimeTicket.initial)
+
+        // when
+        try nonZeroBase.increase(outOfInt32)
+
+        // then
+        XCTAssertEqual(nonZeroBase.value, 2_147_483_647)
+    }
+
+    /// A `Long` counter still wraps at 64 bits (JS `BigInt.asIntN(64, …)`).
+    func test_can_wrap_around_long_counter_on_int64_overflow() throws {
+        // given
+        let counter = CRDTCounter(value: Int64.max, createdAt: TimeTicket.initial)
+
+        // when
+        try counter.increase(Primitive(value: .integer(1), createdAt: TimeTicket.initial))
+
+        // then
+        XCTAssertEqual(counter.value, Int64.min)
+    }
 }

--- a/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
+++ b/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
@@ -61,7 +61,7 @@ final class TreeRestoreTests: XCTestCase {
                                    parentID: paragraph.id,
                                    leftSiblingID: nil,
                                    rightSiblingID: nil)
-        let (untombstoned, recreated) = try tree.restore([span])
+        let (untombstoned, recreated, _, _) = try tree.restore([span])
 
         // then — exactly 3 characters, and `size` agrees with the value length
         XCTAssertTrue(untombstoned.isEmpty, "the node was purged, so nothing can be un-tombstoned")
@@ -97,9 +97,9 @@ final class TreeRestoreTests: XCTestCase {
                                    rightSiblingID: nil)
 
         // when — restore twice
-        let (first, recreatedFirst) = try tree.restore([span])
+        let (first, recreatedFirst, _, _) = try tree.restore([span])
         let sizeAfterFirst = tree.size
-        let (second, recreatedSecond) = try tree.restore([span])
+        let (second, recreatedSecond, _, _) = try tree.restore([span])
 
         // then
         XCTAssertEqual(first.count, 1, "the tombstoned node is revived in place")
@@ -132,9 +132,9 @@ final class TreeRestoreTests: XCTestCase {
                                    rightSiblingID: nil)
 
         // when
-        let firstPairs = tree.retombstone([span], timeT())
+        let (firstPairs, _) = try tree.retombstone([span], timeT())
         let xmlAfterFirst = tree.toXML()
-        let secondPairs = tree.retombstone([span], timeT())
+        let (secondPairs, _) = try tree.retombstone([span], timeT())
 
         // then
         XCTAssertEqual(firstPairs.count, 1, "the live node is tombstoned and registered for GC")

--- a/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
+++ b/Tests/Unit/Document/CRDT/TreeRestoreTests.swift
@@ -207,4 +207,92 @@ final class TreeRestoreTests: XCTestCase {
         XCTAssertEqual(second.size, live.paddedSize, "the new parent took it on")
         XCTAssertEqual(tree.toXML(), "<root><p></p><p>ab</p></root>")
     }
+
+    /// Restoring a sub-range of a *removed* straddler must SPLIT it at the span
+    /// boundaries and revive only the isolated middle — the split-aware restore
+    /// added in yorkie-js-sdk#1315.
+    ///
+    /// This is the one path that makes `restore` return pending GC pairs: the two
+    /// remainders split off a removed node are born tombstoned, so they never go
+    /// through `remove()` and get no pair from the normal deletion path. The
+    /// caller must register those pairs BEFORE unregistering the un-tombstoned
+    /// target, because the target is itself one of the split-born pieces and has
+    /// to be walked gc -> live. Without this test the ordering in
+    /// ``TreeEditOperation`` could be reversed and every other test would stay
+    /// green.
+    func test_restore_splits_a_removed_straddler_and_revives_only_the_span() throws {
+        // given — "hello" as one run, tombstoned but NOT purged
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        let textID = posT()
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "hello")],
+                       0, timeT(), timeT)
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        let textNode = try XCTUnwrap(paragraph.innerChildren.first)
+        textNode.remove(timeT())
+        XCTAssertEqual(tree.toXML(), "<root><p></p></root>")
+
+        // when — restore only [1, 3) of the 5-char run, i.e. "el"
+        let span = TreeRestoreSpan(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 1),
+                                   nodeType: DefaultTreeNodeType.text.rawValue,
+                                   isText: true,
+                                   length: 2,
+                                   value: "hello",
+                                   attrs: nil,
+                                   parentID: paragraph.id,
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+        let (untombstoned, recreated, pairs, _) = try tree.restore([span])
+
+        // then — only the isolated middle is live; the straddler was split, not skipped
+        XCTAssertEqual(tree.toXML(), "<root><p>el</p></root>", "only the in-span range may be revived")
+        XCTAssertEqual(untombstoned.count, 1, "exactly the isolated middle is un-tombstoned")
+        XCTAssertEqual(untombstoned.first?.value as String?, "el")
+        XCTAssertTrue(recreated.isEmpty, "a surviving (tombstoned) node is revived, never recreated")
+
+        // the two born-removed remainders are handed back as pending GC pairs
+        XCTAssertEqual(pairs.count, 2, "both split-born remainders need a GC pair")
+        XCTAssertEqual(pairs.compactMap { ($0.child as? CRDTTreeNode)?.id.offset }.sorted(), [1, 3])
+
+        // segmentation: h(removed) | el(live) | lo(removed)
+        let pieces = paragraph.innerChildren
+        XCTAssertEqual(pieces.map { $0.value as String }, ["h", "el", "lo"])
+        XCTAssertEqual(pieces.map(\.isRemoved), [true, false, true])
+        XCTAssertEqual(tree.size, 4, "only the 2 live chars count, plus the <p> padding")
+    }
+
+    /// The symmetric half: `retombstone` splits a LIVE straddler at the same
+    /// boundaries, so undo and redo stay mirror images and segmentation stays
+    /// convergent across replicas.
+    func test_retombstone_splits_a_live_straddler_and_removes_only_the_span() throws {
+        // given — a live "hello" run
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "root"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        let textID = posT()
+        try tree.editT((1, 1),
+                       [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "hello")],
+                       0, timeT(), timeT)
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        XCTAssertEqual(tree.toXML(), "<root><p>hello</p></root>")
+
+        // when — re-remove only [1, 3)
+        let span = TreeRestoreSpan(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 1),
+                                   nodeType: DefaultTreeNodeType.text.rawValue,
+                                   isText: true,
+                                   length: 2,
+                                   value: "hello",
+                                   attrs: nil,
+                                   parentID: paragraph.id,
+                                   leftSiblingID: nil,
+                                   rightSiblingID: nil)
+        let (pairs, _) = try tree.retombstone([span], timeT())
+
+        // then — content outside the span survives
+        XCTAssertEqual(tree.toXML(), "<root><p>hlo</p></root>", "only the in-span range may be re-removed")
+        XCTAssertEqual(pairs.count, 1, "one newly tombstoned node")
+        XCTAssertEqual((pairs.first?.child as? CRDTTreeNode)?.value as String?, "el")
+        XCTAssertEqual(paragraph.innerChildren.map { $0.value as String }, ["h", "el", "lo"])
+        XCTAssertEqual(paragraph.innerChildren.map(\.isRemoved), [false, true, false])
+    }
 }

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.14'
+    image: 'yorkieteam/yorkie:0.7.15'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.14'
+    image: 'yorkieteam/yorkie:0.7.15'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies the two changes from [yorkie-js-sdk v0.7.15](https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.7.15) to the iOS SDK, one commit per upstream change.

- **Make Tree restore split-aware for concurrent overlapping undo** (yorkie-js-sdk#1315)

  `CRDTTree.restore`/`retombstone` used to *skip* any text piece whose boundaries straddled a restore span, on the assumption that causal delivery had already split at those boundaries on every replica. A concurrent operation — or a recreate after GC has purged the tombstones — breaks that assumption, and the replicas end up with different text-node segmentation.

  Both paths now isolate the exact in-span range out of an overlapping piece via the new private `isolateTextRange`, the tree analogue of `RGATreeSplit.isolateRange`, so segmentation converges. To carry the fallout of those splits, `restore` now also returns the pending GC pairs buffered by splitting a removed straddler plus the live-split metadata overhead, and `retombstone` returns its own live-split overhead. `TreeEditOperation` registers the pending pairs *before* unregistering the un-tombstoned targets, so a target that was itself a split-born piece is walked `gc -> live` correctly (mirroring the Text path).

- **Wrap Int counter result in both increase branches** (yorkie-js-sdk#1312)

  `CRDTCounter.increase` converted a `Long` delta with the trapping `T(_:)` initializer, so an `Int32` counter increased by an out-of-int32 `Long` **crashed** rather than wrapping. (In JS the same bug was a silently unwrapped value; Swift's typing turned it into a trap.) Both branches now add in 64-bit and wrap the result down to the counter's own width, matching `bigintToInt32` in the JS SDK and the Go SDK — an Int counter at `1` increased by `5_000_000_000` converges on `705032705` across all SDKs.

Also bumps `Sources/Version.swift` to `0.7.15` and moves the CI `yorkie server` pin to v0.7.15.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- **Requires yorkie server >= 0.7.14.** The identity-preserving Tree undo/redo path relies on the server relaying the tree restore spans in the change pack. An older server silently strips them, so peers apply an undo as a plain edit and the replicas cannot converge. The CI server pin is moved to v0.7.15 in this PR for that reason.
- No public API change: `restore`/`retombstone` are internal, and the counter fix needed no change to the public `YorkieCountable` protocol — `init(truncatingIfNeeded:)` is already a `BinaryInteger` requirement.
- The two upstream `it.skip` known limitations from `history_tree_concurrent_test.ts` are ported as `XCTSkip` with the same rationale, so the iOS suite mirrors the JS suite exactly rather than silently omitting them.
- Gate results: SwiftFormat 0.55.6 and SwiftLint 0.58.2 (the CI-pinned versions) both clean; `swift build --build-tests` clean; 638 unit tests and 501 integration tests green, the latter against a local yorkie 0.7.14 server.
- Additionally verified at runtime on simulators: the `RichTextEditor` and `TextEditorApp` examples, built against this branch, launch, attach, and render; a two-device run on one document shows both participants with live remote cursors and converges bidirectionally.

**Does this PR introduce a user-facing change?**:

```release-note
Make Tree restore split-aware for concurrent overlapping undo, so replicas converge on the same text-node segmentation when overlapping deletes are undone after GC. Wrap the Int counter result in both increase branches, so an Int32 counter increased by an out-of-int32 Long wraps like the other SDKs instead of trapping. Requires yorkie server 0.7.14 or newer for Tree undo/redo.
```

**Additional documentation**:

```docs
- [CHANGELOG]: https://github.com/yorkie-team/yorkie-ios-sdk/blob/main/CHANGELOG.md
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
