### PR TITLE
Apply updates from yorkie-js-sdk 0.7.16

### DIFF
--- a/.github/workflows/swift-integration.yml
+++ b/.github/workflows/swift-integration.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.15
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/c9c5c207238bd689309f0715f4adf9b6aa190cae/Formula/y/yorkie.rb"
+      # yorkie server v0.7.16
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5828495937144dfc247571b53378887c520031b/Formula/y/yorkie.rb"
         
     steps:
     - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     
     env:
-      # yorkie server v0.7.15
-      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/c9c5c207238bd689309f0715f4adf9b6aa190cae/Formula/y/yorkie.rb"
+      # yorkie server v0.7.16
+      YORKIE_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/f5828495937144dfc247571b53378887c520031b/Formula/y/yorkie.rb"
       # swiftlint v0.58.2
       SWIFTLINT_RB_URL: "https://raw.githubusercontent.com/Homebrew/homebrew-core/ae3894d1d8d343733160e1c57903187228628d9d/Formula/s/swiftlint.rb"
       # swiftformat v0.55.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 This file was reconstructed from the project's [GitHub Releases](https://github.com/yorkie-team/yorkie-ios-sdk/releases).
 
+## [v0.7.16] - 2026-08-25
+
+- Keep a tree position resolvable when two nodes claim one ID in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270
+- Stamp merge-bound inserts and filter style-range interlopers in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270
+- Stop undo and element splits from reusing a node's identity in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270
+
 ## [v0.7.15] - 2026-08-21
 
 - Make Tree restore split-aware for concurrent overlapping undo in https://github.com/yorkie-team/yorkie-ios-sdk/pull/269

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This file was reconstructed from the project's [GitHub Releases](https://github.
 
 ## [v0.7.16] - 2026-08-25
 
+> Requires a Yorkie server v0.7.16 or later. The tree node identity rules below are a wire contract shared with the server (yorkie#1927, yorkie#1929); against an older server a tree undo/redo can abort a sync with `ErrInvalidArgument: offset out of range` instead of degrading.
+
 - Keep a tree position resolvable when two nodes claim one ID in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270
 - Stamp merge-bound inserts and filter style-range interlopers in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270
 - Stop undo and element splits from reusing a node's identity in https://github.com/yorkie-team/yorkie-ios-sdk/pull/270

--- a/Sources/API/Converter.swift
+++ b/Sources/API/Converter.swift
@@ -571,6 +571,7 @@ extension Converter {
                     pbTreeEditOperation.restoreMode = .restore
                 }
             }
+            pbTreeEditOperation.splitTickets = treeEditOperation.getSplitTickets().map { toTimeTicket($0) }
             pbOperation.treeEdit = pbTreeEditOperation
         } else if let treeStyleOperation = operation as? TreeStyleOperation {
             var pbTreeStyleOperation = PbOperation.TreeStyle()
@@ -672,16 +673,18 @@ extension Converter {
                     treeRetombstoneSpans = try pbTreeEditOperation.retombstoneSpans.map { try fromTreeRestoreSpan($0) }
                     treeRestoreMode = pbTreeEditOperation.restoreMode == .retombstone ? .retombstone : .restore
                 }
-                return TreeEditOperation(parentCreatedAt: fromTimeTicket(pbTreeEditOperation.parentCreatedAt),
-                                         fromPos: fromTreePos(pbTreeEditOperation.from),
-                                         toPos: fromTreePos(pbTreeEditOperation.to),
-                                         contents: fromTreeNodesWhenEdit(pbTreeEditOperation.contents),
-                                         splitLevel: pbTreeEditOperation.splitLevel,
-                                         executedAt: fromTimeTicket(pbTreeEditOperation.executedAt),
-                                         isUndoOp: treeRestoreMode != nil,
-                                         restoreSpans: treeRestoreSpans,
-                                         restoreMode: treeRestoreMode,
-                                         retombstoneSpans: treeRetombstoneSpans)
+                let treeEdit = TreeEditOperation(parentCreatedAt: fromTimeTicket(pbTreeEditOperation.parentCreatedAt),
+                                                 fromPos: fromTreePos(pbTreeEditOperation.from),
+                                                 toPos: fromTreePos(pbTreeEditOperation.to),
+                                                 contents: fromTreeNodesWhenEdit(pbTreeEditOperation.contents),
+                                                 splitLevel: pbTreeEditOperation.splitLevel,
+                                                 executedAt: fromTimeTicket(pbTreeEditOperation.executedAt),
+                                                 isUndoOp: treeRestoreMode != nil,
+                                                 restoreSpans: treeRestoreSpans,
+                                                 restoreMode: treeRestoreMode,
+                                                 retombstoneSpans: treeRetombstoneSpans)
+                treeEdit.setSplitTickets(pbTreeEditOperation.splitTickets.map { fromTimeTicket($0) })
+                return treeEdit
             } else if case let .treeStyle(pbTreeStyleOperation) = pbOperation.body {
                 if !pbTreeStyleOperation.attributesToRemove.isEmpty {
                     return TreeStyleOperation(parentCreatedAt: fromTimeTicket(pbTreeStyleOperation.parentCreatedAt),

--- a/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
+++ b/Sources/API/V1/Generated/yorkie/v1/resources.pb.swift
@@ -916,6 +916,15 @@ public struct Yorkie_V1_Operation: Sendable {
       set {_uniqueStorage()._retombstoneSpans = newValue}
     }
 
+    /// split_tickets carries the tickets the originating replica issued for the
+    /// nodes an element split creates, in issue order. Empty for a change
+    /// written before this field existed, which replays through the simulation
+    /// that reconstructed them from executed_at and the content count.
+    public var splitTickets: [Yorkie_V1_TimeTicket] {
+      get {_storage._splitTickets}
+      set {_uniqueStorage()._splitTickets = newValue}
+    }
+
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     public init() {}
@@ -3851,7 +3860,7 @@ extension Yorkie_V1_Operation.Increase: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Yorkie_V1_Operation.protoMessageName + ".TreeEdit"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{3}created_at_map_by_actor\0\u{1}contents\0\u{3}executed_at\0\u{3}split_level\0\u{3}restore_spans\0\u{3}restore_mode\0\u{3}retombstone_spans\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}parent_created_at\0\u{1}from\0\u{1}to\0\u{3}created_at_map_by_actor\0\u{1}contents\0\u{3}executed_at\0\u{3}split_level\0\u{3}restore_spans\0\u{3}restore_mode\0\u{3}retombstone_spans\0\u{3}split_tickets\0")
 
   fileprivate class _StorageClass {
     var _parentCreatedAt: Yorkie_V1_TimeTicket? = nil
@@ -3864,6 +3873,7 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
     var _restoreSpans: [Yorkie_V1_TreeRestoreSpan] = []
     var _restoreMode: Yorkie_V1_RestoreMode = .unspecified
     var _retombstoneSpans: [Yorkie_V1_TreeRestoreSpan] = []
+    var _splitTickets: [Yorkie_V1_TimeTicket] = []
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -3884,6 +3894,7 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
       _restoreSpans = source._restoreSpans
       _restoreMode = source._restoreMode
       _retombstoneSpans = source._retombstoneSpans
+      _splitTickets = source._splitTickets
     }
   }
 
@@ -3912,6 +3923,7 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
         case 8: try { try decoder.decodeRepeatedMessageField(value: &_storage._restoreSpans) }()
         case 9: try { try decoder.decodeSingularEnumField(value: &_storage._restoreMode) }()
         case 10: try { try decoder.decodeRepeatedMessageField(value: &_storage._retombstoneSpans) }()
+        case 11: try { try decoder.decodeRepeatedMessageField(value: &_storage._splitTickets) }()
         default: break
         }
       }
@@ -3954,6 +3966,9 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
       if !_storage._retombstoneSpans.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._retombstoneSpans, fieldNumber: 10)
       }
+      if !_storage._splitTickets.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._splitTickets, fieldNumber: 11)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3973,6 +3988,7 @@ extension Yorkie_V1_Operation.TreeEdit: SwiftProtobuf.Message, SwiftProtobuf._Me
         if _storage._restoreSpans != rhs_storage._restoreSpans {return false}
         if _storage._restoreMode != rhs_storage._restoreMode {return false}
         if _storage._retombstoneSpans != rhs_storage._retombstoneSpans {return false}
+        if _storage._splitTickets != rhs_storage._splitTickets {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/API/V1/yorkie/v1/resources.proto
+++ b/Sources/API/V1/yorkie/v1/resources.proto
@@ -135,6 +135,11 @@ message Operation {
     repeated TreeRestoreSpan restore_spans = 8; // identity-preserving undo/redo
     RestoreMode restore_mode = 9;
     repeated TreeRestoreSpan retombstone_spans = 10;
+    // split_tickets carries the tickets the originating replica issued for the
+    // nodes an element split creates, in issue order. Empty for a change
+    // written before this field existed, which replays through the simulation
+    // that reconstructed them from executed_at and the content count.
+    repeated TimeTicket split_tickets = 11;
   }
   message TreeStyle {
     TimeTicket parent_created_at = 1;

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -1270,22 +1270,116 @@ class CRDTTree: CRDTElement {
      *   captured from the first styled node (for undo reverse op), and keys of attributes that
      *   did not previously exist on the first styled node (for undo reverse op).
      */
+    /// `recordInsertedContent` attaches the inserted nodes to this edit's content change.
+    ///
+    /// A removal at the same index already emitted a change there; the insert rides on it rather
+    /// than emitting a second change at the same position.
+    ///
+    /// - Parameters:
+    ///   - changes: The change list being built, mutated in place.
+    ///   - contents: The live nodes this edit inserted.
+    ///   - fromIdx: The index the edit applied at.
+    ///   - fromPath: The path the edit applied at.
+    ///   - editedAt: The ticket of the edit.
     @discardableResult
+    private func recordInsertedContent(
+        _ changes: inout [TreeChange],
+        _ contents: [CRDTTreeNode],
+        _ fromIdx: Int,
+        _ fromPath: [Int],
+        _ editedAt: TimeTicket
+    ) {
+        let value = TreeChangeValue.nodes(contents)
+
+        if let last = changes.last, last.from == fromIdx {
+            var merged = last
+            merged.value = value
+            changes.removeLast()
+            changes.append(merged)
+        } else {
+            changes.append(TreeChange(actor: editedAt.actorID,
+                                      type: .content,
+                                      from: fromIdx,
+                                      to: fromIdx,
+                                      fromPath: fromPath,
+                                      toPath: fromPath,
+                                      value: value,
+                                      splitLevel: 0))
+        }
+    }
+
+    /// `intendedMergeStamp` returns the merge stamp an insert should carry when its position was
+    /// declared inside a parent a concurrent merge removed.
+    ///
+    /// §9.4: the content physically lands in the merge target, so stamping it as merged-from the
+    /// declared parent keeps it distinguishable from nodes that were never inside that parent —
+    /// style-range resolution and merge-delete propagation key on this.
+    ///
+    /// - Parameters:
+    ///   - fromPos: The declared insert position.
+    ///   - fromParent: The parent the insert actually resolves into.
+    /// - Returns: The intended parent and the merge ticket to stamp, or `(nil, nil)` when the insert
+    ///   was not redirected by a merge.
+    /// - Throws: Rethrows from ``CRDTTreePos/toTreeNodePair(tree:)``.
+    private func intendedMergeStamp(
+        _ fromPos: CRDTTreePos,
+        _ fromParent: CRDTTreeNode
+    ) throws -> (CRDTTreeNode?, TimeTicket?) {
+        let declaredFromParent = try fromPos.toTreeNodePair(tree: self).0
+        guard declaredFromParent !== fromParent,
+              declaredFromParent.isRemoved,
+              declaredFromParent.mergedInto != nil,
+              self.resolveMergeTarget(declaredFromParent) === fromParent
+        else {
+            return (nil, nil)
+        }
+
+        // Take the merge ticket from a sibling the merge moved; the parent's own `removedAt` may
+        // have been overwritten by a later LWW tombstone.
+        for child in fromParent.innerChildren where child.mergedFrom == declaredFromParent.id {
+            if let mergedAt = child.mergedAt {
+                return (declaredFromParent, mergedAt)
+            }
+        }
+        return (declaredFromParent, declaredFromParent.removedAt)
+    }
+
+    /// `resolveStyleRange` resolves a style operation's range to its traversal endpoints.
+    ///
+    /// Shared by ``style(_:_:_:_:)`` and ``removeStyle(_:_:_:_:)``: it splits text at both ends and
+    /// advances past split siblings the editing client did not know about, so the range covers all
+    /// concurrent split products.
+    ///
+    /// - Parameters:
+    ///   - range: The style range in CRDT positions.
+    ///   - editedAt: The ticket of the styling change.
+    ///   - versionVector: The styling client's causal knowledge, or `nil` for a local edit.
+    /// - Returns: The from/to parent and left-sibling nodes, plus the data-size delta the splits produced.
+    /// - Throws: Rethrows from ``findNodesAndSplitText(_:_:_:)``.
+    private func resolveStyleRange(
+        _ range: TreePosRange,
+        _ editedAt: TimeTicket,
+        _ versionVector: VersionVector?
+    ) throws -> (CRDTTreeNode, CRDTTreeNode, CRDTTreeNode, CRDTTreeNode, DataSize) {
+        var diff = DataSize(data: 0, meta: 0)
+        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt, .range)
+        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt, .range)
+        diff.addDataSizes(others: fromDiff, toDiff)
+
+        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
+        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
+
+        return (fromParent, fromLeft, toParent, toLeft, diff)
+    }
+
     func style(
         _ range: TreePosRange,
         _ attributes: [String: String]?,
         _ editedAt: TimeTicket,
         _ versionVector: VersionVector?
     ) throws -> ([GCPair], [TreeChange], DataSize, [String: String], [String]) {
-        var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt, .range)
-        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt, .range)
-        diff.addDataSizes(others: fromDiff, toDiff)
-
-        // Advance past split siblings unknown to the editing client so the range
-        // covers all concurrent split products. Skip when leftNode == parent.
-        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
-        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
+        let (fromParent, fromLeft, toParent, toLeft, rangeDiff) = try self.resolveStyleRange(range, editedAt, versionVector)
+        var diff = rangeDiff
 
         let shouldSkipToken = try self.styleSkipPredicate(range.1, versionVector)
 
@@ -1424,15 +1518,8 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ versionVector: VersionVector? = nil
     ) throws -> ([GCPair], [TreeChange], DataSize, [String: String]) {
-        var diff = DataSize(data: 0, meta: 0)
-        let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt, .range)
-        let ((toParent, toLeftRaw), toDiff) = try self.findNodesAndSplitText(range.1, editedAt, .range)
-        diff.addDataSizes(others: fromDiff, toDiff)
-
-        // Advance past split siblings unknown to the editing client so the range
-        // covers all concurrent split products. Skip when leftNode == parent.
-        let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
-        let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
+        let (fromParent, fromLeft, toParent, toLeft, rangeDiff) = try self.resolveStyleRange(range, editedAt, versionVector)
+        var diff = rangeDiff
 
         let shouldSkipToken = try self.styleSkipPredicate(range.1, versionVector)
 
@@ -1775,29 +1862,7 @@ class CRDTTree: CRDTElement {
             // target. Stamp it as merged-from the declared parent so it stays
             // distinguishable from nodes that were never inside that parent —
             // style-range resolution and merge-delete propagation key on this.
-            let declaredFromParent = try range.0.toTreeNodePair(tree: self).0
-            let intendedParent: CRDTTreeNode? = {
-                guard declaredFromParent !== fromParent,
-                      declaredFromParent.isRemoved,
-                      declaredFromParent.mergedInto != nil,
-                      self.resolveMergeTarget(declaredFromParent) === fromParent
-                else {
-                    return nil
-                }
-                return declaredFromParent
-            }()
-            var intendedMergedAt: TimeTicket?
-            if let intendedParent {
-                // Take the merge ticket from a sibling the merge moved; the parent's
-                // own `removedAt` may have been overwritten by a later LWW tombstone.
-                for child in fromParent.innerChildren where child.mergedFrom == intendedParent.id {
-                    if let mergedAt = child.mergedAt {
-                        intendedMergedAt = mergedAt
-                        break
-                    }
-                }
-                intendedMergedAt = intendedMergedAt ?? intendedParent.removedAt
-            }
+            let (intendedParent, intendedMergedAt) = try self.intendedMergeStamp(range.0, fromParent)
 
             var aliveContents = [CRDTTreeNode]()
             var leftInChildren = fromLeft // tree
@@ -1842,25 +1907,7 @@ class CRDTTree: CRDTElement {
             }
 
             if aliveContents.isEmpty == false {
-                let value = TreeChangeValue.nodes(aliveContents)
-
-                if changes.isEmpty == false, changes.last!.from == fromIdx {
-                    var last = changes.last!
-
-                    last.value = value
-
-                    changes.removeLast()
-                    changes.append(last)
-                } else {
-                    changes.append(TreeChange(actor: editedAt.actorID,
-                                              type: .content,
-                                              from: fromIdx,
-                                              to: fromIdx,
-                                              fromPath: fromPath,
-                                              toPath: fromPath,
-                                              value: value,
-                                              splitLevel: 0))
-                }
+                self.recordInsertedContent(&changes, aliveContents, fromIdx, fromPath, editedAt)
             }
         }
         pairs.append(contentsOf: self.drainPendingGCPairs())

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -920,13 +920,11 @@ class CRDTTree: CRDTElement {
     private func mergedAnchorInterloperGuard(
         _ pos: CRDTTreePos,
         _ versionVector: VersionVector?
-    ) -> ((CRDTTreeNode) -> Bool)? {
+    ) throws -> ((CRDTTreeNode) -> Bool)? {
         guard let versionVector else {
             return nil
         }
-        guard let (declaredParent, _) = try? pos.toTreeNodePair(tree: self) else {
-            return nil
-        }
+        let (declaredParent, _) = try pos.toTreeNodePair(tree: self)
         guard declaredParent.isRemoved,
               declaredParent.mergedInto != nil,
               let removedAt = declaredParent.removedAt,
@@ -988,8 +986,8 @@ class CRDTTree: CRDTElement {
     private func styleSkipPredicate(
         _ pos: CRDTTreePos,
         _ versionVector: VersionVector?
-    ) -> (CRDTTreeNode, TokenType) -> Bool {
-        let anchorGuard = self.mergedAnchorInterloperGuard(pos, versionVector)
+    ) throws -> (CRDTTreeNode, TokenType) -> Bool {
+        let anchorGuard = try self.mergedAnchorInterloperGuard(pos, versionVector)
         return { node, tokenType in
             // Skip styling via End token when the node has an unknown split
             // sibling. The End token is in the range only because a concurrent
@@ -1289,7 +1287,7 @@ class CRDTTree: CRDTElement {
         let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
         let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
-        let shouldSkipToken = self.styleSkipPredicate(range.1, versionVector)
+        let shouldSkipToken = try self.styleSkipPredicate(range.1, versionVector)
 
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
@@ -1436,7 +1434,7 @@ class CRDTTree: CRDTElement {
         let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
         let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
-        let shouldSkipToken = self.styleSkipPredicate(range.1, versionVector)
+        let shouldSkipToken = try self.styleSkipPredicate(range.1, versionVector)
 
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
@@ -1777,10 +1775,9 @@ class CRDTTree: CRDTElement {
             // target. Stamp it as merged-from the declared parent so it stays
             // distinguishable from nodes that were never inside that parent —
             // style-range resolution and merge-delete propagation key on this.
-            let declaredFromParent = (try? range.0.toTreeNodePair(tree: self))?.0
+            let declaredFromParent = try range.0.toTreeNodePair(tree: self).0
             let intendedParent: CRDTTreeNode? = {
-                guard let declaredFromParent,
-                      declaredFromParent !== fromParent,
+                guard declaredFromParent !== fromParent,
                       declaredFromParent.isRemoved,
                       declaredFromParent.mergedInto != nil,
                       self.resolveMergeTarget(declaredFromParent) === fromParent

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -315,7 +315,10 @@ final class CRDTTreeNode: IndexTreeNode {
 
     var innerChildren: [CRDTTreeNode]
 
-    let id: CRDTTreeNodeID
+    /// The node's identity. Mutable only so that a copy-reinsert reverse operation can take a fresh
+    /// identity before it executes — see ``TreeEditOperation/reissueContentIDs(_:)``. A node already
+    /// registered in a ``CRDTTree`` must never be re-identified in place.
+    var id: CRDTTreeNodeID
     var removedAt: TimeTicket?
     var attrs: RHT?
 

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -330,9 +330,11 @@ final class CRDTTreeNode: IndexTreeNode {
     var insNextID: CRDTTreeNodeID?
 
     /**
-     * `mergedFrom` records the source parent's ID when this node was moved by a
-     * concurrent merge. Persisted in the snapshot encoding as the witness of the
-     * merge relationship.
+     * `mergedFrom` records the parent this node logically belongs to when a merge
+     * relocated it into the merge target: the source parent it was moved out of,
+     * or the declared parent of an insert redirected by the §9.4 intended-parent
+     * stamp. Persisted in the snapshot encoding as the witness of the merge
+     * relationship.
      */
     var mergedFrom: CRDTTreeNodeID?
 
@@ -464,6 +466,10 @@ final class CRDTTreeNode: IndexTreeNode {
                                  type: self.type,
                                  removedAt: self.removedAt)
         clone.attrs = self.attrs?.deepcopy()
+        // The split product holds the other half of the same moved node, so it
+        // carries the same merge stamp (as `cloneText` does).
+        clone.mergedFrom = self.mergedFrom
+        clone.mergedAt = self.mergedAt
         return clone
     }
 
@@ -894,6 +900,107 @@ class CRDTTree: CRDTElement {
     }
 
     /**
+     * `mergedAnchorInterloperGuard` prepares the §9.4 per-node filter for a style
+     * range whose end position was declared inside a parent that a merge unknown
+     * to the styling client removed. The moved anchor child resolves in the merge
+     * target, so the traversal covers nodes sitting between the merge-source
+     * tombstone and the moved children — nodes the styling client saw outside its
+     * range, after the then-live parent. The predicate skips exactly those
+     * interlopers.
+     *
+     * - Parameters:
+     *   - pos: The range-end position of the style operation.
+     *   - versionVector: The styling client's causal knowledge, or `nil` for a local edit.
+     * - Returns: A predicate that reports whether a node is an interloper, or `nil`
+     *   when this shape does not apply.
+     */
+    private func mergedAnchorInterloperGuard(
+        _ pos: CRDTTreePos,
+        _ versionVector: VersionVector?
+    ) -> ((CRDTTreeNode) -> Bool)? {
+        guard let versionVector else {
+            return nil
+        }
+        guard let (declaredParent, _) = try? pos.toTreeNodePair(tree: self) else {
+            return nil
+        }
+        guard declaredParent.isRemoved,
+              declaredParent.mergedInto != nil,
+              let removedAt = declaredParent.removedAt,
+              ticketKnown(versionVector, removedAt) == false
+        else {
+            return nil
+        }
+        let target = self.resolveMergeTarget(declaredParent)
+        // Restricted to the shape where the tombstone sits directly under the
+        // merge target; in other shapes the resolved range already excludes the
+        // interlopers.
+        guard target !== declaredParent, declaredParent.parent === target else {
+            return nil
+        }
+        // Collect the target's children positioned after the merge-source
+        // tombstone in one pass, so the predicate is O(depth) per node.
+        var afterTombstone = Set<ObjectIdentifier>()
+        var seenTombstone = false
+        for child in target.innerChildren {
+            if child === declaredParent {
+                seenTombstone = true
+                continue
+            }
+            if seenTombstone {
+                afterTombstone.insert(ObjectIdentifier(child))
+            }
+        }
+        return { node in
+            // Judge by the node's highest ancestor directly under the merge
+            // target, so an interloper's descendants are skipped with it.
+            var top = node
+            while let parent = top.parent, parent !== target {
+                top = parent
+            }
+            guard top.parent === target else {
+                return false
+            }
+            // Fail open on any merge stamp: an earlier merge keeps the ORIGINAL
+            // source in `mergedFrom` (first-move stamp rule), so stamp equality
+            // cannot prove the node was outside the styled range. Only stamp-free
+            // nodes are positively interlopers.
+            if top.mergedFrom != nil {
+                return false
+            }
+            return afterTombstone.contains(ObjectIdentifier(top))
+        }
+    }
+
+    /**
+     * `styleSkipPredicate` builds the per-token skip checks shared by ``style(_:_:_:_:)``
+     * and ``removeStyle(_:_:_:_:)``: the End-token unknown-split-sibling exclusion and the
+     * §9.4 merged-anchor interloper filter for the range-end position.
+     *
+     * - Parameters:
+     *   - pos: The range-end position of the style operation.
+     *   - versionVector: The styling client's causal knowledge, or `nil` for a local edit.
+     * - Returns: A predicate that reports whether the given token must be skipped.
+     */
+    private func styleSkipPredicate(
+        _ pos: CRDTTreePos,
+        _ versionVector: VersionVector?
+    ) -> (CRDTTreeNode, TokenType) -> Bool {
+        let anchorGuard = self.mergedAnchorInterloperGuard(pos, versionVector)
+        return { node, tokenType in
+            // Skip styling via End token when the node has an unknown split
+            // sibling. The End token is in the range only because a concurrent
+            // split extended the range into the sibling.
+            if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
+                return true
+            }
+            // §9.4: the node is in the range only because an unknown merge pulled
+            // the range-end anchor past it.
+            return anchorGuard?(node) ?? false
+        }
+    }
+
+    /**
      * `advancePastUnknownSplitSiblings` follows the `insNextID` chain of the
      * given node, advancing past element-type split siblings that the editing
      * client did not know about (not in `versionVector`).
@@ -1179,6 +1286,8 @@ class CRDTTree: CRDTElement {
         let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
         let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
+        let shouldSkipToken = self.styleSkipPredicate(range.1, versionVector)
+
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
         var prevAttributes = [String: String]()
@@ -1196,10 +1305,7 @@ class CRDTTree: CRDTElement {
                 editedAt,
                 clientLamportAtChange
             ), !node.isText, let attributes {
-                // Skip styling via End token when the node has an unknown split
-                // sibling. The End token is in the range only because a
-                // concurrent split extended the range into the sibling.
-                if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
+                if shouldSkipToken(node, tokenType) {
                     return
                 }
 
@@ -1327,6 +1433,8 @@ class CRDTTree: CRDTElement {
         let fromLeft = fromLeftRaw !== fromParent ? self.advancePastUnknownSplitSiblings(fromLeftRaw, versionVector) : fromLeftRaw
         let toLeft = toLeftRaw !== toParent ? self.advancePastUnknownSplitSiblings(toLeftRaw, versionVector) : toLeftRaw
 
+        let shouldSkipToken = self.styleSkipPredicate(range.1, versionVector)
+
         var changes: [TreeChange] = []
         var pairs = [GCPair]()
         let value = TreeChangeValue.attributesToRemove(attributesToRemove)
@@ -1345,10 +1453,7 @@ class CRDTTree: CRDTElement {
                 editedAt,
                 clientLamportAtChange
             ), !attributesToRemove.isEmpty {
-                // Skip styling via End token when the node has an unknown split
-                // sibling. The End token is in the range only because a
-                // concurrent split extended the range into the sibling.
-                if tokenType == .end, let versionVector, self.hasUnknownSplitSibling(node, versionVector) {
+                if shouldSkipToken(node, tokenType) {
                     return
                 }
 
@@ -1664,6 +1769,36 @@ class CRDTTree: CRDTElement {
         let insertedContentSize = contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
 
         if let contents, contents.isEmpty == false {
+            // §9.4: When the insert position was declared inside a parent that a
+            // concurrent merge removed, the content physically lands in the merge
+            // target. Stamp it as merged-from the declared parent so it stays
+            // distinguishable from nodes that were never inside that parent —
+            // style-range resolution and merge-delete propagation key on this.
+            let declaredFromParent = (try? range.0.toTreeNodePair(tree: self))?.0
+            let intendedParent: CRDTTreeNode? = {
+                guard let declaredFromParent,
+                      declaredFromParent !== fromParent,
+                      declaredFromParent.isRemoved,
+                      declaredFromParent.mergedInto != nil,
+                      self.resolveMergeTarget(declaredFromParent) === fromParent
+                else {
+                    return nil
+                }
+                return declaredFromParent
+            }()
+            var intendedMergedAt: TimeTicket?
+            if let intendedParent {
+                // Take the merge ticket from a sibling the merge moved; the parent's
+                // own `removedAt` may have been overwritten by a later LWW tombstone.
+                for child in fromParent.innerChildren where child.mergedFrom == intendedParent.id {
+                    if let mergedAt = child.mergedAt {
+                        intendedMergedAt = mergedAt
+                        break
+                    }
+                }
+                intendedMergedAt = intendedMergedAt ?? intendedParent.removedAt
+            }
+
             var aliveContents = [CRDTTreeNode]()
             var leftInChildren = fromLeft // tree
 
@@ -1675,6 +1810,11 @@ class CRDTTree: CRDTElement {
                 } else {
                     // 05-1-2. insert after leftSibling
                     try fromParent.insertAfter(content, leftInChildren)
+                }
+
+                if let intendedParent {
+                    content.mergedFrom = intendedParent.id
+                    content.mergedAt = intendedMergedAt
                 }
 
                 leftInChildren = content

--- a/Sources/Document/CRDT/CRDTTree.swift
+++ b/Sources/Document/CRDT/CRDTTree.swift
@@ -809,8 +809,19 @@ class CRDTTree: CRDTElement {
         self.indexTree = IndexTree(root: root)
         self.nodeMapByID = LLRBTree()
 
+        // Registering every node is the cost of loading a document, so it runs
+        // without the duplicate check: a plain put per node, then one comparison
+        // to see whether any ID was claimed twice. Only a tree that carries
+        // duplicates pays for resolving them.
+        var nodeCount = 0
         self.indexTree.traverseAll { node, _ in
             self.nodeMapByID.put(node.id, node)
+            nodeCount += 1
+        }
+        if self.nodeMapByID.size != nodeCount {
+            self.indexTree.traverseAll { node, _ in
+                self.registerNode(node)
+            }
         }
 
         // Rebuild runtime merge state from the persisted `mergedFrom` field.
@@ -957,10 +968,83 @@ class CRDTTree: CRDTElement {
     }
 
     /**
-     * `registerNode` registers the given node to the tree.
+     * `registerNode` registers the given node to the tree, keeping a live node
+     * over a tombstone when both claim the same ID.
+     *
+     * Documents written by older clients can carry two nodes under one ID (an
+     * undo that re-inserted a deleted piece by copy). A plain put lets the
+     * winner depend on the order the nodes were registered — operation order on
+     * a live document, document order on one rebuilt from a snapshot — so after
+     * a reload the same position resolves to a different node and its offset can
+     * fall outside that node. Keeping the live one makes both orders agree for a
+     * live/tombstone pair, which is the shape those documents carry.
+     *
+     * Two nodes in the same state keep the last-registered-wins behavior, and
+     * stay order-dependent: element IDs issued for a split can legitimately
+     * collide with an inserted node's ID (see the delimiter note in
+     * ``TreeEditOperation``), and that resolution order is what the rest of the
+     * tree already assumes.
+     *
+     * A node this refuses stays in the index tree while another node answers for
+     * its ID, so it is reachable by traversal but not by lookup. That is the
+     * intended trade for a duplicate: the alternative is unregistering a node
+     * that positions still resolve through.
      */
     func registerNode(_ node: CRDTTreeNode) {
+        if let entry = self.nodeMapByID.floorEntry(node.id),
+           entry.value !== node,
+           entry.key == node.id,
+           node.isRemoved,
+           entry.value.isRemoved == false
+        {
+            return
+        }
+
         self.nodeMapByID.put(node.id, node)
+    }
+
+    /**
+     * `dropDuplicateContents` returns the contents that would not put a second
+     * node under an ID already in the tree.
+     *
+     * Content created by an edit carries that edit's lamport and actor, so a
+     * content node whose ID names another change is a copy of a node that
+     * already exists — what the copy-reinsert undo path sends when it reverses a
+     * deletion. Inserting it would leave two nodes under one identity, so the
+     * copy is dropped and the rest of the edit applies.
+     *
+     * Content from this edit's own change is kept even when its ID collides: the
+     * delimiters an element split consumes are simulated rather than replayed,
+     * so an ID issued here can legitimately collide, and dropping it would lose
+     * a node the client already inserted.
+     *
+     * Dropping rather than failing is deliberate: such changes are already in
+     * the history of existing documents, and a change that cannot be replayed is
+     * a document that can never be loaded again. A collision anywhere in a
+     * content node's subtree drops that whole subtree, on the grounds that a
+     * copy is copied whole.
+     *
+     * - Parameters:
+     *   - contents: The content nodes this edit is about to insert.
+     *   - editedAt: The ticket of the edit inserting them.
+     * - Returns: The subset of `contents` whose IDs are free.
+     */
+    func dropDuplicateContents(_ contents: [CRDTTreeNode], _ editedAt: TimeTicket) -> [CRDTTreeNode] {
+        contents.filter { content in
+            var reused = false
+            traverseAll(node: content) { node, _ in
+                let createdAt = node.id.createdAt
+                if createdAt.lamport == editedAt.lamport, createdAt.actorID == editedAt.actorID {
+                    return
+                }
+
+                if let entry = self.nodeMapByID.floorEntry(node.id), entry.key == node.id {
+                    reused = true
+                }
+            }
+
+            return reused == false
+        }
     }
 
     /**
@@ -1439,7 +1523,7 @@ class CRDTTree: CRDTElement {
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket,
         _ versionVector: VersionVector? = nil
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan]) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan], Int) {
         // 01. find nodes from the given range and split nodes.
         var diff = DataSize(data: 0, meta: 0)
         let ((fromParent, fromLeftRaw), fromDiff) = try self.findNodesAndSplitText(range.0, editedAt)
@@ -1569,6 +1653,16 @@ class CRDTTree: CRDTElement {
         }
 
         // 05. Insert: insert the given nodes at the given position.
+        //
+        // The identity check runs here rather than on entry: resolving the range
+        // above splits text nodes, and a split can create the very ID a content
+        // node carries. Checking before that would let the copy through and leave
+        // two nodes under one ID. `insertedContentSize` is measured now, while the
+        // content is still detached — inserting under a removed parent tombstones
+        // it and shrinks what its size reads back as.
+        let contents = contents.map { self.dropDuplicateContents($0, editedAt) }
+        let insertedContentSize = contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
+
         if let contents, contents.isEmpty == false {
             var aliveContents = [CRDTTreeNode]()
             var leftInChildren = fromLeft // tree
@@ -1595,7 +1689,7 @@ class CRDTTree: CRDTElement {
                         diff.addDataSizes(others: node.getDataSize())
                     }
 
-                    self.nodeMapByID.put(node.id, node)
+                    self.registerNode(node)
 
                     // Capture this inserted node's identity span for
                     // identity-preserving insert undo/redo.
@@ -1642,7 +1736,7 @@ class CRDTTree: CRDTElement {
         // subtree top-down (a child's recreate resolves its parent by identity).
         let outRemoved = spansComplete ? removedSpans : []
         let outInserted = spansComplete ? Array(insertedSpans.reversed()) : []
-        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel, preTombstoned, outRemoved, outInserted)
+        return (changes, pairs, diff, nodesToBeRemoved, fromIdx, mergeLevel, preTombstoned, outRemoved, outInserted, insertedContentSize)
     }
 
     /**
@@ -1791,7 +1885,7 @@ class CRDTTree: CRDTElement {
         _ splitLevel: Int32,
         _ editedAt: TimeTicket,
         _ issueTimeTicket: () -> TimeTicket
-    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan]) {
+    ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan], Int) {
         let fromPos = try self.findPos(range.0)
         let toPos = try self.findPos(range.1)
         return try self.edit(
@@ -2202,7 +2296,12 @@ extension CRDTTree: GCParent {
         } catch {
             return
         }
-        self.nodeMapByID.remove(node.id)
+        // `nodeMapByID` is keyed by ID, so an unconditional remove would also
+        // unregister a different node that shares this one's ID — see
+        // ``registerNode(_:)``. Only drop the entry this node actually holds.
+        if let entry = self.nodeMapByID.floorEntry(node.id), entry.value === node, entry.key == node.id {
+            self.nodeMapByID.remove(node.id)
+        }
 
         if let insPrevID = node.insPrevID {
             self.findFloorNode(insPrevID)?.insNextID = node.insNextID
@@ -2556,7 +2655,7 @@ extension CRDTTree {
                let succIdx = siblings.firstIndex(where: { $0 === succ })
             {
                 try parent.insertAt(node, succIdx)
-                self.nodeMapByID.put(node.id, node)
+                self.registerNode(node)
                 return node
             }
             if offset > span.id.offset || offset > 0 {
@@ -2564,7 +2663,7 @@ extension CRDTTree {
                    pred.isText, pred.parent === parent
                 {
                     try parent.insertAfter(node, pred)
-                    self.nodeMapByID.put(node.id, node)
+                    self.registerNode(node)
                     return node
                 }
             }
@@ -2575,7 +2674,7 @@ extension CRDTTree {
            let left = self.findFloorNode(leftSiblingID), left.parent === parent
         {
             try parent.insertAfter(node, left)
-            self.nodeMapByID.put(node.id, node)
+            self.registerNode(node)
             return node
         }
 
@@ -2585,7 +2684,7 @@ extension CRDTTree {
            let rightIdx = siblings.firstIndex(where: { $0 === right })
         {
             try parent.insertAt(node, rightIdx)
-            self.nodeMapByID.put(node.id, node)
+            self.registerNode(node)
             return node
         }
 
@@ -2594,7 +2693,7 @@ extension CRDTTree {
         // total order this rung needs.
         let insertIdx = siblings.firstIndex { $0.id > node.id } ?? siblings.count
         try parent.insertAt(node, insertIdx)
-        self.nodeMapByID.put(node.id, node)
+        self.registerNode(node)
         return node
     }
 

--- a/Sources/Document/Document.swift
+++ b/Sources/Document/Document.swift
@@ -398,6 +398,11 @@ public class Document: Attachable {
                 let prev = add.value.createdAt
                 add.value.setCreatedAt(ticket)
                 self.internalHistory.reconcileCreatedAt(prevCreatedAt: prev, currCreatedAt: ticket)
+            } else if let treeEdit = op as? TreeEditOperation {
+                // A reverse that re-inserts a copy of removed nodes carries their original ids;
+                // inserting them again would leave two nodes under one id. Restore-mode reverses
+                // revive by identity and keep theirs.
+                try treeEdit.reissueContentIDs { context.issueTimeTicket }
             }
 
             context.push(operation: op)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -787,7 +787,7 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
-        let (_, pairs, diff, _, _, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
+        let (_, pairs, diff, _, _, _, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
             context.issueTimeTicket
         }, nil)
         self.context?.acc(diff)

--- a/Sources/Document/Json/JSONTree.swift
+++ b/Sources/Document/Json/JSONTree.swift
@@ -787,8 +787,14 @@ public class JSONTree {
             crdtNodes = try contents?.compactMap { try createCRDTTreeNode(context: context, content: $0) }
         }
 
+        // Splitting an element creates nodes that need tickets. Record the ones issued so the
+        // operation can carry them: every other replica then uses them instead of reconstructing them
+        // from the operation, which it cannot do correctly once content has descendants.
+        var splitTickets = [TimeTicket]()
         let (_, pairs, diff, _, _, _, _, _, _, _) = try tree.edit((fromPos, toPos), crdtNodes?.compactMap { $0.deepcopy() }, splitLevel, ticket, {
-            context.issueTimeTicket
+            let issued = context.issueTimeTicket
+            splitTickets.append(issued)
+            return issued
         }, nil)
         self.context?.acc(diff)
 
@@ -796,16 +802,16 @@ public class JSONTree {
             self.context?.registerGCPair(pair)
         }
 
-        context.push(
-            operation: TreeEditOperation(
-                parentCreatedAt: tree.createdAt,
-                fromPos: fromPos,
-                toPos: toPos,
-                contents: crdtNodes,
-                splitLevel: splitLevel,
-                executedAt: ticket
-            )
+        let edit = TreeEditOperation(
+            parentCreatedAt: tree.createdAt,
+            fromPos: fromPos,
+            toPos: toPos,
+            contents: crdtNodes,
+            splitLevel: splitLevel,
+            executedAt: ticket
         )
+        edit.setSplitTickets(splitTickets)
+        context.push(operation: edit)
 
         return true
     }

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -96,6 +96,11 @@ final class TreeEditOperation: Operation {
     private var lastFromIdx: Int?
     /// The pre-edit end index captured by the most recent `execute`, used to reconcile parked ops.
     private var lastToIdx: Int?
+    /// The tree-index token count the tree actually accepted from ``contents`` on the most recent
+    /// `execute`. The tree drops content whose ID it already holds, so this can be smaller than the
+    /// content this operation carries; a reverse range covering a dropped copy would delete a
+    /// neighbour on redo.
+    private var insertedContentSize: Int?
     /// Set on boundary-deletion ops that were generated to reverse a split. When this op executes
     /// (as undo), ``toReverseOperation(_:_:_:)`` uses this value to regenerate a proper split op
     /// for redo, rather than re-inserting the tombstoned boundary nodes as content.
@@ -244,7 +249,12 @@ final class TreeEditOperation: Operation {
          * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
          * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
          */
-        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
+        // The tree drops content that reuses an ID it already holds, and reports the size of what it
+        // accepted. The reverse operation and the undo stack both read that size rather than the
+        // content this operation carried: a range covering content the tree refused would delete a
+        // neighbour on redo. The delimiter simulation below stays on the original count, since the
+        // server simulates it the same way.
+        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans, insertedContentSize) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
             var delimiter = editedAt.delimiter
             if let contents {
                 delimiter += UInt32(contents.count)
@@ -261,6 +271,7 @@ final class TreeEditOperation: Operation {
         self.lastFromIdx = preEditFromIdx
         let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }
         self.lastToIdx = preEditFromIdx + removedSize
+        self.insertedContentSize = insertedContentSize
 
         // Build the reverse op for undo.
         // A pure split (splitLevel > 0, no content inserted, no nodes removed) gets a
@@ -394,8 +405,13 @@ final class TreeEditOperation: Operation {
             return splitUndoOp
         }
 
-        // Total tree-index tokens inserted by this edit.
-        let insertedContentSize = self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
+        // Inserted content size in tree index tokens, measured before the edit: these nodes are now
+        // in the tree, and one inserted under a concurrently removed parent is tombstoned on the way
+        // in, which shrinks the size read back here. The guard below relies on that pre-edit size to
+        // recognize an edit that had no effect. What it counts is the content the tree accepted, not
+        // the content this operation carried — a reverse range covering a dropped copy would delete a
+        // neighbour on redo.
+        let insertedContentSize = self.insertedContentSize ?? 0
 
         // Guard: if the positions exceed the post-edit tree size, the edit was a no-op (e.g. a
         // concurrent parent deletion tombstoned the inserted content). Skip the reverse op.
@@ -560,8 +576,15 @@ final class TreeEditOperation: Operation {
     }
 
     /// `getContentSize` returns the total visible size of this operation's content.
+    ///
+    /// Once the operation has run, this is the size the tree accepted: content whose ID was already
+    /// in the tree is dropped, and the undo stack shifts its stored indices by this size, so counting
+    /// the dropped copy would move every index in the stack past content that was never inserted.
     func getContentSize() -> Int {
-        self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
+        if let insertedContentSize = self.insertedContentSize {
+            return insertedContentSize
+        }
+        return self.contents?.reduce(0) { $0 + $1.paddedSize } ?? 0
     }
 
     /**

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -116,6 +116,12 @@ final class TreeEditOperation: Operation {
     private(set) var restoreMode: RestoreMode?
     private(set) var retombstoneSpans: [TreeRestoreSpan]?
 
+    /// The tickets the originating replica issued for the nodes an element split creates, in issue
+    /// order. A replica applying the operation consumes them instead of reconstructing them, so
+    /// neither side depends on the other's allocation staying in step. Empty for a change written
+    /// before the field existed, which falls back to the reconstruction.
+    private var splitTickets: [TimeTicket] = []
+
     init(parentCreatedAt: TimeTicket,
          fromPos: CRDTTreePos,
          toPos: CRDTTreePos,
@@ -143,6 +149,68 @@ final class TreeEditOperation: Operation {
         self.retombstoneSpans = retombstoneSpans
     }
 
+    /// `reissueContentIDs` gives every node this operation inserts a fresh identity.
+    ///
+    /// A reverse operation that reverses a deletion by re-inserting a copy of the removed nodes
+    /// carries their original ids, so executing it would put two nodes under one id — the ambiguity
+    /// that makes a position anchored there resolve differently on different replicas. Undo already
+    /// re-identifies a restored value elsewhere: ``ArraySetOperation`` and ``AddOperation`` both take
+    /// the fresh ticket in ``Document/undo()``. This is the tree's counterpart, called from the same
+    /// place so the ids come from the change the undo creates.
+    ///
+    /// A restore-mode reverse is left alone: it revives nodes under their original identity by
+    /// design, which is what makes concurrent undos of one deletion converge rather than duplicate.
+    ///
+    /// - Parameter issueTimeTicket: Issues the next ticket of the change the undo creates.
+    /// - Throws: ``YorkieError`` with code `errRefused` when this operation also splits.
+    func reissueContentIDs(_ issueTimeTicket: @escaping () -> TimeTicket) throws {
+        guard let contents = self.contents, self.restoreMode == nil else {
+            return
+        }
+
+        // The tickets taken here start at `executedAt.delimiter + 1` and run one per node, while
+        // `execute` simulates the tickets an element split consumes starting at
+        // `executedAt.delimiter + contents.count + 1`. The two ranges overlap as soon as content has
+        // descendants, so this only holds while no content-bearing reverse splits — which is every
+        // reverse `toReverseOperation` builds, all of them `splitLevel: 0`.
+        if self.splitLevel != 0 {
+            throw YorkieError(code: .errRefused, message: "cannot reissue content ids on a splitting edit")
+        }
+
+        for content in contents {
+            traverseAll(node: content) { node, _ in
+                node.id = CRDTTreeNodeID(createdAt: issueTimeTicket(), offset: 0)
+                // A fresh identity has to be fresh in every field that names a node. The copy came
+                // from `deepcopy`, which carries the split chain and the merge lineage of the node it
+                // copied: left in place they would splice this node into a chain it never belonged
+                // to, and `purge` relinking that chain would unlink the real tombstone from it.
+                node.insPrevID = nil
+                node.insNextID = nil
+                node.mergedFrom = nil
+                node.mergedAt = nil
+                node.mergedInto = nil
+            }
+        }
+    }
+
+    /// `getSplitTickets` returns the tickets issued for the nodes an element split created, in issue
+    /// order.
+    ///
+    /// - Returns: The issued tickets, empty when this edit did not split an element.
+    func getSplitTickets() -> [TimeTicket] {
+        self.splitTickets
+    }
+
+    /// `setSplitTickets` records the tickets issued for the nodes an element split created.
+    ///
+    /// The originating replica calls this after executing the edit, so every other replica can use
+    /// them instead of reconstructing them.
+    ///
+    /// - Parameter tickets: The tickets in issue order.
+    func setSplitTickets(_ tickets: [TimeTicket]) {
+        self.splitTickets = tickets
+    }
+
     /**
      * `execute` executes this operation on the given `CRDTRoot`.
      */
@@ -158,7 +226,7 @@ final class TreeEditOperation: Operation {
             throw YorkieError(code: .errInvalidArgument, message: log)
         }
 
-        var editedAt = self.executedAt
+        let editedAt = self.executedAt
         guard let tree = parentObject as? CRDTTree else {
             throw YorkieError(code: .errInvalidArgument, message: "fail to execute, only Tree can execute edit")
         }
@@ -254,16 +322,26 @@ final class TreeEditOperation: Operation {
         // content this operation carried: a range covering content the tree refused would delete a
         // neighbour on redo. The delimiter simulation below stays on the original count, since the
         // server simulates it the same way.
+        // Splitting an element creates nodes that need tickets. The originating replica issued them
+        // and carries them here, so this hands them back in the same order. A change written before
+        // the field existed carries none, and falls back to reconstructing them from `editedAt` and
+        // the number of top-level contents — a reconstruction that is wrong as soon as content has
+        // descendants, since each of those consumed a ticket too.
+        var issuedSplitTickets = 0
+        // The reconstruction advances one delimiter per issued ticket from a base captured once, so
+        // successive tickets in a multi-level split are consecutive. Reading the base back off the
+        // last issued ticket instead would re-add the content count on every call.
+        var splitDelimiter = editedAt.delimiter + UInt32(self.contents?.count ?? 0)
         let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans, insertedContentSize) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
-            var delimiter = editedAt.delimiter
-            if let contents {
-                delimiter += UInt32(contents.count)
+            if issuedSplitTickets < self.splitTickets.count {
+                let ticket = self.splitTickets[issuedSplitTickets]
+                issuedSplitTickets += 1
+                return ticket
             }
 
-            delimiter += 1
-            editedAt = TimeTicket(lamport: editedAt.lamport, delimiter: delimiter, actorID: editedAt.actorID)
+            splitDelimiter += 1
 
-            return editedAt
+            return TimeTicket(lamport: editedAt.lamport, delimiter: splitDelimiter, actorID: editedAt.actorID)
         }, versionVector)
 
         // Capture the pre-edit range so a remote/local edit can reconcile parked undo ops. `toIdx`

--- a/Sources/Document/Operation/TreeEditOperation.swift
+++ b/Sources/Document/Operation/TreeEditOperation.swift
@@ -193,6 +193,39 @@ final class TreeEditOperation: Operation {
         }
     }
 
+    /// `makeSplitTicketIssuer` returns the closure ``CRDTTree/edit(_:_:_:_:_:_:)`` uses to issue
+    /// tickets for the nodes an element split creates.
+    ///
+    /// The originating replica issued them and carries them in ``splitTickets``, so this hands them
+    /// back in the same order. A change written before that field existed carries none and falls
+    /// back to reconstructing them from `editedAt` and the number of top-level contents — a
+    /// reconstruction that is wrong as soon as content has descendants, since each of those consumed
+    /// a ticket too.
+    ///
+    /// TODO(sejongk): When splitting element nodes, a new nodeID is assigned with a different
+    /// timeTicket. In the same change context, the timeTickets share the same lamport and actorID
+    /// but have different delimiters, incremented by one for each. This logic might be unclear;
+    /// consider refactoring for multi-level concurrent editing in the Tree implementation.
+    ///
+    /// - Parameter editedAt: The ticket this operation executes at.
+    /// - Returns: A closure returning the next split ticket on each call.
+    private func makeSplitTicketIssuer(_ editedAt: TimeTicket) -> () -> TimeTicket {
+        var issued = 0
+        // The base is captured once and advanced one delimiter per issued ticket, so successive
+        // tickets in a multi-level split are consecutive. Reading the base back off the last issued
+        // ticket instead would re-add the content count on every call.
+        var delimiter = editedAt.delimiter + UInt32(self.contents?.count ?? 0)
+        return {
+            if issued < self.splitTickets.count {
+                let ticket = self.splitTickets[issued]
+                issued += 1
+                return ticket
+            }
+            delimiter += 1
+            return TimeTicket(lamport: editedAt.lamport, delimiter: delimiter, actorID: editedAt.actorID)
+        }
+    }
+
     /// `getSplitTickets` returns the tickets issued for the nodes an element split created, in issue
     /// order.
     ///
@@ -310,39 +343,18 @@ final class TreeEditOperation: Operation {
             self.toPos = try fromIdx == toIdx ? self.fromPos : (tree.findPos(toIdx))
         }
 
-        /**
-         * TODO(sejongk): When splitting element nodes, a new nodeID is assigned with a different timeTicket.
-         * In the same change context, the timeTickets share the same lamport and actorID but have different delimiters,
-         * incremented by one for each.
-         * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
-         * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
-         */
         // The tree drops content that reuses an ID it already holds, and reports the size of what it
         // accepted. The reverse operation and the undo stack both read that size rather than the
         // content this operation carried: a range covering content the tree refused would delete a
-        // neighbour on redo. The delimiter simulation below stays on the original count, since the
-        // server simulates it the same way.
-        // Splitting an element creates nodes that need tickets. The originating replica issued them
-        // and carries them here, so this hands them back in the same order. A change written before
-        // the field existed carries none, and falls back to reconstructing them from `editedAt` and
-        // the number of top-level contents — a reconstruction that is wrong as soon as content has
-        // descendants, since each of those consumed a ticket too.
-        var issuedSplitTickets = 0
-        // The reconstruction advances one delimiter per issued ticket from a base captured once, so
-        // successive tickets in a multi-level split are consecutive. Reading the base back off the
-        // last issued ticket instead would re-add the content count on every call.
-        var splitDelimiter = editedAt.delimiter + UInt32(self.contents?.count ?? 0)
-        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans, insertedContentSize) = try tree.edit((self.fromPos, self.toPos), self.contents?.compactMap { $0.deepcopy() }, self.splitLevel, editedAt, {
-            if issuedSplitTickets < self.splitTickets.count {
-                let ticket = self.splitTickets[issuedSplitTickets]
-                issuedSplitTickets += 1
-                return ticket
-            }
-
-            splitDelimiter += 1
-
-            return TimeTicket(lamport: editedAt.lamport, delimiter: splitDelimiter, actorID: editedAt.actorID)
-        }, versionVector)
+        // neighbour on redo.
+        let (changes, pairs, diff, removedNodes, preEditFromIdx, mergeLevel, preTombstoned, removedSpans, insertedSpans, insertedContentSize) = try tree.edit(
+            (self.fromPos, self.toPos),
+            self.contents?.compactMap { $0.deepcopy() },
+            self.splitLevel,
+            editedAt,
+            self.makeSplitTicketIssuer(editedAt),
+            versionVector
+        )
 
         // Capture the pre-edit range so a remote/local edit can reconcile parked undo ops. `toIdx`
         // is `fromIdx` plus the total visible tokens of the nodes this edit removed.

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -263,8 +263,15 @@ extension IndexTreeNode {
     func splitText(_ offset: Int32, _ absOffset: Int32) throws -> (Self?, DataSize) {
         var diff = DataSize(data: 0, meta: 0)
 
-        guard offset > 0, offset < self.size else {
+        guard offset != 0, offset != self.size else {
             return (nil, diff)
+        }
+
+        // A position that anchors past the end of this node cannot be resolved
+        // here. Slicing would quietly hand back an empty right value and the
+        // split would look like a no-op, leaving the edit at the wrong position.
+        guard offset > 0, offset < self.size else {
+            throw YorkieError(code: .errInvalidArgument, message: "split at \(offset) of \(self.size): offset out of range")
         }
 
         let leftValue = self.value.substring(to: Int(offset)) as NSString

--- a/Sources/Util/IndexTree.swift
+++ b/Sources/Util/IndexTree.swift
@@ -277,7 +277,7 @@ extension IndexTreeNode {
         let leftValue = self.value.substring(to: Int(offset)) as NSString
         let rightValue = self.value.substring(from: Int(offset)) as NSString
 
-        if rightValue.length == 0 || offset == size {
+        if rightValue.length == 0 {
             return (nil, diff)
         }
 

--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -16,4 +16,4 @@
 
 import Foundation
 
-let yorkieVersion = "0.7.15"
+let yorkieVersion = "0.7.16"

--- a/Tests/Integration/TreeStyleMovedAnchorIntegrationTests.swift
+++ b/Tests/Integration/TreeStyleMovedAnchorIntegrationTests.swift
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Integration tests for "Tree.Style range ending after a merge-moved child",
+// ported from yorkie-js-sdk v0.7.16:
+// `packages/sdk/test/integration/tree_style_moved_anchor_test.ts`
+// (yorkie-js-sdk#1317 "Stamp merge-bound inserts and filter style-range
+// interlopers"). These tests require a running yorkie server at
+// http://localhost:8080.
+
+import XCTest
+@testable @preconcurrency import Yorkie
+#if SWIFT_TEST
+@testable import YorkieTestHelper
+#endif
+
+final class TreeStyleMovedAnchorIntegrationTests: XCTestCase {
+    @MainActor
+    func test_does_not_style_a_node_concurrently_inserted_at_the_merged_anchor() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 inserts an empty <p> after the second paragraph, then
+            // styles a range ending after `c`, a non-leftmost position inside
+            // the second paragraph. The inserted <p> is outside the styled
+            // range on d1.
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(8, 8, JSONTreeElementNode(type: "p", children: [])) }
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 6, ["bold": "x"]) }
+            // d2 concurrently removes the range, merging across the paragraphs.
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 5) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><p></p>cd</r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_does_not_leave_attributes_from_removeStyle_on_a_concurrently_inserted_node() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(8, 8, JSONTreeElementNode(type: "p", children: [])) }
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.removeStyle(0, 6, ["bold"]) }
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 5) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><p></p>cd</r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_still_styles_an_own_insert_that_was_inside_the_styled_range() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — d1 inserts <b> inside the second paragraph, before `c`,
+            // and styles a range that covers it. The insert resolves into the
+            // merge target on d2, and must stay styled on both replicas.
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(5, 5, JSONTreeElementNode(type: "b", children: [])) }
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 8, ["bold": "x"]) }
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 5) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><b bold=\"x\"></b>cd</r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_skips_descendants_of_a_node_inserted_at_the_merged_anchor() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — the inserted <p> carries a nested <b>; both are outside
+            // the styled range on d1, so neither may be styled on the merging
+            // replica.
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(8, 8, JSONTreeElementNode(type: "p", children: [])) }
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(9, 9, JSONTreeElementNode(type: "b", children: [])) }
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 6, ["bold": "x"]) }
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 5) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><p><b></b></p>cd</r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_still_styles_a_sibling_before_the_merge_source_tombstone() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "b", children: []),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — the leading <b> is inside the styled range on both
+            // replicas and sits before the merge-source tombstone after the
+            // merge.
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 8, ["bold": "x"]) }
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(2, 7) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><b bold=\"x\"></b>cd</r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_still_styles_a_child_that_arrived_via_an_earlier_synced_merge() async throws {
+        try await withTwoClientsAndDocuments(self.description) { c1, d1, c2, d2 in
+            // given
+            try d1.update { root, _ in
+                root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                    JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                    JSONTreeElementNode(type: "s", children: [JSONTreeElementNode(type: "i", children: [])])
+                ]))
+            }
+            try await c1.sync()
+            try await c2.sync()
+
+            // when — fully synced merge: <s> into <p> — <i> moves into <p>
+            // and keeps mergedFrom=s forever (stamped only on the first move).
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.edit(3, 5) }
+            try await c1.sync()
+            try await c2.sync()
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r><p>ab<i></i></p></r>")
+            XCTAssertEqual((d2.getRoot().tree as? JSONTree)?.toXML(), "<r><p>ab<i></i></p></r>")
+
+            // d1 styles a range ending after <i>, a non-leftmost position
+            // inside <p>, covering <i>. d2 concurrently merges <p> into <r>.
+            try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 5, ["bold": "x"]) }
+            try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 1) }
+
+            try await c1.sync()
+            try await c2.sync()
+            try await c1.sync()
+
+            // then
+            XCTAssertEqual((d1.getRoot().tree as? JSONTree)?.toXML(), "<r>ab<i bold=\"x\"></i></r>")
+            XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        }
+    }
+
+    @MainActor
+    func test_converges_when_a_third_client_inserts_at_the_merged_anchor() async throws {
+        let rpcAddress = "http://localhost:8080"
+        let c1 = Client(rpcAddress)
+        let c2 = Client(rpcAddress)
+        let c3 = Client(rpcAddress)
+        try await c1.activate()
+        try await c2.activate()
+        try await c3.activate()
+
+        let docKey = "\(self.description)-\(Date().description)".toDocKey
+        let d1 = Document(key: docKey)
+        let d2 = Document(key: docKey)
+        let d3 = Document(key: docKey)
+        try await c1.attach(d1, [:], .manual)
+        try await c2.attach(d2, [:], .manual)
+        try await c3.attach(d3, [:], .manual)
+
+        try d1.update { root, _ in
+            root.tree = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")]),
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "cd")])
+            ]))
+        }
+        try await c1.sync()
+        try await c2.sync()
+        try await c3.sync()
+
+        // d3's insert is unknown to d1's style, so the version-vector check
+        // keeps it unstyled on every replica.
+        try d1.update { root, _ in try (root.tree as? JSONTree)?.style(0, 6, ["bold": "x"]) }
+        try d2.update { root, _ in try (root.tree as? JSONTree)?.edit(0, 5) }
+        try d3.update { root, _ in try (root.tree as? JSONTree)?.edit(8, 8, JSONTreeElementNode(type: "p", children: [])) }
+
+        for client in [c1, c2, c3] {
+            try await client.sync()
+        }
+        try await c1.sync()
+        try await c2.sync()
+
+        XCTAssertEqual(d1.toSortedJSON(), d2.toSortedJSON())
+        XCTAssertEqual(d2.toSortedJSON(), d3.toSortedJSON())
+
+        try await c1.detach(d1)
+        try await c2.detach(d2)
+        try await c3.detach(d3)
+        try await c1.deactivate()
+        try await c2.deactivate()
+        try await c3.deactivate()
+    }
+}

--- a/Tests/Unit/API/V1/TreeEditSplitTicketsConverterTests.swift
+++ b/Tests/Unit/API/V1/TreeEditSplitTicketsConverterTests.swift
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftProtobuf
+import XCTest
+@testable import Yorkie
+
+/// Converter round-trip coverage for `Operation.TreeEdit.split_tickets = 11`,
+/// added in yorkie-js-sdk v0.7.16 (yorkie-js-sdk#1319 "Stop undo and element
+/// splits from reusing a node's identity"). The tickets an element split
+/// consumes are now carried on the wire rather than reconstructed on the
+/// receiving side, since a reconstruction that advances by the top-level
+/// content count cannot account for a ticket each descendant of that content
+/// also took.
+final class TreeEditSplitTicketsConverterTests: XCTestCase {
+    private let parentCreatedAt = TimeTicket(lamport: 1, delimiter: 0, actorID: ActorIDs.initial)
+    private let executedAt = TimeTicket(lamport: 4, delimiter: 0, actorID: ActorIDs.initial)
+    private lazy var pos = CRDTTreePos(
+        parentID: CRDTTreeNodeID(createdAt: self.parentCreatedAt, offset: 0),
+        leftSiblingID: CRDTTreeNodeID(createdAt: self.parentCreatedAt, offset: 0)
+    )
+
+    /// Serializes the given operation to bytes and decodes it back, mirroring
+    /// `converter.operationToBinary` / `converter.bytesToOperation` in JS.
+    private func roundTrip(_ operation: Yorkie.Operation) throws -> TreeEditOperation {
+        let pbOperation = try Converter.toOperation(operation)
+        let bytes = try pbOperation.serializedData()
+        let restoredPb = try PbOperation(serializedBytes: bytes)
+        let restoredOps = try Converter.fromOperations([restoredPb])
+        guard let treeEditOp = restoredOps.first as? TreeEditOperation else {
+            throw YorkieError(code: .errUnexpected, message: "expected a TreeEditOperation after round-trip")
+        }
+        return treeEditOp
+    }
+
+    func test_round_trips_the_split_tickets_in_issue_order() throws {
+        // given — the tickets a multi-level split would have issued.
+        let op = TreeEditOperation(
+            parentCreatedAt: self.parentCreatedAt,
+            fromPos: self.pos,
+            toPos: self.pos,
+            contents: nil,
+            splitLevel: 2,
+            executedAt: self.executedAt
+        )
+        let issued = [
+            TimeTicket(lamport: 4, delimiter: 1, actorID: ActorIDs.initial),
+            TimeTicket(lamport: 4, delimiter: 2, actorID: ActorIDs.initial)
+        ]
+        op.setSplitTickets(issued)
+
+        // when
+        let restored = try self.roundTrip(op)
+
+        // then
+        XCTAssertEqual(restored.getSplitTickets().map { $0.toTestString }, issued.map { $0.toTestString })
+    }
+
+    func test_leaves_ordinary_edits_without_split_tickets() throws {
+        // given — a plain edit that never called setSplitTickets.
+        let op = TreeEditOperation(
+            parentCreatedAt: self.parentCreatedAt,
+            fromPos: self.pos,
+            toPos: self.pos,
+            contents: nil,
+            splitLevel: 0,
+            executedAt: self.executedAt
+        )
+
+        // when
+        let restored = try self.roundTrip(op)
+
+        // then
+        XCTAssertTrue(restored.getSplitTickets().isEmpty)
+    }
+
+    /// A server or peer older than v0.7.16 does not know field 11 and drops
+    /// it, so the op arrives with no split tickets at all — the fallback
+    /// reconstruction (delimiter simulation in `TreeEditOperation.execute`)
+    /// is what keeps such a change replayable, but decoding itself must not
+    /// throw or invent tickets.
+    func test_decodes_to_no_tickets_for_a_peer_that_predates_the_field() throws {
+        // given — a serialized operation with field 11 stripped, as an old
+        // peer that never wrote it would send.
+        let op = TreeEditOperation(
+            parentCreatedAt: self.parentCreatedAt,
+            fromPos: self.pos,
+            toPos: self.pos,
+            contents: nil,
+            splitLevel: 1,
+            executedAt: self.executedAt
+        )
+        op.setSplitTickets([TimeTicket(lamport: 4, delimiter: 1, actorID: ActorIDs.initial)])
+
+        var pbOp = try Converter.toOperation(op)
+        guard case .treeEdit(var pbTreeEdit) = pbOp.body else {
+            return XCTFail("expected a tree edit operation body")
+        }
+        pbTreeEdit.splitTickets = []
+        pbOp.body = Yorkie_V1_Operation.OneOf_Body.treeEdit(pbTreeEdit)
+
+        // when
+        let bytes = try pbOp.serializedData()
+        let decoded = try Converter.fromOperations([PbOperation(serializedBytes: bytes)])
+        let stripped = try XCTUnwrap(decoded.first as? TreeEditOperation)
+
+        // then
+        XCTAssertTrue(stripped.getSplitTickets().isEmpty, "an old peer's change carries no split tickets")
+    }
+}

--- a/Tests/Unit/Document/CRDT/CRDTTreeDuplicateIdTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeDuplicateIdTests.swift
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Ported from yorkie-js-sdk v0.7.16:
+/// `packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts`
+/// (yorkie-js-sdk#1318 "Keep a tree position resolvable when two nodes claim
+/// one ID").
+///
+/// A `CRDTTreeNodeID` (createdAt + offset) is the identity every position
+/// anchors to, so it must name a single node. An undo that reverses a
+/// deletion by re-inserting a copy of the removed nodes keeps their IDs,
+/// which leaves two nodes under one ID; a plain `put` then picks a winner by
+/// insertion order, and that order differs between a live document and one
+/// rebuilt from a snapshot. These mirror the server-side rules in yorkie#1927.
+final class CRDTTreeDuplicateIdTests: XCTestCase {
+    /// Builds `<r><p>0123456789</p></r>` and returns the tree with the id of
+    /// its text node.
+    private func buildDigitTree() throws -> (tree: CRDTTree, textID: CRDTTreeNodeID) {
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: "r"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+
+        let textID = posT()
+        try tree.editT(
+            (1, 1),
+            [CRDTTreeNode(id: textID, type: DefaultTreeNodeType.text.rawValue, value: "0123456789")],
+            0, timeT(), timeT
+        )
+        XCTAssertEqual(tree.toXML(), "<r><p>0123456789</p></r>")
+
+        return (tree, textID)
+    }
+
+    /// Returns the ids that name more than one node in the tree.
+    private func duplicatedIDs(_ tree: CRDTTree) -> [String] {
+        var counts = [String: Int]()
+        tree.indexTree.traverseAll { node, _ in
+            counts[node.toIDString, default: 0] += 1
+        }
+        return counts.filter { $0.value > 1 }.map { "\($0.key) x\($0.value)" }
+    }
+
+    /// Reproduces the state an older SDK left in stored documents: the
+    /// character at text offset 5 is deleted, and a copy of it is attached
+    /// under the tombstone's ORIGINAL id. It bypasses `edit` so the test keeps
+    /// exercising an already-corrupted document even once the edit path
+    /// refuses to create duplicates.
+    @discardableResult
+    private func corruptWithDuplicatedNodeID(_ tree: CRDTTree, _ textID: CRDTTreeNodeID) throws -> CRDTTreeNodeID {
+        try tree.editT((6, 7), nil, 0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>")
+
+        let paragraph = try XCTUnwrap(tree.root.innerChildren.first)
+        let tombstoneID = CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5)
+        let tombstone = try XCTUnwrap(tree.findFloorNode(tombstoneID))
+        XCTAssertTrue(tombstone.isRemoved)
+
+        // The copy lands before the tombstone, where an insert at the same
+        // index puts it, and wins nodeMapByID because it is registered last.
+        let dupe = CRDTTreeNode(id: tombstoneID, type: DefaultTreeNodeType.text.rawValue, value: "5")
+        let index = try XCTUnwrap(paragraph.innerChildren.firstIndex { $0 === tombstone })
+        try paragraph.insertAt(dupe, index)
+        tree.registerNode(dupe)
+        XCTAssertEqual(tree.toXML(), "<r><p>0123456789</p></r>")
+
+        return tombstoneID
+    }
+
+    /// Round-trips the tree through the snapshot encoding, as a client does
+    /// when it loads a document.
+    private func rebuildFromSnapshot(_ tree: CRDTTree) throws -> CRDTTree {
+        let object = CRDTObject(createdAt: timeT())
+        object.set(key: "t", value: tree)
+        let bytes = try Converter.objectToBytes(obj: object)
+        let restored = try Converter.bytesToObject(bytes: bytes)
+        return try XCTUnwrap(restored.get(key: "t") as? CRDTTree)
+    }
+
+    func test_drops_content_that_reuses_an_id_from_an_earlier_change() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try tree.editT((6, 7), nil, 0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>")
+
+        // when — the undo arrives as a later change, so it carries a later
+        // lamport than the id its content reuses.
+        let undoAt = TimeTicket(lamport: timeT().lamport + 1, delimiter: 1, actorID: ActorIDs.initial)
+        try tree.editT(
+            (6, 6),
+            [CRDTTreeNode(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5), type: DefaultTreeNodeType.text.rawValue, value: "5")],
+            0, undoAt, { undoAt }
+        )
+
+        // then
+        XCTAssertEqual(self.duplicatedIDs(tree), [], "an id names at most one node")
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>", "the copy is not inserted")
+    }
+
+    func test_drops_content_whose_id_this_edit_is_about_to_create_by_splitting() throws {
+        // given — nothing has split the text node yet, so no node carries
+        // (textID, 5). Resolving the insert position splits it there, which
+        // creates that id moments before the copy is inserted under it.
+        let (tree, textID) = try self.buildDigitTree()
+
+        // when
+        let undoAt = TimeTicket(lamport: timeT().lamport + 1, delimiter: 1, actorID: ActorIDs.initial)
+        try tree.editT(
+            (6, 6),
+            [CRDTTreeNode(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5), type: DefaultTreeNodeType.text.rawValue, value: "5")],
+            0, undoAt, { undoAt }
+        )
+
+        // then
+        XCTAssertEqual(self.duplicatedIDs(tree), [], "an id names at most one node")
+    }
+
+    func test_drops_content_that_reuses_an_id_from_another_actor() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try tree.editT((6, 7), nil, 0, timeT(), timeT)
+
+        // when
+        let undoAt = TimeTicket(lamport: timeT().lamport, delimiter: 1, actorID: "0123456789abcdef01234567")
+        try tree.editT(
+            (6, 6),
+            [CRDTTreeNode(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5), type: DefaultTreeNodeType.text.rawValue, value: "5")],
+            0, undoAt, { undoAt }
+        )
+
+        // then
+        XCTAssertEqual(self.duplicatedIDs(tree), [], "an id names at most one node")
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>")
+    }
+
+    func test_keeps_colliding_content_issued_by_this_change() throws {
+        // given — the delimiters an element split consumes are simulated
+        // rather than replayed, so an id issued by this edit can collide with
+        // one already in the tree. That content belongs to the document.
+        let (tree, _) = try self.buildDigitTree()
+        let existingID = tree.root.innerChildren[0].id
+
+        // when
+        let editedAt = TimeTicket(lamport: existingID.createdAt.lamport, delimiter: existingID.createdAt.delimiter + 1, actorID: existingID.createdAt.actorID)
+        try tree.editT(
+            (12, 12),
+            [CRDTTreeNode(id: CRDTTreeNodeID(createdAt: existingID.createdAt, offset: 0), type: "p")],
+            0, editedAt, { editedAt }
+        )
+
+        // then
+        XCTAssertEqual(tree.toXML(), "<r><p>0123456789</p><p></p></r>", "content issued by this change is inserted even when its id collides")
+    }
+
+    func test_resolves_a_duplicated_id_to_the_same_node_after_a_snapshot_rebuild() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try self.corruptWithDuplicatedNodeID(tree, textID)
+
+        // when
+        let rebuilt = try self.rebuildFromSnapshot(tree)
+
+        // then
+        XCTAssertEqual(rebuilt.toXML(), tree.toXML())
+
+        let id = CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5)
+        let live = try XCTUnwrap(tree.findFloorNode(id))
+        let cold = try XCTUnwrap(rebuilt.findFloorNode(id))
+        XCTAssertEqual(
+            cold.isRemoved, live.isRemoved,
+            "live resolves to a \(live.isRemoved ? "tombstone" : "live node"), rebuilt to a \(cold.isRemoved ? "tombstone" : "live node")"
+        )
+    }
+
+    func test_applies_an_edit_anchored_at_a_duplicated_id_after_a_rebuild() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try self.corruptWithDuplicatedNodeID(tree, textID)
+
+        // Keep editing before the duplicated id: this splits the run owning
+        // offsets 0..5, so the piece at offset 0 no longer spans up to offset 5.
+        try tree.editT((4, 4), [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "x")], 0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<r><p>012x3456789</p></r>")
+
+        let rebuilt = try self.rebuildFromSnapshot(tree)
+        let parentID = rebuilt.root.innerChildren[0].id
+        let editedAt = timeT()
+
+        // when / then
+        XCTAssertNoThrow(try rebuilt.edit(
+            (
+                CRDTTreePos(parentID: parentID, leftSiblingID: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5)),
+                CRDTTreePos(parentID: parentID, leftSiblingID: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 6))
+            ),
+            nil, 0, editedAt, { editedAt }, nil
+        ))
+    }
+
+    func test_keeps_the_live_node_resolvable_when_its_tombstone_is_purged() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try self.corruptWithDuplicatedNodeID(tree, textID)
+
+        let id = CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5)
+        let live = try XCTUnwrap(tree.findFloorNode(id))
+        XCTAssertFalse(live.isRemoved)
+
+        var tombstone: CRDTTreeNode?
+        tree.indexTree.traverseAll { node, _ in
+            if node.id == id, node.isRemoved {
+                tombstone = node
+            }
+        }
+        let tombstoneNode = try XCTUnwrap(tombstone)
+
+        // when
+        tree.purge(node: tombstoneNode)
+
+        // then
+        XCTAssertTrue(tree.findFloorNode(id) === live, "the live node keeps the id after its tombstone is collected")
+        XCTAssertEqual(tree.toXML(), "<r><p>0123456789</p></r>")
+    }
+
+    func test_does_not_let_a_dropped_copy_widen_the_reverse_operation() throws {
+        // given
+        let (tree, textID) = try self.buildDigitTree()
+        try tree.editT((6, 7), nil, 0, timeT(), timeT)
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>")
+
+        let root = CRDTRoot(rootObject: CRDTObject(createdAt: TimeTicket.initial))
+        root.registerElement(tree, parent: nil)
+
+        // The undo of that deletion, as the copy-reinsert path builds it: one
+        // content node carrying the id of the piece just tombstoned.
+        let undoAt = TimeTicket(lamport: timeT().lamport + 1, delimiter: 1, actorID: ActorIDs.initial)
+        let pos = try tree.findPos(6)
+        let op = TreeEditOperation(
+            parentCreatedAt: tree.createdAt,
+            fromPos: pos,
+            toPos: pos,
+            contents: [CRDTTreeNode(id: CRDTTreeNodeID(createdAt: textID.createdAt, offset: 5), type: DefaultTreeNodeType.text.rawValue, value: "5")],
+            splitLevel: 0,
+            executedAt: undoAt
+        )
+
+        // when
+        let result = try op.execute(root: root)
+
+        // then
+        XCTAssertEqual(tree.toXML(), "<r><p>012346789</p></r>", "the copy is not inserted")
+
+        // The undo stack shifts its stored indices by this size when a remote
+        // edit arrives, so it has to match what the tree accepted.
+        XCTAssertEqual(op.getContentSize(), 0, "an edit whose content was dropped inserted nothing")
+
+        // Redoing must not delete a neighbour that this edit never inserted.
+        if let redo = result?.reverseOp as? TreeEditOperation {
+            XCTAssertEqual(redo.fromPos, redo.toPos, "the reverse of an edit that inserted nothing spans nothing")
+        }
+    }
+
+    func test_refuses_to_split_a_text_node_past_its_end() throws {
+        // given
+        let node = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "hello")
+
+        // when / then
+        XCTAssertThrowsError(try node.splitText(Int32(node.size) + 1, 0)) { error in
+            guard let yorkieError = error as? YorkieError else {
+                return XCTFail("expected a YorkieError")
+            }
+            XCTAssertEqual(yorkieError.code, .errInvalidArgument)
+        }
+        XCTAssertEqual(node.value, "hello", "a refused split leaves the node alone")
+    }
+}

--- a/Tests/Unit/Document/CRDT/CRDTTreeDuplicateIdTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeDuplicateIdTests.swift
@@ -268,9 +268,8 @@ final class CRDTTreeDuplicateIdTests: XCTestCase {
         XCTAssertEqual(op.getContentSize(), 0, "an edit whose content was dropped inserted nothing")
 
         // Redoing must not delete a neighbour that this edit never inserted.
-        if let redo = result?.reverseOp as? TreeEditOperation {
-            XCTAssertEqual(redo.fromPos, redo.toPos, "the reverse of an edit that inserted nothing spans nothing")
-        }
+        let redo = try XCTUnwrap(result?.reverseOp as? TreeEditOperation)
+        XCTAssertEqual(redo.fromPos, redo.toPos, "the reverse of an edit that inserted nothing spans nothing")
     }
 
     func test_refuses_to_split_a_text_node_past_its_end() throws {

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -86,6 +86,30 @@ final class CRDTTreeNodeTests: XCTestCase {
         XCTAssertEqual(right?.mergedAt, mergeTicket)
     }
 
+    // Ported from yorkie-js-sdk v0.7.16: CRDTTreeNode — splitElement preserves mergedFrom and mergedAt.
+    func test_splitElement_preserves_mergedFrom_and_mergedAt() throws {
+        // given — a paragraph a merge previously moved
+        let root = CRDTTreeNode(id: posT(), type: "r", children: [])
+        let para = CRDTTreeNode(id: posT(), type: "p", children: [])
+        try root.append(contentsOf: [para])
+        try para.append(contentsOf: [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "helloworld")])
+
+        let sourceID = CRDTTreeNodeID(createdAt: timeT(), offset: 0)
+        let mergeTicket = timeT()
+        para.mergedFrom = sourceID
+        para.mergedAt = mergeTicket
+
+        // when — split the text, then split the element between the halves
+        _ = try para.children[0].splitText(5, 0)
+        let split = try para.splitElement(1, timeT()).0
+
+        // then — the split product holds the other half of the same moved node,
+        // so it carries the same merge stamp (as splitText does)
+        XCTAssertNotNil(split)
+        XCTAssertEqual(split?.mergedFrom, sourceID)
+        XCTAssertEqual(split?.mergedAt, mergeTicket)
+    }
+
     // Ported from yorkie-js-sdk v0.7.4: CRDTTreeNode — deepcopy preserves merge metadata.
     func test_deepcopy_preserves_merge_metadata() throws {
         // given
@@ -326,6 +350,44 @@ final class CRDTTreeEditTests: XCTestCase {
         XCTAssertEqual(treeNode.size, 4)
         XCTAssertEqual(treeNode.children![0].size, 2)
         XCTAssertEqual(treeNode.children![0].children![0].size, 2)
+    }
+
+    // Ported from yorkie-js-sdk v0.7.16: CRDTTree.Edit — stamps an insert declared inside a
+    // merged-away parent (yorkie-js-sdk#1317).
+    func test_stamps_an_insert_declared_inside_a_merged_away_parent() throws {
+        // given — <root><p>ab</p><p>cd</p></root>, capturing the leftmost position
+        // inside the second paragraph before the merge
+        let tree = CRDTTree(root: CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.root.rawValue), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((1, 1), [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "ab")], 0, timeT(), timeT)
+        try tree.editT((4, 4), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT((5, 5), [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "cd")], 0, timeT(), timeT)
+
+        let pos = try tree.findPos(5)
+        let declaredParent = try tree.findNodesAndSplitText(pos, timeT()).0.0
+
+        // when — merge the second paragraph into the first, then apply an insert that still
+        // declares the merged-away paragraph as its parent. A later delete LWW-overwrites the
+        // tombstone first, so the merge ticket is only recoverable from the moved sibling.
+        let mergeTicket = timeT()
+        try tree.editT((3, 5), nil, 0, mergeTicket, timeT)
+        _ = declaredParent.remove(timeT())
+        let content = CRDTTreeNode(id: posT(), type: "b")
+        _ = try tree.edit((pos, pos), [content], 0, timeT(), timeT, nil)
+
+        // then — the content lands in the merge target (the surviving first paragraph) but is
+        // stamped as merged-from the declared parent, like a merge-moved child.
+        //
+        // NOTE: upstream reads the merge ticket from the moved sibling rather than the parent's
+        // `removedAt` because a later delete can LWW-overwrite that tombstone. On iOS the
+        // `mergedAt` assertion below does NOT discriminate the two sources: `CRDTTreeNode.remove`
+        // keeps the EARLIEST tombstone (`removedAt <= self.removedAt`), where the JS SDK overwrites
+        // with the newer one, so `removedAt` here still equals the merge ticket. That divergence
+        // predates this sync (it has been in `remove` since the v0.7.4 port) and is tracked
+        // separately — this test is kept faithful to the upstream scenario.
+        XCTAssertTrue(content.parent === tree.root.innerChildren[0])
+        XCTAssertEqual(content.mergedFrom, declaredParent.id)
+        XCTAssertEqual(content.mergedAt, mergeTicket)
     }
 
     func test_can_find_the_closest_TreePos_when_parentNode_or_leftSiblingNode_does_not_exist() async throws {

--- a/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeTests.swift
@@ -253,7 +253,7 @@ final class CRDTTreeEditTests: XCTestCase {
         let sizeBefore = tree.size
         let fromPos = try tree.findPos(0)
         let toPos = try tree.findPos(4)
-        let (_, _, _, removedNodes, _, _, _, _, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
+        let (_, _, _, removedNodes, _, _, _, _, _, _) = try tree.edit((fromPos, toPos), nil, 0, timeT(), timeT, nil)
 
         XCTAssertEqual(removedNodes.count, 2, "both the <p> and its text child are removed")
         let removedSize = removedNodes.reduce(0) { $0 + $1.paddedSize }

--- a/Tests/Unit/Document/CRDT/CRDTTreeUndoCopyPathTests.swift
+++ b/Tests/Unit/Document/CRDT/CRDTTreeUndoCopyPathTests.swift
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Ported from yorkie-js-sdk v0.7.16:
+/// `packages/sdk/test/unit/document/undo_copy_path_test.ts`
+/// (yorkie-js-sdk#1319 "Stop undo and element splits from reusing a node's
+/// identity").
+///
+/// These drive a real undo/redo through the copy-reinsert reverse — the one
+/// that re-inserts the nodes a deletion removed instead of reviving them by
+/// identity. `CRDTTree.edit` only fills the identity spans when the edit was
+/// merge- and split-free, so the copy path is what remains for merge
+/// propagation and for reverse operations older SDKs left on an undo stack.
+/// Neither is reachable through ordinary editing, so the spans are blanked
+/// here to reproduce it faithfully.
+///
+/// The JS test reproduces this by monkey-patching `CRDTTree.prototype.edit`.
+/// `CRDTTree` is not `final`, so the Swift port subclasses it instead and
+/// overrides `edit` to blank the same two return values.
+final class CRDTTreeUndoCopyPathTests: XCTestCase {
+    /// Forces every edit through this tree onto the copy-reinsert reverse
+    /// path by blanking the identity spans (`removedSpans` / `insertedSpans`,
+    /// tuple positions 7 and 8) that `CRDTTree.edit` would otherwise fill —
+    /// the same shape `toReverseOperation` sees for a merge- or split-touched
+    /// edit, or a reverse an older SDK left on an undo stack.
+    private final class CopyPathForcingCRDTTree: CRDTTree {
+        override func edit(
+            _ range: TreePosRange,
+            _ contents: [CRDTTreeNode]?,
+            _ splitLevel: Int32,
+            _ editedAt: TimeTicket,
+            _ issueTimeTicket: () -> TimeTicket,
+            _ versionVector: VersionVector?
+        ) throws -> ([TreeChange], [GCPair], DataSize, [CRDTTreeNode], Int, Int, Set<String>, [TreeRestoreSpan], [TreeRestoreSpan], Int) {
+            var result = try super.edit(range, contents, splitLevel, editedAt, issueTimeTicket, versionVector)
+            result.7 = []
+            result.8 = []
+            return result
+        }
+    }
+
+    /// Returns a root that resolves the tree by its creation ticket (as
+    /// `TreeEditOperation.execute` requires) and the tree itself, holding
+    /// `<r><p>abcdef</p></r>`.
+    private func buildDoc() throws -> (root: CRDTRoot, tree: CRDTTree) {
+        let tree = CopyPathForcingCRDTTree(root: CRDTTreeNode(id: posT(), type: "r"), createdAt: timeT())
+        try tree.editT((0, 0), [CRDTTreeNode(id: posT(), type: "p")], 0, timeT(), timeT)
+        try tree.editT(
+            (1, 1),
+            [CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "abcdef")],
+            0, timeT(), timeT
+        )
+        XCTAssertEqual(tree.toXML(), "<r><p>abcdef</p></r>")
+
+        let root = CRDTRoot(rootObject: CRDTObject(createdAt: TimeTicket.initial))
+        root.registerElement(tree, parent: nil)
+        return (root, tree)
+    }
+
+    /// Returns the ids that name more than one node in the tree.
+    private func duplicatedIDs(_ tree: CRDTTree) -> [String] {
+        var counts = [String: Int]()
+        tree.indexTree.traverseAll { node, _ in
+            counts[node.toIDString, default: 0] += 1
+        }
+        return counts.filter { $0.value > 1 }.map { $0.key }
+    }
+
+    /// Deletes "bcd" (leaving "aef") through the copy-path-forced tree and
+    /// returns the executed delete op alongside its reverse (undo) op — the
+    /// content-copy shape `toReverseOperation` falls back to.
+    private func deleteBCD(_ root: CRDTRoot, _ tree: CRDTTree) throws -> TreeEditOperation {
+        let fromPos = try tree.findPos(2)
+        let toPos = try tree.findPos(5)
+        let deleteOp = TreeEditOperation(
+            parentCreatedAt: tree.createdAt,
+            fromPos: fromPos,
+            toPos: toPos,
+            contents: nil,
+            splitLevel: 0,
+            executedAt: timeT()
+        )
+        let result = try deleteOp.execute(root: root)
+        XCTAssertEqual(tree.toXML(), "<r><p>aef</p></r>")
+        return try XCTUnwrap(result?.reverseOp as? TreeEditOperation)
+    }
+
+    func test_restores_the_text_without_duplicating_an_id() throws {
+        // given
+        let (root, tree) = try self.buildDoc()
+        let before = tree.toXML()
+        let reverseOp = try self.deleteBCD(root, tree)
+        XCTAssertNotNil(reverseOp.contents, "the copy path re-inserts the removed nodes as content")
+
+        // when — drive the undo exactly as `Document.executeUndoRedo` does:
+        // assign a fresh executedAt, reissue the reverse op's content ids,
+        // then execute it.
+        reverseOp.executedAt = timeT()
+        try reverseOp.reissueContentIDs { timeT() }
+        try reverseOp.execute(root: root)
+
+        // then
+        XCTAssertEqual(tree.toXML(), before, "the undo restores the text")
+        XCTAssertEqual(self.duplicatedIDs(tree), [], "the re-inserted copy must not reuse the tombstone it came from")
+    }
+
+    func test_does_not_splice_the_copy_into_the_chain_it_came_from() throws {
+        // given
+        let (root, tree) = try self.buildDoc()
+        let reverseOp = try self.deleteBCD(root, tree)
+
+        var before = Set<String>()
+        tree.indexTree.traverseAll { node, _ in before.insert(node.toIDString) }
+
+        // when
+        reverseOp.executedAt = timeT()
+        try reverseOp.reissueContentIDs { timeT() }
+        try reverseOp.execute(root: root)
+
+        // then
+        var insertedCount = 0
+        tree.indexTree.traverseAll { node, _ in
+            let id = node.toIDString
+            if before.contains(id) {
+                return
+            }
+            insertedCount += 1
+            // The copy came from a deepcopy of a node the deletion removed,
+            // which carries that node's split chain and merge lineage. A
+            // fresh identity has to be fresh in those too, or the copy is
+            // spliced into a chain it never belonged to.
+            XCTAssertNil(node.insPrevID, "\(id) kept a split chain")
+            XCTAssertNil(node.insNextID, "\(id) kept a split chain")
+            XCTAssertNil(node.mergedFrom, "\(id) kept a merge lineage")
+            XCTAssertNil(node.mergedAt, "\(id) kept a merge lineage")
+        }
+        XCTAssertGreaterThan(insertedCount, 0, "the undo re-inserted the removed content")
+    }
+
+    func test_returns_to_the_deleted_state_on_redo() throws {
+        // given
+        let (root, tree) = try self.buildDoc()
+        let undoOp = try self.deleteBCD(root, tree)
+        let deleted = tree.toXML()
+
+        undoOp.executedAt = timeT()
+        try undoOp.reissueContentIDs { timeT() }
+        let undoResult = try undoOp.execute(root: root)
+
+        // when
+        let redoOp = try XCTUnwrap(undoResult?.reverseOp as? TreeEditOperation)
+        redoOp.executedAt = timeT()
+        try redoOp.reissueContentIDs { timeT() }
+        try redoOp.execute(root: root)
+
+        // then
+        XCTAssertEqual(tree.toXML(), deleted)
+        XCTAssertEqual(self.duplicatedIDs(tree), [])
+    }
+}

--- a/Tests/Unit/Document/Operation/TreeEditOperationReissueContentIDsTests.swift
+++ b/Tests/Unit/Document/Operation/TreeEditOperationReissueContentIDsTests.swift
@@ -42,8 +42,8 @@ final class TreeEditOperationReissueContentIDsTests: XCTestCase {
     func test_gives_copied_content_a_fresh_identity() throws {
         // given
         let pos = CRDTTreePos(parentID: posT(), leftSiblingID: posT())
-        let p = CRDTTreeNode(id: posT(), type: "p")
-        try p.append(contentsOf: [
+        let para = CRDTTreeNode(id: posT(), type: "para")
+        try para.append(contentsOf: [
             CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a"),
             CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "b")
         ])
@@ -52,7 +52,7 @@ final class TreeEditOperationReissueContentIDsTests: XCTestCase {
             parentCreatedAt: timeT(),
             fromPos: pos,
             toPos: pos,
-            contents: [p],
+            contents: [para],
             splitLevel: 0,
             executedAt: timeT(),
             isUndoOp: true
@@ -66,7 +66,7 @@ final class TreeEditOperationReissueContentIDsTests: XCTestCase {
         let after = self.idsOf(op.contents!)
         // The count is stated rather than derived from the same traversal the
         // reissue uses, so a traversal that skipped a node would show up here.
-        XCTAssertEqual(after.count, 3, "the <p> and its two texts")
+        XCTAssertEqual(after.count, 3, "the <para> and its two texts")
         XCTAssertEqual(after.count, before.count)
         XCTAssertEqual(Set(after).count, after.count, "every node gets its own id")
         for id in after {

--- a/Tests/Unit/Document/Operation/TreeEditOperationReissueContentIDsTests.swift
+++ b/Tests/Unit/Document/Operation/TreeEditOperationReissueContentIDsTests.swift
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Ported from yorkie-js-sdk v0.7.16:
+/// `packages/sdk/test/unit/document/undo_content_identity_test.ts`
+/// (yorkie-js-sdk#1319 "Stop undo and element splits from reusing a node's
+/// identity").
+///
+/// A reverse operation that re-inserts a copy of the nodes an edit removed
+/// carries their original ids. Inserting them again would put two nodes under
+/// one id, which is what makes a position anchored there ambiguous. Undo
+/// gives a restored value a new identity elsewhere already — `ArraySetOperation`
+/// and `AddOperation` both take a fresh ticket in `Document.executeUndoRedo`
+/// — and the tree's copy path is the one that did not, until
+/// `TreeEditOperation.reissueContentIDs` closed the gap.
+final class TreeEditOperationReissueContentIDsTests: XCTestCase {
+    /// Collects the ids of a content subtree.
+    private func idsOf(_ contents: [CRDTTreeNode]) -> [String] {
+        var ids = [String]()
+        for content in contents {
+            traverseAll(node: content) { node, _ in ids.append(node.toIDString) }
+        }
+        return ids
+    }
+
+    func test_gives_copied_content_a_fresh_identity() throws {
+        // given
+        let pos = CRDTTreePos(parentID: posT(), leftSiblingID: posT())
+        let p = CRDTTreeNode(id: posT(), type: "p")
+        try p.append(contentsOf: [
+            CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a"),
+            CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "b")
+        ])
+
+        let op = TreeEditOperation(
+            parentCreatedAt: timeT(),
+            fromPos: pos,
+            toPos: pos,
+            contents: [p],
+            splitLevel: 0,
+            executedAt: timeT(),
+            isUndoOp: true
+        )
+        let before = self.idsOf(op.contents!)
+
+        // when
+        try op.reissueContentIDs { timeT() }
+
+        // then
+        let after = self.idsOf(op.contents!)
+        // The count is stated rather than derived from the same traversal the
+        // reissue uses, so a traversal that skipped a node would show up here.
+        XCTAssertEqual(after.count, 3, "the <p> and its two texts")
+        XCTAssertEqual(after.count, before.count)
+        XCTAssertEqual(Set(after).count, after.count, "every node gets its own id")
+        for id in after {
+            XCTAssertFalse(before.contains(id), "no node keeps the id it was copied from")
+        }
+    }
+
+    // Deliberately over-constrained: a restore reverse is built with no
+    // contents at all in production, so this pins the guard rather than a
+    // shape production emits.
+    func test_leaves_a_restore_mode_reverse_alone() throws {
+        // given
+        let pos = CRDTTreePos(parentID: posT(), leftSiblingID: posT())
+        let node = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a")
+        let op = TreeEditOperation(
+            parentCreatedAt: timeT(),
+            fromPos: pos,
+            toPos: pos,
+            contents: [node],
+            splitLevel: 0,
+            executedAt: timeT(),
+            isUndoOp: true,
+            restoreSpans: [],
+            restoreMode: .restore,
+            retombstoneSpans: []
+        )
+        let before = self.idsOf(op.contents!)
+
+        // when
+        try op.reissueContentIDs { timeT() }
+
+        // then
+        XCTAssertEqual(self.idsOf(op.contents!), before, "a restore revives nodes by identity and must keep it")
+    }
+
+    func test_assigns_ids_that_a_later_reissue_does_not_repeat() throws {
+        // given
+        let pos = CRDTTreePos(parentID: posT(), leftSiblingID: posT())
+        let first = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a")
+        let second = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a")
+
+        let opA = TreeEditOperation(parentCreatedAt: timeT(), fromPos: pos, toPos: pos, contents: [first], splitLevel: 0, executedAt: timeT(), isUndoOp: true)
+        let opB = TreeEditOperation(parentCreatedAt: timeT(), fromPos: pos, toPos: pos, contents: [second], splitLevel: 0, executedAt: timeT(), isUndoOp: true)
+
+        // when
+        try opA.reissueContentIDs { timeT() }
+        try opB.reissueContentIDs { timeT() }
+
+        // then
+        XCTAssertNotEqual(self.idsOf(opA.contents!), self.idsOf(opB.contents!))
+    }
+
+    func test_refuses_to_reissue_ids_on_a_splitting_edit() throws {
+        // given — `reissueContentIDs` relies on the reconstruction's simulated
+        // delimiter range never overlapping the ids it assigns, which only
+        // holds while the operation carries no split (see the doc comment on
+        // `reissueContentIDs`).
+        let pos = CRDTTreePos(parentID: posT(), leftSiblingID: posT())
+        let node = CRDTTreeNode(id: posT(), type: DefaultTreeNodeType.text.rawValue, value: "a")
+        let op = TreeEditOperation(
+            parentCreatedAt: timeT(),
+            fromPos: pos,
+            toPos: pos,
+            contents: [node],
+            splitLevel: 1,
+            executedAt: timeT(),
+            isUndoOp: true
+        )
+
+        // when / then
+        XCTAssertThrowsError(try op.reissueContentIDs { timeT() }) { error in
+            XCTAssertEqual((error as? YorkieError)?.code, .errRefused)
+        }
+    }
+}

--- a/Tests/Unit/Document/SplitTicketsTests.swift
+++ b/Tests/Unit/Document/SplitTicketsTests.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Yorkie
+
+/// Ported from yorkie-js-sdk v0.7.16:
+/// `packages/sdk/test/unit/document/split_ticket_test.ts`
+/// (yorkie-js-sdk#1319 "Stop undo and element splits from reusing a node's
+/// identity").
+///
+/// The tickets an element split consumes are carried by the operation rather
+/// than reconstructed from it: a reconstruction advancing by the number of
+/// top-level contents cannot account for the ticket each descendant also
+/// took.
+final class SplitTicketsTests: XCTestCase {
+    /// Returns the ids that name more than one node in the document's "t" tree.
+    @MainActor
+    private func duplicatedIDs(_ doc: Document) -> [String] {
+        guard let tree = doc.getRootObject().get(key: "t") as? CRDTTree else {
+            return []
+        }
+        var counts = [String: Int]()
+        tree.indexTree.traverseAll { node, _ in
+            counts[node.toIDString, default: 0] += 1
+        }
+        return counts.filter { $0.value > 1 }.map { $0.key }
+    }
+
+    @MainActor
+    func test_does_not_land_on_the_content_the_same_edit_inserts() throws {
+        // given
+        let doc = Document(key: "split-tickets-doc")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")])
+            ]))
+        }
+
+        // when — two edits within the SAME change: an element split (issues a
+        // split ticket), then an insert at a position the delimiter
+        // simulation could otherwise collide with.
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "q"), 1)
+            try (root.t as? JSONTree)?.edit(1, 1, JSONTreeTextNode(value: "z"), 0)
+        }
+
+        // then
+        XCTAssertEqual(self.duplicatedIDs(doc), [])
+    }
+
+    @MainActor
+    func test_survives_the_round_trip_to_the_wire() throws {
+        // given
+        let doc = Document(key: "split-tickets-wire-doc")
+        try doc.update { root, _ in
+            root.t = JSONTree(initialRoot: JSONTreeElementNode(type: "r", children: [
+                JSONTreeElementNode(type: "p", children: [JSONTreeTextNode(value: "ab")])
+            ]))
+        }
+        try doc.update { root, _ in
+            try (root.t as? JSONTree)?.edit(2, 2, JSONTreeTextNode(value: "q"), 1)
+        }
+
+        // when
+        let pack = doc.createChangePack()
+        let pbPack = Converter.toChangePack(pack: pack)
+        let restored = try Converter.fromChangePack(pbPack)
+
+        let sent = pack.getChanges()
+            .flatMap { $0.operations }
+            .compactMap { $0 as? TreeEditOperation }
+            .flatMap { $0.getSplitTickets() }
+        let received = restored.getChanges()
+            .flatMap { $0.operations }
+            .compactMap { $0 as? TreeEditOperation }
+            .flatMap { $0.getSplitTickets() }
+
+        // then
+        XCTAssertFalse(sent.isEmpty, "the edit split an element, so it issued tickets")
+        XCTAssertEqual(
+            received.map { $0.toTestString },
+            sent.map { $0.toTestString },
+            "a replica reads back the tickets the originator issued"
+        )
+    }
+}

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.15'
+    image: 'yorkieteam/yorkie:0.7.16'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.15'
+    image: 'yorkieteam/yorkie:0.7.16'
     container_name: 'yorkie'
 #    command: ['server', '--enable-pprof']
     restart: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports the three fixes in [yorkie-js-sdk v0.7.16](https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.7.16), one commit per upstream change:

- **Keep a tree position resolvable when two nodes claim one ID** ([js#1318](https://github.com/yorkie-team/yorkie-js-sdk/pull/1318)) — `registerNode` now keeps a live node over a tombstone when both claim an ID, `dropDuplicateContents` refuses content that reuses an ID from another change, `purge` only removes the map entry the purged node actually holds, and `IndexTreeNode.splitText` refuses an out-of-range offset instead of letting the slice absorb it. `CRDTTree.edit` reports the content size it accepted so a reverse range never covers a dropped copy.
- **Stamp merge-bound inserts and filter style-range interlopers** ([js#1317](https://github.com/yorkie-team/yorkie-js-sdk/pull/1317)) — inserts declared inside a merged-away parent carry `mergedFrom`, and style traversal skips nodes that are only in range because an unknown merge pulled the range-end anchor past them. `style` and `removeStyle` share one predicate.
- **Stop undo and element splits from reusing a node's identity** ([js#1319](https://github.com/yorkie-team/yorkie-js-sdk/pull/1319)) — a copy-reinsert reverse takes fresh tickets at undo time, and `Operation.TreeEdit.split_tickets` (field 11) carries the tickets the originating replica issued for an element split instead of every replica reconstructing them.

Also bumps `Version.swift` to 0.7.16 and moves the CI yorkie-server pin and docker images to v0.7.16.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- **Wire change.** `resources.proto` gains `Operation.TreeEdit.split_tickets = 11`; `resources.pb.swift` was regenerated with the pinned buf plugins and the diff contains only that field. The field is additive — a change written before it existed carries none and replays through the old reconstruction, so stored histories are unaffected.
- **Requires a Yorkie server >= 0.7.16.** These identity rules are a wire contract shared with the server (yorkie#1927, yorkie#1929). Against an older server a tree undo/redo can abort a sync with `ErrInvalidArgument: offset out of range` rather than degrading. Noted in the CHANGELOG.
- **One divergence fixed beyond the port.** The split-ticket reconstruction in `TreeEditOperation.execute` recomputed its delimiter base from a mutated `editedAt`, re-adding `contents.count` on every call, so a multi-level split produced non-consecutive delimiters that did not match the JS SDK or the server. The base is now captured once, matching upstream.
- **`CRDTTreeNode.id` became `var`.** It is written in exactly one place (`reissueContentIDs`), and only ever on detached content a reverse operation carries — never on a node already registered in a tree.
- The last commit is a pure refactor: the port pushed `CRDTTree.edit`, `CRDTTree.style` and `TreeEditOperation.execute` past the 110-line lint limit, so four helpers were extracted. No behaviour change.

Gates run locally, all green:

| Gate | Result |
| --- | --- |
| SwiftFormat 0.55.6 `--lint .` | 0/252 files require formatting |
| SwiftLint 0.58.2 `lint --strict` | 0 violations in 196 files |
| `swift build --build-tests` | clean |
| Unit tests | 661 passed |
| Integration tests (against a v0.7.16 server) | 499 passed; the 18 failures are all `WebhookIntegrationTests`, which need the auth-webhook stub CI provisions |
| Two-device runtime collab check | RichTextEditor built from this branch, 5/5 — insert both directions, styled insert, and undo all converge across two simulators |

**Does this PR introduce a user-facing change?**:

```release-note
Fix tree node identity so a position always resolves to a single node: undo no longer re-inserts copies under an existing ID, element splits carry the tickets the originating replica issued, and style ranges no longer cover nodes pulled in by an unknown merge.

action required: this release requires a Yorkie server v0.7.16 or later.
```

**Additional documentation**:

```docs
- [CHANGELOG]: https://github.com/yorkie-team/yorkie-ios-sdk/blob/main/CHANGELOG.md
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tree editing, undo/redo, element splitting, and merge behavior.
  * Preserved tree-edit information during synchronization and serialization.
* **Bug Fixes**
  * Prevented duplicate node identities and incorrect styling around merged content.
  * Added validation for invalid text-splitting offsets.
  * Improved restoration and redo consistency for tree changes.
* **Compatibility**
  * Updated the release to v0.7.16.
  * Requires Yorkie server v0.7.16 or later for reliable tree undo/redo synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->